### PR TITLE
main #74 の進捗修正を 1.21.1-main へ forward-port

### DIFF
--- a/src/generated/resources/data/apprenticecodex/advancement/apprentice_codex/craft_copper_spell_amplifier.json
+++ b/src/generated/resources/data/apprenticecodex/advancement/apprentice_codex/craft_copper_spell_amplifier.json
@@ -1,5 +1,5 @@
 {
-  "parent": "apprenticecodex:apprentice_codex/root",
+  "parent": "apprenticecodex:apprentice_codex/craft_iron_spell_amplifier",
   "criteria": {
     "crafted_copper_spell_amplifier": {
       "conditions": {

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/AdvancementGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/AdvancementGenerator.java
@@ -112,7 +112,7 @@ public final class AdvancementGenerator implements AdvancementProvider.Advanceme
                 .save(saver, advancementId("craft_iron_spell_amplifier"), existingFileHelper);
 
         Advancement.Builder.advancement()
-                .parent(root)
+                .parent(ironAmp)
                 .display(ItemRegistry.COPPER_SPELL_AMPLIFIER.get(),
                         Component.translatable("advancements.apprenticecodex.apprentice_codex.craft_copper_spell_amplifier.title"),
                         Component.translatable("advancements.apprenticecodex.apprentice_codex.craft_copper_spell_amplifier.description"),


### PR DESCRIPTION
## 概要
main でマージ済みの PR #74 の変更を 1.21.1-main へ forward-port します。

## 取り込み元
- PR: #74
- commit: 33e11f7378d3bba11c0192307e9b0f5f52455fc4

## 変更内容
- 銅スペル増幅器の進捗 parent を修正
- datagen 実装と生成済み advancement JSON の整合を更新

## 取り込み方法
- `git cherry-pick -x 33e11f7378d3bba11c0192307e9b0f5f52455fc4`

## 確認
- `./gradlew.bat build` 成功