### PR TITLE
パステルスタッフの1.21.1エンチャ未対応修正

### DIFF
--- a/src/generated/resources/data/minecraft/tags/item/enchantable/mining_loot.json
+++ b/src/generated/resources/data/minecraft/tags/item/enchantable/mining_loot.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "apprenticecodex:pastel_staff"
+  ]
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/ItemTagGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/ItemTagGenerator.java
@@ -27,6 +27,7 @@ public final class ItemTagGenerator extends ItemTagsProvider {
     private static final TagKey<Item> CURIOS_RING = createTag("curios", "ring");
     private static final TagKey<Item> CURIOS_BELT = createTag("curios", "belt");
     private static final TagKey<Item> CURIOS_SPELLBOOK = createTag("curios", "spellbook");
+    private static final TagKey<Item> MINECRAFT_ENCHANTABLE_MINING_LOOT = createTag("minecraft", "enchantable/mining_loot");
     private static final TagKey<Item> MALUM_SOUL_HUNTER_WEAPON = createTag("malum", "soul_hunter_weapon");
     private static final TagKey<Item> TOMAGIC_REVERSAL_WEAPON = createTag("traveloptics", "can_cast_reversal");
     private static final TagKey<Item> HIDDEN_FROM_RECIPE_VIEWERS = createTag("c", "hidden_from_recipe_viewers");
@@ -46,6 +47,8 @@ public final class ItemTagGenerator extends ItemTagsProvider {
         tag(IRONS_STAFF).add(ItemRegistry.PASTEL_STAFF.get());
         tag(IRONS_UPGRADE_WHITELIST).add(ItemRegistry.ENDER_GRIMOIRE.get());
         tag(CURIOS_SPELLBOOK).add(ItemRegistry.ENDER_GRIMOIRE.get());
+        // 1.21.1 のバニラ enchantment JSON は Fortune / Silk Touch を mining_loot タグで判定する.
+        tag(MINECRAFT_ENCHANTABLE_MINING_LOOT).add(ItemRegistry.PASTEL_STAFF.get());
         tag(MALUM_SOUL_HUNTER_WEAPON).add(ItemRegistry.PASTEL_STAFF.get());
         tag(TOMAGIC_REVERSAL_WEAPON).add(ItemRegistry.PASTEL_STAFF.get());
         tag(OFFHAND_MAGIC_ENCHANTABLE).add(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
@@ -23,7 +23,6 @@ import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.component.CustomData;
@@ -43,11 +42,7 @@ public class PastelStaff extends StaffItem implements GeoItem, IPresetSpellConta
     public static final String STONE_AFFINITY_SCHOOL_TAG = "StoneAffinitySchool";
     public static final int DEFAULT_STONE_TINT_COLOR = 0xFFFFFF;
 
-    private static final String VANILLA_NAMESPACE = "minecraft";
-    private static final ItemStack DURABILITY_ENCHANTMENT_PROBE_STACK = new ItemStack(Items.ELYTRA);
-    private static final Set<ResourceLocation> ALLOWED_VANILLA_WEAPON_ENCHANTMENTS = Set.of(
-            ResourceLocation.withDefaultNamespace("looting"),
-            ResourceLocation.withDefaultNamespace("knockback"),
+    private static final Set<ResourceLocation> EXTRA_SUPPORTED_ENCHANTMENTS = Set.of(
             ResourceLocation.withDefaultNamespace("fortune"),
             ResourceLocation.withDefaultNamespace("silk_touch")
     );
@@ -146,25 +141,17 @@ public class PastelStaff extends StaffItem implements GeoItem, IPresetSpellConta
 
     @Override
     public boolean supportsEnchantment(ItemStack stack, Holder<Enchantment> enchantment) {
+        if (super.supportsEnchantment(stack, enchantment)) {
+            return true;
+        }
+
         var enchantmentId = enchantment.unwrapKey().map(key -> key.location()).orElse(null);
-        if (enchantmentId == null) {
-            return false;
-        }
-
-        if (isDurabilityTargetEnchantment(enchantment)) {
-            return false;
-        }
-
-        if (VANILLA_NAMESPACE.equals(enchantmentId.getNamespace())) {
-            return ALLOWED_VANILLA_WEAPON_ENCHANTMENTS.contains(enchantmentId);
-        }
-
-        return enchantment.value().isSupportedItem(new ItemStack(Items.DIAMOND_SWORD));
+        return enchantmentId != null && EXTRA_SUPPORTED_ENCHANTMENTS.contains(enchantmentId);
     }
 
     @Override
     public boolean isPrimaryItemFor(ItemStack stack, Holder<Enchantment> enchantment) {
-        return supportsEnchantment(stack, enchantment);
+        return super.isPrimaryItemFor(stack, enchantment) || supportsEnchantment(stack, enchantment);
     }
 
     @Override
@@ -184,10 +171,6 @@ public class PastelStaff extends StaffItem implements GeoItem, IPresetSpellConta
     @Override
     public int getEnchantmentValue(ItemStack stack) {
         return 22;
-    }
-
-    private static boolean isDurabilityTargetEnchantment(Holder<Enchantment> enchantment) {
-        return enchantment.value().isSupportedItem(DURABILITY_ENCHANTMENT_PROBE_STACK);
     }
 
     public int getStoneTintColor(ItemStack stack) {


### PR DESCRIPTION
そもそも1.20.1は杖にエンチャントが乗らないのが1.21.1だと乗るので色々とズレてるっぽい