### PR TITLE
1.21.1-main に PR CI を追加

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,49 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches:
+      - 1.21.1-main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-gametest:
+    name: build-and-gametest
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Temurin 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      # PR から持ち込まれた wrapper を実行する前に正規の Gradle wrapper かを検証する。
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      - name: Build and run GameTest server
+        run: ./gradlew build runGameTestServer --no-daemon --stacktrace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,12 +93,14 @@ Get-ChildItem build\libs\*.jar
 4. サーバー側の登録・データ読込・レシピ・生成・GameTest 対象構造に影響する変更では、`./gradlew.bat runGameTestServer` が成功することを確認する。
 5. `main` から `1.21.1-main` への forward-port では、実装内容に関係なく `./gradlew.bat runGameTestServer` が成功することを確認する。
 6. 必要に応じて `./gradlew.bat runClient` で動作確認する。
-7. 必要に応じて関連ドキュメントを更新する。
+7. `1.21.1-main` へ取り込む変更は PR で流し、`PR CI / build-and-gametest` の成功を確認してから merge する。
+8. 必要に応じて関連ドキュメントを更新する。
 
 ## 6. レビューチェックリスト
 - 必須チェック項目: Java 21 環境で `./gradlew.bat build` が成功すること。
 - 必須チェック項目: サーバー側の登録・データ読込・レシピ・生成に影響する変更では、`./gradlew.bat runGameTestServer` が成功すること。
 - 必須チェック項目: `main` から `1.21.1-main` への forward-port では、実装内容に関係なく `./gradlew.bat runGameTestServer` が成功すること。
+- 必須チェック項目: `1.21.1-main` 向け PR では `PR CI / build-and-gametest` が成功していること。
 - 必須チェック項目: 追加・変更した要素の登録漏れ（Registry/EventBus）がないこと。
 - 必須チェック項目: サーバー専用環境で問題となるクライアント専用参照を追加していないこと。
 - リグレッション確認: 既存コンテンツの ID 変更や削除による互換性破壊を避ける。
@@ -126,6 +128,15 @@ Get-ChildItem build\libs\*.jar
 - 取り込み判断で迷わないよう、`main` 側では無関係な整形・リネームの混在を避ける。
 - 同種コンフリクトの再解決コストを下げるため、`git config rerere.enabled true` を推奨する。
 - `1.21.1-main` のみで必要になった修正は、`main` への逆取り込みが必要かを別途判断し、必要時のみ個別対応で反映する。
+
+## 8.1 `1.21.1-main` の PR CI 運用
+- `1.21.1-main` への反映は PR 経由のみとし、直接 push しない。
+- required check は `PR CI / build-and-gametest` とする。
+- workflow は `pull_request` でのみ動かし、`pull_request_target` は使わない。
+- CI では repository secrets を使わず、`GITHUB_TOKEN` は read-only に固定する。
+- 通常変更は `merge commit` を使い、バージョン更新 PR だけ `rebase merge` を許可する。
+- `squash merge` は使わない。
+- bootstrap 詰まりを避けるため、workflow を target branch に載せる前に required check を有効化しない。手順は `docs/github-pr-protection.md` に従う。
 
 ## 9. Codex運用上の注意（コメント保全/文字化け対策）
 - 原因整理: Windows PowerShell 5.1（コードページ 932）で `Get-Content` 既定読み取りを使うと、UTF-8日本語が文字化けして表示される。

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Iron's Spells 'n Spellbooks用の小さなアドオンMODです.
 - 注意:
   これらはサーバー側の起動・読込・登録ミスの検知が主目的です。renderer や screen など client 専用の起動不良は別途 `runClient` で確認が必要です。
 
+## PR 運用
+
+- `1.21.1-main` への取り込みは PR 経由で行い、`PR CI / build-and-gametest` の成功を必須とします。
+- GitHub Actions は `pull_request` でのみ実行し、`pull_request_target` は使いません。
+- CI では secrets を使いません。workflow 権限は read-only に固定します。
+- 通常の PR は `Create a merge commit` を使います。
+- バージョン更新 PR だけは `Rebase and merge` を使ってかまいません。
+- `Squash and merge` は使いません。
+- GitHub 側の設定手順と bootstrap 順序は `docs/github-pr-protection.md` を参照してください。
+
 ## データパック調整
 
 - 親和ポーションの素材は、既定では各 school の `focus` を使います。

