### PR TITLE
スペルガンや打撃杖などの Imbue 後に呪文を取り外せない不具合を 1.21.1 へ取り込み

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTests.java
@@ -29,11 +29,13 @@ import jp.aquafactory.apprenticecodex.effect.CastingMoveSpeedAdjustment;
 import jp.aquafactory.apprenticecodex.enchantment.Enchantments;
 import jp.aquafactory.apprenticecodex.network.packet.SenseEvilHighlightsPacket;
 import jp.aquafactory.apprenticecodex.item.AbstractOffhandMagicItem;
+import jp.aquafactory.apprenticecodex.item.AbstractImbueShieldItem;
 import jp.aquafactory.apprenticecodex.item.AbstractRightClickMagicWeaponItem;
 import jp.aquafactory.apprenticecodex.item.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.item.AbstractSwingMagicItem;
 import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.item.NonDamageableAnvilMergeItem;
+import jp.aquafactory.apprenticecodex.item.RestrictedSpellImbuableItem;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.item.flask.AlchemistsFlask;
 import jp.aquafactory.apprenticecodex.item.flask.SpellcastersFlask;
@@ -114,9 +116,6 @@ import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.ai.village.poi.PoiTypes;
 import net.minecraft.world.entity.npc.VillagerData;
 import net.minecraft.world.entity.npc.VillagerProfession;
-import net.minecraft.world.inventory.AbstractContainerMenu;
-import net.minecraft.world.inventory.CraftingContainer;
-import net.minecraft.world.inventory.TransientCraftingContainer;
 import net.minecraft.world.item.ArmorItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -2076,6 +2075,65 @@ public final class ApprenticeCodexGameTests {
                     "Copper Swingcast Staff preset spell mismatch: " + spellData.getSpell().getSpellResource());
             helper.assertTrue(spellData.getLevel() == 1,
                     "Copper Swingcast Staff preset spell level mismatch: " + spellData.getLevel());
+        });
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void goldSpellcasterGunImbuedSpellStaysRemovableAfterNormalization(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (AbstractSpellGunItem) ItemRegistry.GOLD_SPELLCASTER_GUN.get();
+            var stack = createInitializedPresetStack(item);
+            var replacementSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+
+            applyRestrictedImbueNormalization(helper, stack, item, replacementSpell, 1);
+
+            var spellContainer = ISpellContainer.get(stack);
+            helper.assertTrue(spellContainer != null, "Gold Spellcaster Gun normalized spell container is null");
+            assertSpellData(helper, spellContainer, 0, replacementSpell, 1, false,
+                    "Gold Spellcaster Gun imbued spell should be removable");
+            helper.assertTrue(spellContainer.getSpellAtIndex(0).canRemove(),
+                    "Gold Spellcaster Gun imbued spell should remain extractable in Spellcaster Workbench");
+        });
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void copperSwingcastStaffReplacementSpellStaysRemovableAfterNormalization(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (AbstractSwingcastStaffItem) ItemRegistry.COPPER_SWINGCAST_STAFF.get();
+            var stack = createInitializedPresetStack(item);
+            var initialContainer = ISpellContainer.get(stack);
+            var replacementSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.BALL_LIGHTNING_SPELL.get();
+
+            helper.assertTrue(initialContainer != null, "Copper Swingcast Staff spell container is null");
+            assertSpellData(helper, initialContainer, 0, io.redspace.ironsspellbooks.api.registry.SpellRegistry.BALL_LIGHTNING_SPELL.get(), 1, true,
+                    "Copper Swingcast Staff preset spell should remain locked");
+
+            applyRestrictedImbueNormalization(helper, stack, item, replacementSpell, 1);
+
+            var normalizedContainer = ISpellContainer.get(stack);
+            helper.assertTrue(normalizedContainer != null, "Copper Swingcast Staff normalized spell container is null");
+            assertSpellData(helper, normalizedContainer, 0, replacementSpell, 1, false,
+                    "Copper Swingcast Staff replacement spell should be removable");
+            helper.assertTrue(normalizedContainer.getSpellAtIndex(0).canRemove(),
+                    "Copper Swingcast Staff replacement spell should remain extractable in Spellcaster Workbench");
+        });
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void reflectcastShieldImbuedSpellStaysRemovableAfterNormalization(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (AbstractImbueShieldItem) ItemRegistry.REFLECTCAST_SHIELD.get();
+            var stack = createInitializedPresetStack(item);
+            var replacementSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+
+            applyRestrictedImbueNormalization(helper, stack, item, replacementSpell, 1);
+
+            var spellContainer = ISpellContainer.get(stack);
+            helper.assertTrue(spellContainer != null, "Reflectcast Shield normalized spell container is null");
+            assertSpellData(helper, spellContainer, 0, replacementSpell, 1, false,
+                    "Reflectcast Shield imbued spell should be removable");
+            helper.assertTrue(spellContainer.getSpellAtIndex(0).canRemove(),
+                    "Reflectcast Shield imbued spell should remain extractable in Spellcaster Workbench");
         });
     }
 
