### PR TITLE
PR #463 を 1.21.1-main へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/LocalPlayerSpellcasterQuiverMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/LocalPlayerSpellcasterQuiverMixin.java
@@ -1,21 +1,64 @@
 package jp.aquafactory.apprenticecodex.mixin;
 
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiver;
+import net.minecraft.client.player.Input;
 import net.minecraft.client.player.LocalPlayer;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LocalPlayer.class)
 public abstract class LocalPlayerSpellcasterQuiverMixin {
+    @Shadow
+    public Input input;
 
-    @ModifyConstant(method = "aiStep", constant = @Constant(floatValue = 0.2F))
-    private float apprenticecodex$ignoreBowDrawSlowdown(float value) {
+    @Unique
+    private boolean apprenticecodex$restoreBowDrawInput;
+    @Unique
+    private float apprenticecodex$bowDrawLeftImpulse;
+    @Unique
+    private float apprenticecodex$bowDrawForwardImpulse;
+
+    @Inject(
+            method = "aiStep",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/tutorial/Tutorial;onInput(Lnet/minecraft/client/player/Input;)V",
+                    shift = At.Shift.AFTER
+            )
+    )
+    private void apprenticecodex$captureBowDrawInput(CallbackInfo ci) {
+        apprenticecodex$restoreBowDrawInput = false;
         if (!SpellcasterQuiver.shouldIgnoreBowSlowdown((LocalPlayer) (Object) this)) {
-            return value;
+            return;
         }
 
-        // バニラ弓系の入力減衰だけを打ち消し、他の移動補正には触れない。
-        return 1.0F;
+        apprenticecodex$restoreBowDrawInput = true;
+        apprenticecodex$bowDrawLeftImpulse = input.leftImpulse;
+        apprenticecodex$bowDrawForwardImpulse = input.forwardImpulse;
+    }
+
+    @Inject(
+            method = "aiStep",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/client/player/LocalPlayer;autoJumpTime:I",
+                    opcode = Opcodes.GETFIELD,
+                    ordinal = 0
+            )
+    )
+    private void apprenticecodex$restoreBowDrawInput(CallbackInfo ci) {
+        if (!apprenticecodex$restoreBowDrawInput) {
+            return;
+        }
+
+        apprenticecodex$restoreBowDrawInput = false;
+        // 外部 MOD も同じ 0.2F 定数を変更するため、定数変更ではなく減速後の入力値だけを戻す。
+        input.leftImpulse = apprenticecodex$bowDrawLeftImpulse;
+        input.forwardImpulse = apprenticecodex$bowDrawForwardImpulse;
     }
 }


### PR DESCRIPTION
## 概要
- PR #463 の詠唱者の矢筒の移動減速解除 mixin 変更を `1.21.1-main` へ forward-port
- `LocalPlayer.aiStep` の `0.2F` 定数を書き換える `@ModifyConstant` を廃止
- 入力更新直後の移動入力を保存し、詠唱者の矢筒条件が成立した場合のみ item-use slowdown 後に復元する方式へ変更

## 取り込み元
- `efe60b10cbc2910f63518d62e3bdb8b1b2a3d94a`
- `git cherry-pick -x` で取り込み

## 検証
- `git diff --name-status origin/1.21.1-main..HEAD`
  - `src/main/java/jp/aquafactory/apprenticecodex/mixin/LocalPlayerSpellcasterQuiverMixin.java` のみ変更
- `./gradlew.bat runGameTestServer`
  - 323 required tests passed
- `./gradlew.bat build`
  - 成功
- `./gradlew.bat runClient`
  - 起動成功
  - ワールドに入り、詠唱者の矢筒の移動速度低下打ち消しが機能することを手動確認

## 補足
- 開発環境には Origins を入れていないため、Origins: Classes 併用での実衝突確認は未実施
- 競合しやすい `0.2F` 定数変更を廃止していることはコード差分で確認済み