--- a/docs/github-pr-protection.md
+++ b/docs/github-pr-protection.md
@@ -1,0 +1,58 @@
+# GitHub PR 保護設定（`1.21.1-main`）
+
+このリポジトリでは `1.21.1-main` への反映を PR に統一し、`PR CI / build-and-gametest` が成功しない限りマージしない。
+
+## 1. Actions セキュリティ設定
+
+GitHub の `Settings` -> `Actions` -> `General` で次を設定する。
+
+- `Actions permissions`: `Allow select actions and reusable workflows`
+- GitHub 所有 action は許可する
+- 明示許可する追加 action は `gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e` のみとする
+- `Workflow permissions`: `Read repository contents permission`
+- `Allow GitHub Actions to create and approve pull requests`: `Off`
+- `Require actions to be pinned to a full-length commit SHA`: `On`
+- self-hosted runner は使わない
+
+補足:
+
+- この CI は secrets を使わない。
+- workflow は `pull_request` のみで動かし、`pull_request_target` は使わない。
+- `gradle/actions/wrapper-validation` を先に実行し、PR から差し替えられた wrapper をそのまま叩かない。
+
+## 2. bootstrap 手順
+
+target branch に workflow が存在しない段階で required check を先に有効化すると、`Expected — Waiting for status to be reported` のまま詰まることがある。`1.21.1-main` では次の順序を必ず守る。
+
+1. `1.21.1-main` 向け workflow を含む PR を作る
+2. required status check はまだ有効化しない
+3. その PR で `PR CI / build-and-gametest` が 1 回成功することを確認する
+4. PR を `Create a merge commit` で `1.21.1-main` に取り込む
+5. `1.21.1-main` 上に `.github/workflows/pr-ci.yml` が存在することを確認する
+6. その後で ruleset に `PR CI / build-and-gametest` を required check として追加する
+
+## 3. `1.21.1-main` の Ruleset
+
+GitHub の `Settings` -> `Rules` -> `Rulesets` で `1-21-1-main-pr-ci-protection` を作成する。
+
+- Target branches: `1.21.1-main`
+- Restrict deletions: `On`
+- Block force pushes: `On`
+- Require a pull request before merging: `On`
+- Allowed merge methods: `merge`, `rebase`
+- Required status checks:
+  - `PR CI / build-and-gametest`
+- Require branches to be up to date before merging: `On`
+
+補足:
+
+- `Squash and merge` は repository settings 側で無効化する。
+- 通常変更は `Create a merge commit` を使う。
+- バージョン更新 PR だけ `Rebase and merge` を使ってよい。
+
+## 4. 受け入れ確認
+
+1. 軽微な変更で `1.21.1-main` 向け PR を作成し、`PR CI / build-and-gametest` が自動起動することを確認する。
+2. workflow を含む最初の PR では、required check 未設定の状態で CI 成功後に merge できることを確認する。
+3. workflow 反映後に ruleset へ `PR CI / build-and-gametest` を required check として追加する。
+4. 以後の PR では、この check が成功しない限り merge できないことを確認する。

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTests.java
@@ -2912,7 +2912,11 @@ public final class ApprenticeCodexGameTests {
             AttributeModifier.Operation operation,
             String message
     ) {
-        var modifiers = item.getAttributeModifiers(slotContext, UUID.randomUUID(), stack);
+        var slotId = ResourceLocation.fromNamespaceAndPath(
+                ApprenticeCodex.MODID,
+                "gametest/curio/%s_%d".formatted(slotContext.identifier(), slotContext.index())
+        );
+        var modifiers = item.getAttributeModifiers(slotContext, slotId, stack);
         var actualAmount = sumModifierAmount(modifiers.get(attribute), operation);
         helper.assertTrue(Math.abs(actualAmount - expectedAmount) < 1.0e-9D,
                 message + ": expected stacked amount " + expectedAmount + " but got " + actualAmount

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTests.java
@@ -1067,9 +1067,10 @@ public final class ApprenticeCodexGameTests {
     public static void spellDispenserCastHelperSupportsSpectralHammer(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var level = helper.getLevel();
-            var castPos = new BlockPos(0, 1, 0);
-            var targetPos = new BlockPos(0, 1, 3);
-            helper.setBlock(targetPos, Blocks.STONE);
+            var relativeCastPos = new BlockPos(0, 1, 0);
+            var relativeTargetPos = new BlockPos(0, 1, 3);
+            var castPos = helper.absolutePos(relativeCastPos);
+            helper.setBlock(relativeTargetPos, Blocks.STONE);
 
             var castResult = SpellDispenserCastHelper.tryCast(
                     (ServerLevel) level,

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -569,6 +569,5 @@
   "advancements.apprenticecodex.apprentice_codex.craft_atelier_station.title": "アイアンのアトリエ",
   "advancements.apprenticecodex.apprentice_codex.craft_atelier_station.description": "アトリエステーションを作る",
   "advancements.apprenticecodex.apprentice_codex.craft_ashen_circlet.title": "王となれ",
-  "advancements.apprenticecodex.apprentice_codex.craft_ashen_circlet.description": "灰のサークレットを作る",
-
+  "advancements.apprenticecodex.apprentice_codex.craft_ashen_circlet.description": "灰のサークレットを作る"
 }


### PR DESCRIPTION
## 概要
- 1.21.1-main 向けの PR CI workflow を追加
- PR 運用と bootstrap 手順を README / AGENTS / docs に追記
- required check は workflow が target branch に載るまで有効化しない前提で整備

## 確認
- ローカル ./gradlew.bat build runGameTestServer --no-daemon --stacktrace
- build は成功
- GameTest は既存の spelldispensercasthelpersupportsspectralhammer 失敗を再現したため、GitHub-hosted runner 上の実態もこの PR で確認する