### PR TITLE
PR437の1.21.1移植

### DIFF
--- a/src/generated/resources/data/apprenticecodex/spell_dispenser_spell_profiles/profiles.json
+++ b/src/generated/resources/data/apprenticecodex/spell_dispenser_spell_profiles/profiles.json
@@ -475,6 +475,12 @@
       "profile": {
         "owner_required": false
       },
+      "spell": "apprenticecodex:tiro_volley"
+    },
+    {
+      "profile": {
+        "owner_required": false
+      },
       "spell": "apprenticecodex:silent_assassin"
     },
     {

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/spell/SpellDispenserSpellProfileDataGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/spell/SpellDispenserSpellProfileDataGenerator.java
@@ -126,6 +126,7 @@ public final class SpellDispenserSpellProfileDataGenerator extends JsonCodecProv
                         profile(ApprenticeCodex.MODID, "grind_runner", SpellDispenserSpellProfile.OWNER_OPTIONAL),
                         profile(ApprenticeCodex.MODID, "harvest_moon", SpellDispenserSpellProfile.DEFAULT),
                         profile(ApprenticeCodex.MODID, "moon_light", SpellDispenserSpellProfile.OWNER_OPTIONAL),
+                        profile(ApprenticeCodex.MODID, "tiro_volley", SpellDispenserSpellProfile.OWNER_OPTIONAL),
                         profile(ApprenticeCodex.MODID, "silent_assassin", SpellDispenserSpellProfile.OWNER_OPTIONAL),
                         profile(ApprenticeCodex.MODID, "magic_spear", SpellDispenserSpellProfile.OWNER_OPTIONAL),
                         profile(ApprenticeCodex.MODID, "frost_rune", SpellDispenserSpellProfile.OWNER_OPTIONAL)

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/tirovolley/TiroVolley.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/tirovolley/TiroVolley.java
@@ -11,6 +11,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
 import jp.aquafactory.apprenticecodex.spell.ICastHighlightSpell;
+import jp.aquafactory.apprenticecodex.utility.AudioTools;
 import jp.aquafactory.apprenticecodex.utility.CombatTools;
 import jp.aquafactory.apprenticecodex.utility.RaycastTools;
 import jp.aquafactory.apprenticecodex.utility.RotationTools;
@@ -24,6 +25,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.Entity;
@@ -199,6 +201,9 @@ public class TiroVolley extends AbstractSpell implements ICastHighlightSpell {
         musket.setPos(spawnPosition);
         musket.setup(getDamage(spellLevel, caster), spellLevel, fireDelay, target);
         level.addFreshEntity(musket);
+
+        AudioTools.playSoundFromEntity(level, musket, SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 0.5f);
+        AudioTools.playSoundFromEntity(level, musket, SoundEvents.ARMOR_EQUIP_IRON, SoundSource.PLAYERS, 0.5f, 1.5f);
     }
 
     private static Entity findInitialTarget(ServerLevel level, LivingEntity caster) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/tirovolley/TiroVolley.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/tirovolley/TiroVolley.java
@@ -203,7 +203,7 @@ public class TiroVolley extends AbstractSpell implements ICastHighlightSpell {
         level.addFreshEntity(musket);
 
         AudioTools.playSoundFromEntity(level, musket, SoundEvents.ENDERMAN_TELEPORT, SoundSource.PLAYERS, 0.5f);
-        AudioTools.playSoundFromEntity(level, musket, SoundEvents.ARMOR_EQUIP_IRON, SoundSource.PLAYERS, 0.5f, 1.5f);
+        AudioTools.playSoundFromEntity(level, musket, SoundEvents.ARMOR_EQUIP_IRON.value(), SoundSource.PLAYERS, 0.5f, 1.5f);
     }
 
     private static Entity findInitialTarget(ServerLevel level, LivingEntity caster) {


### PR DESCRIPTION
## 概要
- PR #437 のティロボレー微修正を `1.21.1-main` へ forward-port
- スペルディスペンサー定義へ `tiro_volley` を追加
- ティロボレーのマスケット召喚時に効果音を再生
- 1.21.1 API 差分として `SoundEvents.ARMOR_EQUIP_IRON.value()` へ調整

## 検証
- `./gradlew.bat runData`
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat build`