### PR TITLE
詠唱者の矢筒の移動減速解除mixinを競合しにくくする

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/LocalPlayerSpellcasterQuiverMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/LocalPlayerSpellcasterQuiverMixin.java
@@ -1,21 +1,64 @@
 package jp.aquafactory.apprenticecodex.mixin;
 
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiver;
+import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LocalPlayer.class)
 public abstract class LocalPlayerSpellcasterQuiverMixin {
+    @Shadow
+    public Input input;
 
-    @ModifyConstant(method = "aiStep", constant = @Constant(floatValue = 0.2F))
-    private float apprenticecodex$ignoreBowDrawSlowdown(float value) {
+    @Unique
+    private boolean apprenticecodex$restoreBowDrawInput;
+    @Unique
+    private float apprenticecodex$bowDrawLeftImpulse;
+    @Unique
+    private float apprenticecodex$bowDrawForwardImpulse;
+
+    @Inject(
+            method = "aiStep",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/tutorial/Tutorial;onInput(Lnet/minecraft/client/player/Input;)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void apprenticecodex$captureBowDrawInput(CallbackInfo ci) {
+        apprenticecodex$restoreBowDrawInput = false;
         if (!SpellcasterQuiver.shouldIgnoreBowSlowdown((LocalPlayer) (Object) this)) {
-            return value;
+            return;
         }
 
-        // バニラ弓系の入力減衰だけを打ち消し、他の移動補正には触れない。
-        return 1.0F;
+        apprenticecodex$restoreBowDrawInput = true;
+        apprenticecodex$bowDrawLeftImpulse = input.leftImpulse;
+        apprenticecodex$bowDrawForwardImpulse = input.forwardImpulse;
+    }
+
+    @Inject(
+            method = "aiStep",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/client/player/LocalPlayer;autoJumpTime:I",
+                    opcode = Opcodes.GETFIELD,
+                    ordinal = 0
+            )
+    )
+    private void apprenticecodex$restoreBowDrawInput(CallbackInfo ci) {
+        if (!apprenticecodex$restoreBowDrawInput) {
+            return;
+        }
+
+        apprenticecodex$restoreBowDrawInput = false;
+        // 外部 MOD も同じ 0.2F 定数を変更するため、定数変更ではなく減速後の入力値だけを戻す。
+        input.leftImpulse = apprenticecodex$bowDrawLeftImpulse;
+        input.forwardImpulse = apprenticecodex$bowDrawForwardImpulse;
     }
 }


### PR DESCRIPTION
## Summary
- `LocalPlayer.aiStep` の `0.2F` 定数を書き換える `@ModifyConstant` を廃止
- 入力更新直後の移動入力を保存し、詠唱者の矢筒条件が成立した場合のみ item-use slowdown 後に復元する方式へ変更
- Origins: Classes など、同じ定数を変更する外部 MOD との mixin 競合を回避

Fixes #462

## Verification
- `./gradlew.bat build`
- 手元のクラッシュ再現環境で起動成功を確認
- 詠唱者の矢筒の移動速度低下打ち消し機能を確認
- Origins の Archer クラスと併用しても問題ないことを確認

## Forward-port
- `1.21.1-main` 側にも同じ mixin があるため、本変更は forward-port 対象
- 1.21.1 / NeoForge 側では同じ意図で、入力更新後に保存し item-use slowdown 後に復元する注入点へ調整する