@@ -4949,6 +5007,27 @@ public final class ApprenticeCodexGameTests {
             presetSpellContainer.initializeSpellContainer(stack);
         }
         return stack;
+    }
+
+    private static void applyRestrictedImbueNormalization(
+            GameTestHelper helper,
+            ItemStack stack,
+            RestrictedSpellImbuableItem item,
+            AbstractSpell spell,
+            int spellLevel
+    ) {
+        var spellContainer = ISpellContainer.get(stack);
+        helper.assertTrue(spellContainer != null, "Missing spell container before restricted imbue normalization test");
+
+        var mutable = spellContainer.mutableCopy();
+        if (mutable.getSpellAtIndex(0) != SpellData.EMPTY) {
+            helper.assertTrue(mutable.removeSpellAtIndex(0),
+                    "Failed to clear existing spell before restricted imbue normalization test");
+        }
+        helper.assertTrue(mutable.addSpellAtIndex(spell, spellLevel, 0, false),
+                "Failed to prepare unlocked spell data before restricted imbue normalization test");
+        ISpellContainer.set(stack, mutable.toImmutable());
+        item.normalizeImbuedSpellContainer(stack);
     }
 
     private static CraftingInput createCraftingInput(ItemStack... stacks) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractImbueShieldItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractImbueShieldItem.java
@@ -12,7 +12,6 @@ import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.util.AnimationHolder;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.mixin.LivingEntityAccessor;
-import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.InteractionHand;
@@ -147,7 +146,8 @@ public abstract class AbstractImbueShieldItem extends ShieldItem implements IPre
 
         var normalized = ISpellContainer.create(1, false, false).mutableCopy();
         if (spellData != SpellData.EMPTY && canImbueSpell(spellData)) {
-            normalized.addSpellAtIndex(spellData.getSpell(), spellData.getLevel(), 0, true);
+            // Workbench 抽出可否は locked を見るため、差し替え後の呪文は preset 扱いにしない。
+            normalized.addSpellAtIndex(spellData.getSpell(), spellData.getLevel(), 0, false);
         }
         ISpellContainer.set(stack, normalized.toImmutable());
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSpellGunItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSpellGunItem.java
@@ -230,7 +230,8 @@ public abstract class AbstractSpellGunItem extends Item implements IPresetSpellC
         var spellData = getPrimarySpellData(stack);
         var normalized = ISpellContainer.create(1, false, false).mutableCopy();
         if (spellData != null && canImbueSpell(spellData)) {
-            normalized.addSpellAtIndex(spellData.getSpell(), spellData.getLevel(), 0, true);
+            // Arcane Anvil で差し替えた呪文まで固定すると Workbench 抽出不能になるため、preset 以外は removable に戻す。
+            normalized.addSpellAtIndex(spellData.getSpell(), spellData.getLevel(), 0, false);
         }
         ISpellContainer.set(stack, normalized.toImmutable());
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
@@ -139,7 +139,8 @@ public abstract class AbstractSwingMagicItem extends AbstractRightClickMagicWeap
 
         var normalized = ISpellContainer.create(1, false, false).mutableCopy();
         if (spellData != SpellData.EMPTY && canImbueSpell(spellData)) {
-            normalized.addSpellAtIndex(spellData.getSpell(), spellData.getLevel(), 0, true);
+            // 初期 preset と違い、後から注入した呪文は Spellcaster Workbench で取り外せる状態を維持する。
+            normalized.addSpellAtIndex(spellData.getSpell(), spellData.getLevel(), 0, false);
         }
         ISpellContainer.set(stack, normalized.toImmutable());
     }


### PR DESCRIPTION
## 概要
- `main` の PR #345 を `1.21.1-main` 向けに forward-port
- Spellcaster Workbench / Arcane Anvil 経由で差し替えた呪文が preset 扱いのまま残り、取り外せなくなる不具合を修正
- spell gun / swingcast staff / imbue shield 向けの GameTest を追加

## 取り込み元
- cherry-pick: `8dddfa33790fa024b996c80c85436cd8d97a89c3`

## 確認
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat build`