### PR TITLE
装備バランス値をサーバー設定化

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -97,6 +97,10 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.craftsmansDelightFortuneLevel();
     }
 
+    public static double chromaticMagiaDressSchoolSpellPowerBonusPerHistory() {
+        return ITEMS_CONFIG.chromaticMagiaDressSchoolSpellPowerBonusPerHistory();
+    }
+
     public static double pastelStaffAmplifyTintedMagicMultiplier() {
         return ITEMS_CONFIG.pastelStaffAmplifyTintedMagicMultiplier();
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -129,6 +129,34 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.enableIsekaiTravelGuidebookBonusChestLoot();
     }
 
+    public static float manaForceBladeImbueDamageMultiplierScale() {
+        return ITEMS_CONFIG.manaForceBladeImbueDamageMultiplierScale();
+    }
+
+    public static float manaForceBladeAttackManaCostMultiplier() {
+        return ITEMS_CONFIG.manaForceBladeAttackManaCostMultiplier();
+    }
+
+    public static float manaForceBladeAttackManaSchoolMultiplierScale() {
+        return ITEMS_CONFIG.manaForceBladeAttackManaSchoolMultiplierScale();
+    }
+
+    public static float manaForceBladeMeleeGuardManaCost() {
+        return ITEMS_CONFIG.manaForceBladeMeleeGuardManaCost();
+    }
+
+    public static float manaForceBladeRangedGuardManaCost() {
+        return ITEMS_CONFIG.manaForceBladeRangedGuardManaCost();
+    }
+
+    public static boolean manaForceBladeDisableManaRecoveryWhileGuarding() {
+        return ITEMS_CONFIG.manaForceBladeDisableManaRecoveryWhileGuarding();
+    }
+
+    public static int manaForceBladePerfectGuardTicks() {
+        return ITEMS_CONFIG.manaForceBladePerfectGuardTicks();
+    }
+
     public static float forceFieldDrainManaBasePerHit() {
         return SPELLS_CONFIG.forceFieldDrainManaBasePerHit();
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -97,6 +97,22 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.craftsmansDelightFortuneLevel();
     }
 
+    public static double apprenticeMageRobeSpellPowerBonusPerPiece() {
+        return ITEMS_CONFIG.apprenticeMageRobeSpellPowerBonusPerPiece();
+    }
+
+    public static double enchantressRobeSpellPowerBonusPerPiece() {
+        return ITEMS_CONFIG.enchantressRobeSpellPowerBonusPerPiece();
+    }
+
+    public static double chromaticMagiaDressSpellPowerBonusPerPiece() {
+        return ITEMS_CONFIG.chromaticMagiaDressSpellPowerBonusPerPiece();
+    }
+
+    public static double stealthRuneArmorSpellPowerBonusPerPiece() {
+        return ITEMS_CONFIG.stealthRuneArmorSpellPowerBonusPerPiece();
+    }
+
     public static double chromaticMagiaDressSchoolSpellPowerBonusPerHistory() {
         return ITEMS_CONFIG.chromaticMagiaDressSchoolSpellPowerBonusPerHistory();
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -4,6 +4,7 @@ import jp.aquafactory.apprenticecodex.config.item.CraftsmansDelightServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ChromaticMagiaDressServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.IsekaiTravelGuidebookServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.MagicArmorServerConfig;
+import jp.aquafactory.apprenticecodex.config.item.ManaForceBladeServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.PastelStaffServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.AbsorptionAmplifyAmuletServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArcaneCinderServerConfig;
@@ -19,6 +20,7 @@ final class ItemsServerConfig {
     private final ChromaticMagiaDressServerConfig chromaticMagiaDressConfig;
     private final PastelStaffServerConfig pastelStaffConfig;
     private final IsekaiTravelGuidebookServerConfig isekaiTravelGuidebookConfig;
+    private final ManaForceBladeServerConfig manaForceBladeConfig;
 
     private ItemsServerConfig(
             ArcaneCinderServerConfig arcaneCinderConfig,
@@ -28,7 +30,8 @@ final class ItemsServerConfig {
             MagicArmorServerConfig magicArmorConfig,
             ChromaticMagiaDressServerConfig chromaticMagiaDressConfig,
             PastelStaffServerConfig pastelStaffConfig,
-            IsekaiTravelGuidebookServerConfig isekaiTravelGuidebookConfig
+            IsekaiTravelGuidebookServerConfig isekaiTravelGuidebookConfig,
+            ManaForceBladeServerConfig manaForceBladeConfig
     ) {
         this.arcaneCinderConfig = arcaneCinderConfig;
         this.absorptionAmplifyAmuletConfig = absorptionAmplifyAmuletConfig;
@@ -38,6 +41,7 @@ final class ItemsServerConfig {
         this.chromaticMagiaDressConfig = chromaticMagiaDressConfig;
         this.pastelStaffConfig = pastelStaffConfig;
         this.isekaiTravelGuidebookConfig = isekaiTravelGuidebookConfig;
+        this.manaForceBladeConfig = manaForceBladeConfig;
     }
 
     static ItemsServerConfig define(ForgeConfigSpec.Builder builder) {
@@ -50,6 +54,7 @@ final class ItemsServerConfig {
         var chromaticMagiaDressConfig = ChromaticMagiaDressServerConfig.define(builder);
         var pastelStaffConfig = PastelStaffServerConfig.define(builder);
         var isekaiTravelGuidebookConfig = IsekaiTravelGuidebookServerConfig.define(builder);
+        var manaForceBladeConfig = ManaForceBladeServerConfig.define(builder);
         builder.pop();
 
         return new ItemsServerConfig(
@@ -60,7 +65,8 @@ final class ItemsServerConfig {
                 magicArmorConfig,
                 chromaticMagiaDressConfig,
                 pastelStaffConfig,
-                isekaiTravelGuidebookConfig
+                isekaiTravelGuidebookConfig,
+                manaForceBladeConfig
         );
     }
 
@@ -138,5 +144,33 @@ final class ItemsServerConfig {
 
     boolean enableIsekaiTravelGuidebookBonusChestLoot() {
         return isekaiTravelGuidebookConfig.enableBonusChestLoot();
+    }
+
+    float manaForceBladeImbueDamageMultiplierScale() {
+        return manaForceBladeConfig.imbueDamageMultiplierScale();
+    }
+
+    float manaForceBladeAttackManaCostMultiplier() {
+        return manaForceBladeConfig.attackManaCostMultiplier();
+    }
+
+    float manaForceBladeAttackManaSchoolMultiplierScale() {
+        return manaForceBladeConfig.attackManaSchoolMultiplierScale();
+    }
+
+    float manaForceBladeMeleeGuardManaCost() {
+        return manaForceBladeConfig.meleeGuardManaCost();
+    }
+
+    float manaForceBladeRangedGuardManaCost() {
+        return manaForceBladeConfig.rangedGuardManaCost();
+    }
+
+    boolean manaForceBladeDisableManaRecoveryWhileGuarding() {
+        return manaForceBladeConfig.disableManaRecoveryWhileGuarding();
+    }
+
+    int manaForceBladePerfectGuardTicks() {
+        return manaForceBladeConfig.perfectGuardTicks();
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.config;
 import jp.aquafactory.apprenticecodex.config.item.CraftsmansDelightServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ChromaticMagiaDressServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.IsekaiTravelGuidebookServerConfig;
+import jp.aquafactory.apprenticecodex.config.item.MagicArmorServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.PastelStaffServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.AbsorptionAmplifyAmuletServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArcaneCinderServerConfig;
@@ -14,6 +15,7 @@ final class ItemsServerConfig {
     private final AbsorptionAmplifyAmuletServerConfig absorptionAmplifyAmuletConfig;
     private final ScarletThirstServerConfig scarletThirstConfig;
     private final CraftsmansDelightServerConfig craftsmansDelightConfig;
+    private final MagicArmorServerConfig magicArmorConfig;
     private final ChromaticMagiaDressServerConfig chromaticMagiaDressConfig;
     private final PastelStaffServerConfig pastelStaffConfig;
     private final IsekaiTravelGuidebookServerConfig isekaiTravelGuidebookConfig;
@@ -23,6 +25,7 @@ final class ItemsServerConfig {
             AbsorptionAmplifyAmuletServerConfig absorptionAmplifyAmuletConfig,
             ScarletThirstServerConfig scarletThirstConfig,
             CraftsmansDelightServerConfig craftsmansDelightConfig,
+            MagicArmorServerConfig magicArmorConfig,
             ChromaticMagiaDressServerConfig chromaticMagiaDressConfig,
             PastelStaffServerConfig pastelStaffConfig,
             IsekaiTravelGuidebookServerConfig isekaiTravelGuidebookConfig
@@ -31,6 +34,7 @@ final class ItemsServerConfig {
         this.absorptionAmplifyAmuletConfig = absorptionAmplifyAmuletConfig;
         this.scarletThirstConfig = scarletThirstConfig;
         this.craftsmansDelightConfig = craftsmansDelightConfig;
+        this.magicArmorConfig = magicArmorConfig;
         this.chromaticMagiaDressConfig = chromaticMagiaDressConfig;
         this.pastelStaffConfig = pastelStaffConfig;
         this.isekaiTravelGuidebookConfig = isekaiTravelGuidebookConfig;
@@ -42,6 +46,7 @@ final class ItemsServerConfig {
         var absorptionAmplifyAmuletConfig = AbsorptionAmplifyAmuletServerConfig.define(builder);
         var scarletThirstConfig = ScarletThirstServerConfig.define(builder);
         var craftsmansDelightConfig = CraftsmansDelightServerConfig.define(builder);
+        var magicArmorConfig = MagicArmorServerConfig.define(builder);
         var chromaticMagiaDressConfig = ChromaticMagiaDressServerConfig.define(builder);
         var pastelStaffConfig = PastelStaffServerConfig.define(builder);
         var isekaiTravelGuidebookConfig = IsekaiTravelGuidebookServerConfig.define(builder);
@@ -52,6 +57,7 @@ final class ItemsServerConfig {
                 absorptionAmplifyAmuletConfig,
                 scarletThirstConfig,
                 craftsmansDelightConfig,
+                magicArmorConfig,
                 chromaticMagiaDressConfig,
                 pastelStaffConfig,
                 isekaiTravelGuidebookConfig
@@ -100,6 +106,22 @@ final class ItemsServerConfig {
 
     int craftsmansDelightFortuneLevel() {
         return craftsmansDelightConfig.fortuneLevel();
+    }
+
+    double apprenticeMageRobeSpellPowerBonusPerPiece() {
+        return magicArmorConfig.apprenticeMageRobeSpellPowerBonusPerPiece();
+    }
+
+    double enchantressRobeSpellPowerBonusPerPiece() {
+        return magicArmorConfig.enchantressRobeSpellPowerBonusPerPiece();
+    }
+
+    double chromaticMagiaDressSpellPowerBonusPerPiece() {
+        return magicArmorConfig.chromaticMagiaDressSpellPowerBonusPerPiece();
+    }
+
+    double stealthRuneArmorSpellPowerBonusPerPiece() {
+        return magicArmorConfig.stealthRuneArmorSpellPowerBonusPerPiece();
     }
 
     double chromaticMagiaDressSchoolSpellPowerBonusPerHistory() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -1,6 +1,7 @@
 package jp.aquafactory.apprenticecodex.config;
 
 import jp.aquafactory.apprenticecodex.config.item.CraftsmansDelightServerConfig;
+import jp.aquafactory.apprenticecodex.config.item.ChromaticMagiaDressServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.IsekaiTravelGuidebookServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.PastelStaffServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.AbsorptionAmplifyAmuletServerConfig;
@@ -13,6 +14,7 @@ final class ItemsServerConfig {
     private final AbsorptionAmplifyAmuletServerConfig absorptionAmplifyAmuletConfig;
     private final ScarletThirstServerConfig scarletThirstConfig;
     private final CraftsmansDelightServerConfig craftsmansDelightConfig;
+    private final ChromaticMagiaDressServerConfig chromaticMagiaDressConfig;
     private final PastelStaffServerConfig pastelStaffConfig;
     private final IsekaiTravelGuidebookServerConfig isekaiTravelGuidebookConfig;
 
@@ -21,6 +23,7 @@ final class ItemsServerConfig {
             AbsorptionAmplifyAmuletServerConfig absorptionAmplifyAmuletConfig,
             ScarletThirstServerConfig scarletThirstConfig,
             CraftsmansDelightServerConfig craftsmansDelightConfig,
+            ChromaticMagiaDressServerConfig chromaticMagiaDressConfig,
             PastelStaffServerConfig pastelStaffConfig,
             IsekaiTravelGuidebookServerConfig isekaiTravelGuidebookConfig
     ) {
@@ -28,6 +31,7 @@ final class ItemsServerConfig {
         this.absorptionAmplifyAmuletConfig = absorptionAmplifyAmuletConfig;
         this.scarletThirstConfig = scarletThirstConfig;
         this.craftsmansDelightConfig = craftsmansDelightConfig;
+        this.chromaticMagiaDressConfig = chromaticMagiaDressConfig;
         this.pastelStaffConfig = pastelStaffConfig;
         this.isekaiTravelGuidebookConfig = isekaiTravelGuidebookConfig;
     }
@@ -38,6 +42,7 @@ final class ItemsServerConfig {
         var absorptionAmplifyAmuletConfig = AbsorptionAmplifyAmuletServerConfig.define(builder);
         var scarletThirstConfig = ScarletThirstServerConfig.define(builder);
         var craftsmansDelightConfig = CraftsmansDelightServerConfig.define(builder);
+        var chromaticMagiaDressConfig = ChromaticMagiaDressServerConfig.define(builder);
         var pastelStaffConfig = PastelStaffServerConfig.define(builder);
         var isekaiTravelGuidebookConfig = IsekaiTravelGuidebookServerConfig.define(builder);
         builder.pop();
@@ -47,6 +52,7 @@ final class ItemsServerConfig {
                 absorptionAmplifyAmuletConfig,
                 scarletThirstConfig,
                 craftsmansDelightConfig,
+                chromaticMagiaDressConfig,
                 pastelStaffConfig,
                 isekaiTravelGuidebookConfig
         );
@@ -94,6 +100,10 @@ final class ItemsServerConfig {
 
     int craftsmansDelightFortuneLevel() {
         return craftsmansDelightConfig.fortuneLevel();
+    }
+
+    double chromaticMagiaDressSchoolSpellPowerBonusPerHistory() {
+        return chromaticMagiaDressConfig.schoolSpellPowerBonusPerHistory();
     }
 
     double pastelStaffAmplifyTintedMagicMultiplier() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/ChromaticMagiaDressServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/ChromaticMagiaDressServerConfig.java
@@ -1,0 +1,30 @@
+package jp.aquafactory.apprenticecodex.config.item;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public final class ChromaticMagiaDressServerConfig {
+    private final ForgeConfigSpec.DoubleValue schoolSpellPowerBonusPerHistory;
+
+    private ChromaticMagiaDressServerConfig(ForgeConfigSpec.DoubleValue schoolSpellPowerBonusPerHistory) {
+        this.schoolSpellPowerBonusPerHistory = schoolSpellPowerBonusPerHistory;
+    }
+
+    public static ChromaticMagiaDressServerConfig define(ForgeConfigSpec.Builder builder) {
+        builder.comment("Spell power attribute modifier amount per recorded school history. 0.01 = +1%.")
+                .push("ChromaticMagiaDress");
+
+        var schoolSpellPowerBonusPerHistory = builder.defineInRange(
+                "schoolSpellPowerBonusPerHistory",
+                0.01d,
+                0.0d,
+                10.0d
+        );
+
+        builder.pop();
+        return new ChromaticMagiaDressServerConfig(schoolSpellPowerBonusPerHistory);
+    }
+
+    public double schoolSpellPowerBonusPerHistory() {
+        return schoolSpellPowerBonusPerHistory.get();
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/MagicArmorServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/MagicArmorServerConfig.java
@@ -1,0 +1,85 @@
+package jp.aquafactory.apprenticecodex.config.item;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public final class MagicArmorServerConfig {
+    private final ForgeConfigSpec.DoubleValue apprenticeMageRobeSpellPowerBonusPerPiece;
+    private final ForgeConfigSpec.DoubleValue enchantressRobeSpellPowerBonusPerPiece;
+    private final ForgeConfigSpec.DoubleValue chromaticMagiaDressSpellPowerBonusPerPiece;
+    private final ForgeConfigSpec.DoubleValue stealthRuneArmorSpellPowerBonusPerPiece;
+
+    private MagicArmorServerConfig(
+            ForgeConfigSpec.DoubleValue apprenticeMageRobeSpellPowerBonusPerPiece,
+            ForgeConfigSpec.DoubleValue enchantressRobeSpellPowerBonusPerPiece,
+            ForgeConfigSpec.DoubleValue chromaticMagiaDressSpellPowerBonusPerPiece,
+            ForgeConfigSpec.DoubleValue stealthRuneArmorSpellPowerBonusPerPiece
+    ) {
+        this.apprenticeMageRobeSpellPowerBonusPerPiece = apprenticeMageRobeSpellPowerBonusPerPiece;
+        this.enchantressRobeSpellPowerBonusPerPiece = enchantressRobeSpellPowerBonusPerPiece;
+        this.chromaticMagiaDressSpellPowerBonusPerPiece = chromaticMagiaDressSpellPowerBonusPerPiece;
+        this.stealthRuneArmorSpellPowerBonusPerPiece = stealthRuneArmorSpellPowerBonusPerPiece;
+    }
+
+    public static MagicArmorServerConfig define(ForgeConfigSpec.Builder builder) {
+        var apprenticeMageRobeSpellPowerBonusPerPiece = defineSpellPowerBonusPerPiece(
+                builder,
+                "ApprenticeMageRobe",
+                0.05D
+        );
+        var enchantressRobeSpellPowerBonusPerPiece = defineSpellPowerBonusPerPiece(
+                builder,
+                "EnchantressRobe",
+                0.10D
+        );
+        var chromaticMagiaDressSpellPowerBonusPerPiece = defineSpellPowerBonusPerPiece(
+                builder,
+                "ChromaticMagiaDress",
+                0.10D
+        );
+        var stealthRuneArmorSpellPowerBonusPerPiece = defineSpellPowerBonusPerPiece(
+                builder,
+                "StealthRuneArmor",
+                0.05D
+        );
+
+        return new MagicArmorServerConfig(
+                apprenticeMageRobeSpellPowerBonusPerPiece,
+                enchantressRobeSpellPowerBonusPerPiece,
+                chromaticMagiaDressSpellPowerBonusPerPiece,
+                stealthRuneArmorSpellPowerBonusPerPiece
+        );
+    }
+
+    public double apprenticeMageRobeSpellPowerBonusPerPiece() {
+        return apprenticeMageRobeSpellPowerBonusPerPiece.get();
+    }
+
+    public double enchantressRobeSpellPowerBonusPerPiece() {
+        return enchantressRobeSpellPowerBonusPerPiece.get();
+    }
+
+    public double chromaticMagiaDressSpellPowerBonusPerPiece() {
+        return chromaticMagiaDressSpellPowerBonusPerPiece.get();
+    }
+
+    public double stealthRuneArmorSpellPowerBonusPerPiece() {
+        return stealthRuneArmorSpellPowerBonusPerPiece.get();
+    }
+
+    private static ForgeConfigSpec.DoubleValue defineSpellPowerBonusPerPiece(
+            ForgeConfigSpec.Builder builder,
+            String sectionName,
+            double defaultValue
+    ) {
+        builder.comment("Global spell power attribute modifier amount per armor piece. 0.01 = +1%.")
+                .push(sectionName);
+        var value = builder.defineInRange(
+                "spellPowerBonusPerPiece",
+                defaultValue,
+                0.0D,
+                10.0D
+        );
+        builder.pop();
+        return value;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/ManaForceBladeServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/ManaForceBladeServerConfig.java
@@ -1,0 +1,90 @@
+package jp.aquafactory.apprenticecodex.config.item;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public final class ManaForceBladeServerConfig {
+    private final ForgeConfigSpec.DoubleValue imbueDamageMultiplierScale;
+    private final ForgeConfigSpec.DoubleValue attackManaCostMultiplier;
+    private final ForgeConfigSpec.DoubleValue attackManaSchoolMultiplierScale;
+    private final ForgeConfigSpec.DoubleValue meleeGuardManaCost;
+    private final ForgeConfigSpec.DoubleValue rangedGuardManaCost;
+    private final ForgeConfigSpec.BooleanValue disableManaRecoveryWhileGuarding;
+    private final ForgeConfigSpec.IntValue perfectGuardTicks;
+
+    private ManaForceBladeServerConfig(
+            ForgeConfigSpec.DoubleValue imbueDamageMultiplierScale,
+            ForgeConfigSpec.DoubleValue attackManaCostMultiplier,
+            ForgeConfigSpec.DoubleValue attackManaSchoolMultiplierScale,
+            ForgeConfigSpec.DoubleValue meleeGuardManaCost,
+            ForgeConfigSpec.DoubleValue rangedGuardManaCost,
+            ForgeConfigSpec.BooleanValue disableManaRecoveryWhileGuarding,
+            ForgeConfigSpec.IntValue perfectGuardTicks
+    ) {
+        this.imbueDamageMultiplierScale = imbueDamageMultiplierScale;
+        this.attackManaCostMultiplier = attackManaCostMultiplier;
+        this.attackManaSchoolMultiplierScale = attackManaSchoolMultiplierScale;
+        this.meleeGuardManaCost = meleeGuardManaCost;
+        this.rangedGuardManaCost = rangedGuardManaCost;
+        this.disableManaRecoveryWhileGuarding = disableManaRecoveryWhileGuarding;
+        this.perfectGuardTicks = perfectGuardTicks;
+    }
+
+    public static ManaForceBladeServerConfig define(ForgeConfigSpec.Builder builder) {
+        builder.push("ManaForceBlade");
+
+        var imbueDamageMultiplierScale = builder
+                .comment("Scales the imbued school attack damage multiplier. 1.0 = default behavior. 0 disables imbued attack damage changes.")
+                .defineInRange("imbueDamageMultiplierScale", 1.0d, 0.0d, 10.0d);
+        var attackManaCostMultiplier = builder
+                .comment("Mana cost multiplier for imbued melee hits. 0 disables hit mana cost and its tooltip.")
+                .defineInRange("attackManaCostMultiplier", 3.0d, 0.0d, 10000.0d);
+        var attackManaSchoolMultiplierScale = builder
+                .comment("Scales only the school-derived hit mana cost increase. 1.0 follows damage growth. 0 ignores school multiplier for hit mana cost.")
+                .defineInRange("attackManaSchoolMultiplierScale", 1.0d, 0.0d, 10.0d);
+        var meleeGuardManaCost = builder.defineInRange("meleeGuardManaCost", 50.0d, 0.0d, 10000.0d);
+        var rangedGuardManaCost = builder.defineInRange("rangedGuardManaCost", 20.0d, 0.0d, 10000.0d);
+        var disableManaRecoveryWhileGuarding = builder.define("disableManaRecoveryWhileGuarding", true);
+        var perfectGuardTicks = builder
+                .comment("Ticks treated as perfect guard for vanilla-style Mana Force Blade guard. Not used when Epic Fight is installed because Epic Fight guard skills take priority.")
+                .defineInRange("perfectGuardTicks", 10, 0, 72000);
+
+        builder.pop();
+        return new ManaForceBladeServerConfig(
+                imbueDamageMultiplierScale,
+                attackManaCostMultiplier,
+                attackManaSchoolMultiplierScale,
+                meleeGuardManaCost,
+                rangedGuardManaCost,
+                disableManaRecoveryWhileGuarding,
+                perfectGuardTicks
+        );
+    }
+
+    public float imbueDamageMultiplierScale() {
+        return imbueDamageMultiplierScale.get().floatValue();
+    }
+
+    public float attackManaCostMultiplier() {
+        return attackManaCostMultiplier.get().floatValue();
+    }
+
+    public float attackManaSchoolMultiplierScale() {
+        return attackManaSchoolMultiplierScale.get().floatValue();
+    }
+
+    public float meleeGuardManaCost() {
+        return meleeGuardManaCost.get().floatValue();
+    }
+
+    public float rangedGuardManaCost() {
+        return rangedGuardManaCost.get().floatValue();
+    }
+
+    public boolean disableManaRecoveryWhileGuarding() {
+        return disableManaRecoveryWhileGuarding.get();
+    }
+
+    public int perfectGuardTicks() {
+        return perfectGuardTicks.get();
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/ManaForceBladeConfigSyncEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/ManaForceBladeConfigSyncEvents.java
@@ -1,0 +1,105 @@
+package jp.aquafactory.apprenticecodex.event;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.manaforceblade.ManaForceBladeConfigState;
+import jp.aquafactory.apprenticecodex.network.Networks;
+import jp.aquafactory.apprenticecodex.network.packet.SyncManaForceBladeConfigPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.event.config.ModConfigEvent;
+import net.minecraftforge.server.ServerLifecycleHooks;
+
+@Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID)
+public final class ManaForceBladeConfigSyncEvents {
+    private ManaForceBladeConfigSyncEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    private static void syncToPlayer(ServerPlayer player) {
+        Networks.sendToPlayer(player, createPacket());
+    }
+
+    private static void syncToAllPlayers() {
+        var server = ServerLifecycleHooks.getCurrentServer();
+        if (server == null) {
+            return;
+        }
+
+        var packet = createPacket();
+        for (var player : server.getPlayerList().getPlayers()) {
+            Networks.sendToPlayer(player, packet);
+        }
+    }
+
+    private static SyncManaForceBladeConfigPacket createPacket() {
+        return new SyncManaForceBladeConfigPacket(
+                ApprenticeCodexServerConfig.manaForceBladeImbueDamageMultiplierScale(),
+                ApprenticeCodexServerConfig.manaForceBladeAttackManaCostMultiplier(),
+                ApprenticeCodexServerConfig.manaForceBladeAttackManaSchoolMultiplierScale()
+        );
+    }
+
+    @Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
+    public static final class ModBusEvents {
+        private ModBusEvents() {
+        }
+
+        @SubscribeEvent
+        public static void onConfigLoading(ModConfigEvent.Loading event) {
+            syncIfServerConfig(event);
+        }
+
+        @SubscribeEvent
+        public static void onConfigReloading(ModConfigEvent.Reloading event) {
+            syncIfServerConfig(event);
+        }
+
+        private static void syncIfServerConfig(ModConfigEvent event) {
+            if (event.getConfig().getType() != ModConfig.Type.SERVER) {
+                return;
+            }
+            if (!ApprenticeCodex.MODID.equals(event.getConfig().getModId())) {
+                return;
+            }
+
+            syncToAllPlayers();
+        }
+    }
+
+    @Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID, value = Dist.CLIENT)
+    public static final class ClientEvents {
+        private ClientEvents() {
+        }
+
+        @SubscribeEvent
+        public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+            ManaForceBladeConfigState.reset();
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -294,6 +294,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void manaForceBladeConfigScalesDamageAndManaFormulas(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.manaForceBladeConfigScalesDamageAndManaFormulas(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void betterCombatSpellbreakerIsTwoHandedAndAmplifierHasOffhandSpellPower(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.betterCombatSpellbreakerIsTwoHandedAndAmplifierHasOffhandSpellPower(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -884,6 +884,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void apprenticeMageRobeKeepsExpectedAttributeBonuses(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.apprenticeMageRobeKeepsExpectedAttributeBonuses(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void enchantressRobeKeepsExpectedAttributeBonusesAndImbueSurface(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.enchantressRobeKeepsExpectedAttributeBonusesAndImbueSurface(helper);
     }
@@ -896,6 +901,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     @GameTest(template = TEMPLATE)
     public static void chromaticMagiaDressKeepsExpectedStatsAndImbueSurface(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.chromaticMagiaDressKeepsExpectedStatsAndImbueSurface(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void stealthRuneArmorKeepsExpectedAttributeBonusesAndImbueSurface(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.stealthRuneArmorKeepsExpectedAttributeBonusesAndImbueSurface(helper);
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -4792,11 +4792,75 @@ public final class ApprenticeCodexGameTestScenarios {
             item.hurtEnemy(stack, secondTarget, player);
 
             var expectedMana = 100.0F
-                    - jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveBladeAttackManaCost(stack);
+                    - jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveBladeAttackManaCost(player, stack);
             helper.assertTrue(Math.abs(magicData.getMana() - expectedMana) < 1.0e-4F,
                     "Mana Force Blade should spend attack mana once per tick even when multiple targets are hit"
                             + " expected=" + expectedMana
                             + " actual=" + magicData.getMana());
+        });
+    }
+
+    static void manaForceBladeConfigScalesDamageAndManaFormulas(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (jp.aquafactory.apprenticecodex.item.ManaForceBlade) ItemRegistry.MANA_FORCE_BLADE.get();
+            var stack = new ItemStack(item);
+            item.initializeSpellContainer(stack);
+            setSingleUnlockedSpell(helper, stack,
+                    io.redspace.ironsspellbooks.api.registry.SpellRegistry.GUIDING_BOLT_SPELL.get(), 1);
+
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "mana_force_blade_config_formula_test");
+            var spellPower = player.getAttribute(io.redspace.ironsspellbooks.api.registry.AttributeRegistry.SPELL_POWER.get());
+            helper.assertTrue(spellPower != null,
+                    "Mana Force Blade config formula test could not resolve spell power attribute");
+            if (spellPower != null) {
+                spellPower.setBaseValue(1.5D);
+            }
+
+            var imbuedSchool = jp.aquafactory.apprenticecodex.utility.MagicTools.getImbuedSpellSchool(stack);
+            helper.assertTrue(imbuedSchool != null,
+                    "Mana Force Blade config formula test could not resolve imbued school");
+            var schoolPowerAttribute = jp.aquafactory.apprenticecodex.utility.MagicTools.resolveSchoolPowerAttribute(imbuedSchool);
+            helper.assertTrue(schoolPowerAttribute != null,
+                    "Mana Force Blade config formula test could not resolve school power attribute");
+            var schoolPower = schoolPowerAttribute == null ? null : player.getAttribute(schoolPowerAttribute);
+            helper.assertTrue(schoolPower != null,
+                    "Mana Force Blade config formula test could not resolve player school power instance");
+            if (schoolPower != null) {
+                schoolPower.setBaseValue(1.2D);
+            }
+
+            var baseDamage = jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveBladeAttackDamage(stack);
+            var damageMultiplier = jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveDamageMultiplier(player, stack, 1.0F);
+            helper.assertTrue(Math.abs(damageMultiplier - 1.8F) < 1.0e-4F,
+                    "Mana Force Blade should multiply spell power and school power for imbued damage but got "
+                            + damageMultiplier);
+            helper.assertTrue(Math.abs(jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveDamageMultiplier(player, stack, 0.5F) - 0.9F) < 1.0e-4F,
+                    "Mana Force Blade imbue damage scale should directly scale the final school multiplier");
+            helper.assertTrue(Math.abs(jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveDamageMultiplier(player, stack, 0.0F) - 1.0F) < 1.0e-4F,
+                    "Mana Force Blade imbue damage scale 0 should disable imbued damage changes");
+
+            var fullManaCost = jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveBladeAttackManaCost(
+                    player, stack, 3.0F, 1.0F, 1.0F);
+            helper.assertTrue(Math.abs(fullManaCost - baseDamage * 3.0F * 1.8F) < 1.0e-4F,
+                    "Mana Force Blade full school mana scale should follow final imbued damage: " + fullManaCost);
+
+            var halfSchoolManaCost = jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveBladeAttackManaCost(
+                    player, stack, 3.0F, 0.5F, 1.0F);
+            helper.assertTrue(Math.abs(halfSchoolManaCost - baseDamage * 3.0F * 1.4F) < 1.0e-4F,
+                    "Mana Force Blade half school mana scale should only halve the school-derived increase: "
+                            + halfSchoolManaCost);
+
+            var noSchoolManaCost = jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveBladeAttackManaCost(
+                    player, stack, 3.0F, 0.0F, 1.0F);
+            helper.assertTrue(Math.abs(noSchoolManaCost - baseDamage * 3.0F) < 1.0e-4F,
+                    "Mana Force Blade school mana scale 0 should ignore school multiplier for mana cost: "
+                            + noSchoolManaCost);
+
+            var disabledManaCost = jp.aquafactory.apprenticecodex.item.ManaForceBlade.resolveBladeAttackManaCost(
+                    player, stack, 3.0F, 1.0F, 0.0F);
+            helper.assertTrue(disabledManaCost == 0.0F,
+                    "Mana Force Blade imbue damage scale 0 should also disable hit mana cost");
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -32,6 +32,7 @@ import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserSpellVa
 import jp.aquafactory.apprenticecodex.block.spellcasterworkbench.SpellcasterWorkbenchMenu;
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.enchantment.WisdomExperienceDropEvent;
 import jp.aquafactory.apprenticecodex.entity.spelldispenser.SpellDispenserAnchorEntity;
 import jp.aquafactory.apprenticecodex.compat.malum.MalumHauntedCompat;
@@ -8701,29 +8702,32 @@ public final class ApprenticeCodexGameTestScenarios {
             player.setItemSlot(EquipmentSlot.CHEST, chestplate);
             player.setItemSlot(EquipmentSlot.LEGS, leggings);
             player.setItemSlot(EquipmentSlot.FEET, boots);
+            var schoolSpellPowerBonusPerHistory =
+                    ApprenticeCodexServerConfig.chromaticMagiaDressSchoolSpellPowerBonusPerHistory();
 
             var longSpell = SpellRegistry.COMPOUND_PHIAL.get();
             for (int i = 0; i < 21; ++i) {
                 postSpellOnCast(player, longSpell, 1);
             }
-            assertSchoolSpellPowerBonus(helper, helmet, EquipmentSlot.HEAD, longSpell, 0.20D,
+            assertSchoolSpellPowerBonus(helper, helmet, EquipmentSlot.HEAD, longSpell,
+                    20.0D * schoolSpellPowerBonusPerHistory,
                     "Chromatic Magia Dress helmet should keep only the latest 20 LONG histories");
             assertSchoolSpellPowerBonus(helper, chestplate, EquipmentSlot.CHEST, longSpell, 0.0D,
                     "Chromatic Magia Dress chestplate should ignore non-recast LONG spells");
 
             var continuousSpell = SpellRegistry.FORCE_FIELD.get();
             postSpellOnCast(player, continuousSpell, 1);
-            assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, 0.01D,
+            assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, schoolSpellPowerBonusPerHistory,
                     "Chromatic Magia Dress leggings should record CONTINUOUS spells");
 
             var instantSpell = SpellRegistry.MANA_SLASH.get();
             postSpellOnCast(player, instantSpell, 1);
-            assertSchoolSpellPowerBonus(helper, boots, EquipmentSlot.FEET, instantSpell, 0.01D,
+            assertSchoolSpellPowerBonus(helper, boots, EquipmentSlot.FEET, instantSpell, schoolSpellPowerBonusPerHistory,
                     "Chromatic Magia Dress boots should record INSTANT spells");
 
             var recastSpell = SpellRegistry.ARCHER_MULTIPLE.get();
             postSpellOnCast(player, recastSpell, 1);
-            assertSchoolSpellPowerBonus(helper, chestplate, EquipmentSlot.CHEST, recastSpell, 0.01D,
+            assertSchoolSpellPowerBonus(helper, chestplate, EquipmentSlot.CHEST, recastSpell, schoolSpellPowerBonusPerHistory,
                     "Chromatic Magia Dress chestplate should record initial recast-capable casts");
 
             magicData.getPlayerRecasts().addRecast(new RecastInstance(
@@ -8735,7 +8739,7 @@ public final class ApprenticeCodexGameTestScenarios {
                     null
             ), magicData);
             postSpellOnCast(player, recastSpell, 1);
-            assertSchoolSpellPowerBonus(helper, chestplate, EquipmentSlot.CHEST, recastSpell, 0.01D,
+            assertSchoolSpellPowerBonus(helper, chestplate, EquipmentSlot.CHEST, recastSpell, schoolSpellPowerBonusPerHistory,
                     "Chromatic Magia Dress chestplate should ignore casts while the same spell is in Recast");
         });
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -95,6 +95,7 @@ import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconTargetList;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconTargetManager;
 import jp.aquafactory.apprenticecodex.spell.tinylumberjack.TinyLumberjackJob;
 import jp.aquafactory.apprenticecodex.spell.worldflatter.WorldFlatterDrillEntity;
+import jp.aquafactory.apprenticecodex.item.armor.ApprenticeMageRobeItem;
 import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressItem;
 import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressStats;
 import jp.aquafactory.apprenticecodex.item.armor.EnchantressRobeItem;
@@ -8566,11 +8567,45 @@ public final class ApprenticeCodexGameTestScenarios {
             );
         });
     }
+    static void apprenticeMageRobeKeepsExpectedAttributeBonuses(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var maxManaAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.MAX_MANA.get();
+            var spellPowerAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.SPELL_POWER.get();
+            var expectedSpellPower = ApprenticeCodexServerConfig.apprenticeMageRobeSpellPowerBonusPerPiece();
+            var pieces = Map.of(
+                    ArmorItem.Type.HELMET, (ApprenticeMageRobeItem) ItemRegistry.APPRENTICE_MAGE_SCARF.get(),
+                    ArmorItem.Type.CHESTPLATE, (ApprenticeMageRobeItem) ItemRegistry.APPRENTICE_MAGE_TORSO.get(),
+                    ArmorItem.Type.LEGGINGS, (ApprenticeMageRobeItem) ItemRegistry.APPRENTICE_MAGE_LEGGINGS.get(),
+                    ArmorItem.Type.BOOTS, (ApprenticeMageRobeItem) ItemRegistry.APPRENTICE_MAGE_BOOTS.get()
+            );
+
+            for (var entry : pieces.entrySet()) {
+                var armorType = entry.getKey();
+                var item = entry.getValue();
+                var stack = new ItemStack(item);
+                item.initializeSpellContainer(stack);
+
+                var modifiers = item.getAttributeModifiers(armorType.getSlot(), stack);
+                var maxManaBonus = sumModifierAmount(modifiers.get(maxManaAttribute), AttributeModifier.Operation.ADDITION);
+                helper.assertTrue(Math.abs(maxManaBonus - 50.0D) < 1.0e-9D,
+                        "Apprentice Mage Robe " + armorType + " max mana regression: " + describeModifiers(modifiers));
+
+                var spellPowerBonus = sumModifierAmount(modifiers.get(spellPowerAttribute), AttributeModifier.Operation.MULTIPLY_BASE);
+                helper.assertTrue(Math.abs(spellPowerBonus - expectedSpellPower) < 1.0e-9D,
+                        "Apprentice Mage Robe " + armorType + " spell power config regression: " + describeModifiers(modifiers));
+
+                helper.assertTrue(ISpellContainer.isSpellContainer(stack) == (armorType == ArmorItem.Type.CHESTPLATE),
+                        "Apprentice Mage Robe " + armorType + " imbue surface regression");
+            }
+        });
+    }
+
     static void enchantressRobeKeepsExpectedAttributeBonusesAndImbueSurface(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var maxManaAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.MAX_MANA.get();
             var spellPowerAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.SPELL_POWER.get();
             var lightningSpellPowerAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.LIGHTNING_SPELL_POWER.get();
+            var expectedSpellPower = ApprenticeCodexServerConfig.enchantressRobeSpellPowerBonusPerPiece();
             var pieces = Map.of(
                     ArmorItem.Type.HELMET, (EnchantressRobeItem) ItemRegistry.ENCHANTRESS_HAT.get(),
                     ArmorItem.Type.CHESTPLATE, (EnchantressRobeItem) ItemRegistry.ENCHANTRESS_ROBE.get(),
@@ -8590,8 +8625,8 @@ public final class ApprenticeCodexGameTestScenarios {
                         "Enchantress Robe " + armorType + " max mana regression: " + describeModifiers(modifiers));
 
                 var spellPowerBonus = sumModifierAmount(modifiers.get(spellPowerAttribute), AttributeModifier.Operation.MULTIPLY_BASE);
-                helper.assertTrue(Math.abs(spellPowerBonus - 0.10D) < 1.0e-9D,
-                        "Enchantress Robe " + armorType + " spell power regression: " + describeModifiers(modifiers));
+                helper.assertTrue(Math.abs(spellPowerBonus - expectedSpellPower) < 1.0e-9D,
+                        "Enchantress Robe " + armorType + " spell power config regression: " + describeModifiers(modifiers));
 
                 helper.assertTrue(ISpellContainer.isSpellContainer(stack) == item.hasImbueSlot(),
                         "Enchantress Robe " + armorType + " imbue surface regression: hasImbueSlot="
@@ -8627,8 +8662,9 @@ public final class ApprenticeCodexGameTestScenarios {
                     modifiers.get(io.redspace.ironsspellbooks.api.registry.AttributeRegistry.SPELL_POWER.get()),
                     AttributeModifier.Operation.MULTIPLY_BASE
             );
-            helper.assertTrue(Math.abs(globalSpellPowerBonus - 0.10D) < 1.0e-9D,
-                    "Enchantress Robe chestplate should keep +0.10 spell power after imbue: " + describeModifiers(modifiers));
+            var expectedGlobalSpellPower = ApprenticeCodexServerConfig.enchantressRobeSpellPowerBonusPerPiece();
+            helper.assertTrue(Math.abs(globalSpellPowerBonus - expectedGlobalSpellPower) < 1.0e-9D,
+                    "Enchantress Robe chestplate should keep configured spell power after imbue: " + describeModifiers(modifiers));
 
             var imbuedSchoolSpellPowerBonus = sumModifierAmount(
                     modifiers.get(imbuedSpellPowerAttribute),
@@ -8642,6 +8678,7 @@ public final class ApprenticeCodexGameTestScenarios {
         helper.succeedIf(() -> {
             var maxManaAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.MAX_MANA.get();
             var spellPowerAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.SPELL_POWER.get();
+            var expectedSpellPower = ApprenticeCodexServerConfig.chromaticMagiaDressSpellPowerBonusPerPiece();
             var pieces = Map.of(
                     ArmorItem.Type.HELMET, (ChromaticMagiaDressItem) ItemRegistry.CHROMATIC_MAGIA_DRESS_HAT.get(),
                     ArmorItem.Type.CHESTPLATE, (ChromaticMagiaDressItem) ItemRegistry.CHROMATIC_MAGIA_DRESS_COAT.get(),
@@ -8673,8 +8710,8 @@ public final class ApprenticeCodexGameTestScenarios {
                         "Chromatic Magia Dress " + armorType + " max mana regression: " + describeModifiers(modifiers));
 
                 var spellPowerBonus = sumModifierAmount(modifiers.get(spellPowerAttribute), AttributeModifier.Operation.MULTIPLY_BASE);
-                helper.assertTrue(Math.abs(spellPowerBonus - 0.15D) < 1.0e-9D,
-                        "Chromatic Magia Dress " + armorType + " spell power regression: " + describeModifiers(modifiers));
+                helper.assertTrue(Math.abs(spellPowerBonus - expectedSpellPower) < 1.0e-9D,
+                        "Chromatic Magia Dress " + armorType + " spell power config regression: " + describeModifiers(modifiers));
 
                 helper.assertTrue(ISpellContainer.isSpellContainer(stack) == item.hasImbueSlot(),
                         "Chromatic Magia Dress " + armorType + " imbue surface regression");
@@ -8688,6 +8725,46 @@ public final class ApprenticeCodexGameTestScenarios {
             }
         });
     }
+    static void stealthRuneArmorKeepsExpectedAttributeBonusesAndImbueSurface(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var maxManaAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.MAX_MANA.get();
+            var spellPowerAttribute = io.redspace.ironsspellbooks.api.registry.AttributeRegistry.SPELL_POWER.get();
+            var expectedSpellPower = ApprenticeCodexServerConfig.stealthRuneArmorSpellPowerBonusPerPiece();
+            var pieces = Map.of(
+                    ArmorItem.Type.HELMET, (StealthRuneArmorItem) ItemRegistry.STEALTH_RUNE_ARMOR_HEAD.get(),
+                    ArmorItem.Type.CHESTPLATE, (StealthRuneArmorItem) ItemRegistry.STEALTH_RUNE_ARMOR_BODY.get(),
+                    ArmorItem.Type.LEGGINGS, (StealthRuneArmorItem) ItemRegistry.STEALTH_RUNE_ARMOR_LEG.get(),
+                    ArmorItem.Type.BOOTS, (StealthRuneArmorItem) ItemRegistry.STEALTH_RUNE_ARMOR_FOOT.get()
+            );
+
+            for (var entry : pieces.entrySet()) {
+                var armorType = entry.getKey();
+                var item = entry.getValue();
+                var stack = new ItemStack(item);
+                item.initializeSpellContainer(stack);
+
+                var modifiers = item.getAttributeModifiers(armorType.getSlot(), stack);
+                var maxManaBonus = sumModifierAmount(modifiers.get(maxManaAttribute), AttributeModifier.Operation.ADDITION);
+                helper.assertTrue(Math.abs(maxManaBonus - 50.0D) < 1.0e-9D,
+                        "Stealth Rune Armor " + armorType + " max mana regression: " + describeModifiers(modifiers));
+
+                var spellPowerBonus = sumModifierAmount(modifiers.get(spellPowerAttribute), AttributeModifier.Operation.MULTIPLY_BASE);
+                helper.assertTrue(Math.abs(spellPowerBonus - expectedSpellPower) < 1.0e-9D,
+                        "Stealth Rune Armor " + armorType + " spell power config regression: " + describeModifiers(modifiers));
+
+                helper.assertTrue(ISpellContainer.isSpellContainer(stack) == item.hasImbueSlot(),
+                        "Stealth Rune Armor " + armorType + " imbue surface regression");
+
+                var tooltipLines = new ArrayList<Component>();
+                item.appendHoverText(stack, helper.getLevel(), tooltipLines, TooltipFlag.Default.NORMAL);
+                helper.assertTrue(tooltipLines.stream().anyMatch(line ->
+                                line.getContents() instanceof TranslatableContents contents
+                                        && ("item." + ApprenticeCodex.MODID + ".stealth_rune_armor.desc").equals(contents.getKey())),
+                        "Stealth Rune Armor " + armorType + " should show its lang desc key");
+            }
+        });
+    }
+
     static void chromaticMagiaDressRecordsCastHistoryByArmorTypeAndIgnoresRecasts(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "chromatic_magia_dress_history_test");

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
@@ -10,6 +10,8 @@ import io.redspace.ironsspellbooks.item.SpellSlotUpgradeItem;
 import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import io.redspace.ironsspellbooks.setup.PacketDistributor;
 import jp.aquafactory.apprenticecodex.compat.malum.MalumHauntedCompat;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.manaforceblade.ManaForceBladeConfigState;
 import jp.aquafactory.apprenticecodex.renderer.item.ManaForceBladeRenderer;
 import jp.aquafactory.apprenticecodex.utility.MagicTools;
 import net.minecraft.ChatFormatting;
@@ -151,7 +153,7 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
 
     @Override
     public boolean hurtEnemy(@NotNull ItemStack stack, @NotNull LivingEntity target, @NotNull LivingEntity attacker) {
-        if (hasImbuedSpell(stack) && !attacker.level().isClientSide && attacker instanceof Player player) {
+        if (shouldSpendAttackMana(stack) && !attacker.level().isClientSide && attacker instanceof Player player) {
             trySpendAttackManaOncePerTick(player, stack);
         }
 
@@ -164,14 +166,28 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
         super.appendHoverText(stack, level, lines, flag);
 
         lines.add(Component.translatable(resolveDescriptionTranslationKey()).withStyle(ChatFormatting.GRAY));
-        if (hasImbuedSpell(stack)) {
-            lines.add(Component.translatable(
-                    "item.apprenticecodex.mana_force_blade.desc.imbue_help",
-                    Mth.ceil(resolveBladeAttackManaCost(stack))
-            ).withStyle(ChatFormatting.AQUA));
-        } else {
+        if (!isImbueDamageChangeEnabled(ManaForceBladeConfigState.imbueDamageMultiplierScale())) {
+            return;
+        }
+
+        if (!hasImbuedSpell(stack)) {
             lines.add(Component.translatable("item.apprenticecodex.mana_force_blade.desc.no_imbue")
                     .withStyle(ChatFormatting.GRAY));
+            return;
+        }
+
+        var manaCost = resolveBladeAttackManaCost(
+                null,
+                stack,
+                ManaForceBladeConfigState.attackManaCostMultiplier(),
+                ManaForceBladeConfigState.attackManaSchoolMultiplierScale(),
+                ManaForceBladeConfigState.imbueDamageMultiplierScale()
+        );
+        if (manaCost > 0.0F) {
+            lines.add(Component.translatable(
+                    "item.apprenticecodex.mana_force_blade.desc.imbue_help",
+                    Mth.ceil(manaCost)
+            ).withStyle(ChatFormatting.AQUA));
         }
     }
 
@@ -282,7 +298,36 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
     }
 
     public static float resolveBladeAttackManaCost(ItemStack stack) {
-        return resolveBladeAttackDamage(stack) * 3.0F;
+        return resolveBladeAttackManaCost(null, stack);
+    }
+
+    public static float resolveBladeAttackManaCost(@Nullable LivingEntity attacker, ItemStack stack) {
+        return resolveBladeAttackManaCost(
+                attacker,
+                stack,
+                ApprenticeCodexServerConfig.manaForceBladeAttackManaCostMultiplier(),
+                ApprenticeCodexServerConfig.manaForceBladeAttackManaSchoolMultiplierScale(),
+                ApprenticeCodexServerConfig.manaForceBladeImbueDamageMultiplierScale()
+        );
+    }
+
+    public static float resolveBladeAttackManaCost(
+            @Nullable LivingEntity attacker,
+            ItemStack stack,
+            float attackManaCostMultiplier,
+            float attackManaSchoolMultiplierScale,
+            float imbueDamageMultiplierScale
+    ) {
+        if (attackManaCostMultiplier <= 0.0F || !isImbueDamageChangeEnabled(imbueDamageMultiplierScale)
+                || !hasImbuedSpell(stack)) {
+            return 0.0F;
+        }
+
+        var damageMultiplier = attacker == null
+                ? 1.0F
+                : resolveDamageMultiplier(attacker, stack, imbueDamageMultiplierScale);
+        var schoolManaFactor = 1.0F + (damageMultiplier - 1.0F) * attackManaSchoolMultiplierScale;
+        return resolveBladeAttackDamage(stack) * attackManaCostMultiplier * Math.max(0.0F, schoolManaFactor);
     }
 
     public static boolean hasImbuedSpell(ItemStack stack) {
@@ -293,7 +338,23 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
         return resolveBladeAttackDamage(stack) * resolveDamageMultiplier(attacker, stack);
     }
 
+    public static float resolveFinalAttackDamage(LivingEntity attacker, ItemStack stack, float imbueDamageMultiplierScale) {
+        return resolveBladeAttackDamage(stack) * resolveDamageMultiplier(attacker, stack, imbueDamageMultiplierScale);
+    }
+
     public static float resolveDamageMultiplier(LivingEntity attacker, ItemStack stack) {
+        return resolveDamageMultiplier(
+                attacker,
+                stack,
+                ApprenticeCodexServerConfig.manaForceBladeImbueDamageMultiplierScale()
+        );
+    }
+
+    public static float resolveDamageMultiplier(LivingEntity attacker, ItemStack stack, float imbueDamageMultiplierScale) {
+        if (!isImbueDamageChangeEnabled(imbueDamageMultiplierScale)) {
+            return 1.0F;
+        }
+
         var imbuedSchool = MagicTools.getImbuedSpellSchool(stack);
         if (imbuedSchool == null) {
             return 1.0F;
@@ -302,7 +363,7 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
         var spellPower = (float) attacker.getAttributeValue(AttributeRegistry.SPELL_POWER.get());
         Attribute schoolPowerAttribute = MagicTools.resolveSchoolPowerAttribute(imbuedSchool);
         var schoolSpellPower = schoolPowerAttribute == null ? 1.0F : (float) attacker.getAttributeValue(schoolPowerAttribute);
-        return spellPower * schoolSpellPower;
+        return spellPower * schoolSpellPower * imbueDamageMultiplierScale;
     }
 
     public static void spendMana(Player player, float manaCost) {
@@ -330,7 +391,17 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
 
         // BetterCombat は複数対象を同一 tick 内で個別に攻撃処理するため、攻撃 1 回分の消費に揃える。
         tag.putLong(ATTACK_MANA_SPENT_TICK_TAG, now);
-        spendMana(player, resolveBladeAttackManaCost(stack));
+        spendMana(player, resolveBladeAttackManaCost(player, stack));
+    }
+
+    public static boolean isImbueDamageChangeEnabled(float imbueDamageMultiplierScale) {
+        return imbueDamageMultiplierScale > 0.0F;
+    }
+
+    private static boolean shouldSpendAttackMana(ItemStack stack) {
+        return hasImbuedSpell(stack)
+                && isImbueDamageChangeEnabled(ApprenticeCodexServerConfig.manaForceBladeImbueDamageMultiplierScale())
+                && ApprenticeCodexServerConfig.manaForceBladeAttackManaCostMultiplier() > 0.0F;
     }
 
     private static Multimap<Attribute, AttributeModifier> buildMainhandModifiers() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ApprenticeMageRobeItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ApprenticeMageRobeItem.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import io.redspace.ironsspellbooks.api.spells.IPresetSpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import net.minecraft.client.model.HumanoidModel;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
@@ -70,13 +71,18 @@ public class ApprenticeMageRobeItem extends ArmorItem implements GeoItem, IPrese
     @Override
     public Multimap<Attribute, AttributeModifier> getAttributeModifiers(EquipmentSlot slot, ItemStack stack) {
         var baseModifiers = super.getAttributeModifiers(slot, stack);
-        if (slot != armorType.getSlot() || robeAttributeModifiers.isEmpty()) {
+        if (slot != armorType.getSlot()) {
             return baseModifiers;
         }
 
         var builder = ImmutableMultimap.<Attribute, AttributeModifier>builder();
         builder.putAll(baseModifiers);
         builder.putAll(robeAttributeModifiers);
+        ApprenticeMageRobeStats.addSpellPowerModifier(
+                builder,
+                armorType,
+                ApprenticeCodexServerConfig.apprenticeMageRobeSpellPowerBonusPerPiece()
+        );
         return builder.build();
     }
 
@@ -86,7 +92,7 @@ public class ApprenticeMageRobeItem extends ArmorItem implements GeoItem, IPrese
     }
 
     @Override
-    public boolean isValidRepairItem(ItemStack toRepair, ItemStack repair) {
+    public boolean isValidRepairItem(@NotNull ItemStack toRepair, @NotNull ItemStack repair) {
         return ApprenticeMageRobeStats.isRepairIngredient(repair) || super.isValidRepairItem(toRepair, repair);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ApprenticeMageRobeStats.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ApprenticeMageRobeStats.java
@@ -50,23 +50,19 @@ public final class ApprenticeMageRobeStats {
     private static final Map<ArmorItem.Type, List<AttributeBonus>> ATTRIBUTE_BONUSES = Map.of(
             ArmorItem.Type.HELMET,
             List.of(
-                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana"),
-                    new AttributeBonus(AttributeRegistry.SPELL_POWER, 0.05D, AttributeModifier.Operation.MULTIPLY_BASE, "spell_power")
+                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana")
             ),
             ArmorItem.Type.CHESTPLATE,
             List.of(
-                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana"),
-                    new AttributeBonus(AttributeRegistry.SPELL_POWER, 0.05D, AttributeModifier.Operation.MULTIPLY_BASE, "spell_power")
+                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana")
             ),
             ArmorItem.Type.LEGGINGS,
             List.of(
-                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana"),
-                    new AttributeBonus(AttributeRegistry.SPELL_POWER, 0.05D, AttributeModifier.Operation.MULTIPLY_BASE, "spell_power")
+                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana")
             ),
             ArmorItem.Type.BOOTS,
             List.of(
-                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana"),
-                    new AttributeBonus(AttributeRegistry.SPELL_POWER, 0.05D, AttributeModifier.Operation.MULTIPLY_BASE, "spell_power")
+                    new AttributeBonus(AttributeRegistry.MAX_MANA, 50, AttributeModifier.Operation.ADDITION, "max_mana")
             )
     );
 
@@ -104,6 +100,20 @@ public final class ApprenticeMageRobeStats {
             );
         }
         return builder.build();
+    }
+
+    static void addSpellPowerModifier(
+            ImmutableMultimap.Builder<Attribute, AttributeModifier> builder,
+            ArmorItem.Type type,
+            double amount
+    ) {
+        MagicArmorAttributeHelper.addModifier(
+                builder,
+                AttributeRegistry.SPELL_POWER.get(),
+                amount,
+                AttributeModifier.Operation.MULTIPLY_BASE,
+                "apprenticecodex.apprentice_mage_robe." + typeToken(type) + ".spell_power.1"
+        );
     }
 
     private static int durabilityFor(ArmorItem.Type type) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
@@ -6,6 +6,7 @@ import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import io.redspace.ironsspellbooks.api.spells.IPresetSpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.registry.EnchantmentRegistry;
 import jp.aquafactory.apprenticecodex.renderer.armor.ChromaticMagiaDressRenderer;
 import jp.aquafactory.apprenticecodex.utility.MagicTools;
@@ -41,7 +42,6 @@ import java.util.function.Consumer;
 public class ChromaticMagiaDressItem extends ArmorItem implements GeoItem, IPresetSpellContainer {
     private static final ResourceLocation ARMOR_TEXTURE =
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "textures/geo/chromatic_magia_dress.png");
-    private static final double SCHOOL_SPELL_POWER_BONUS_PER_HISTORY = 0.01D;
 
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
     private final Type armorType;
@@ -186,12 +186,14 @@ public class ChromaticMagiaDressItem extends ArmorItem implements GeoItem, IPres
             ItemStack stack
     ) {
         var schools = ChromaticMagiaDressHistory.readSchools(stack);
+        var schoolSpellPowerBonusPerHistory =
+                ApprenticeCodexServerConfig.chromaticMagiaDressSchoolSpellPowerBonusPerHistory();
         for (int i = 0; i < schools.size(); ++i) {
             var schoolPowerAttribute = MagicTools.resolveSchoolPowerAttribute(schools.get(i));
             MagicArmorAttributeHelper.addModifier(
                     builder,
                     schoolPowerAttribute,
-                    SCHOOL_SPELL_POWER_BONUS_PER_HISTORY,
+                    schoolSpellPowerBonusPerHistory,
                     AttributeModifier.Operation.MULTIPLY_BASE,
                     "apprenticecodex.chromatic_magia_dress."
                             + ChromaticMagiaDressStats.typeToken(armorType)

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
@@ -141,6 +141,11 @@ public class ChromaticMagiaDressItem extends ArmorItem implements GeoItem, IPres
 
         var extraBuilder = ImmutableMultimap.<Attribute, AttributeModifier>builder();
         extraBuilder.putAll(armorAttributeModifiers);
+        ChromaticMagiaDressStats.addSpellPowerModifier(
+                extraBuilder,
+                armorType,
+                ApprenticeCodexServerConfig.chromaticMagiaDressSpellPowerBonusPerPiece()
+        );
         addHistorySpellPowerModifiers(extraBuilder, stack);
 
         var mergedExtraModifiers = MagicArmorAttributeHelper.mergeTooltipEquivalentModifiers(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressStats.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressStats.java
@@ -41,8 +41,7 @@ public final class ChromaticMagiaDressStats {
     );
 
     private static final List<AttributeBonus> COMMON_ATTRIBUTE_BONUSES = List.of(
-            new AttributeBonus(AttributeRegistry.MAX_MANA, 125.0D, AttributeModifier.Operation.ADDITION, "max_mana"),
-            new AttributeBonus(AttributeRegistry.SPELL_POWER, 0.15D, AttributeModifier.Operation.MULTIPLY_BASE, "spell_power")
+            new AttributeBonus(AttributeRegistry.MAX_MANA, 125.0D, AttributeModifier.Operation.ADDITION, "max_mana")
     );
 
     private ChromaticMagiaDressStats() {
@@ -74,6 +73,20 @@ public final class ChromaticMagiaDressStats {
             );
         }
         return builder.build();
+    }
+
+    static void addSpellPowerModifier(
+            ImmutableMultimap.Builder<Attribute, AttributeModifier> builder,
+            ArmorItem.Type type,
+            double amount
+    ) {
+        MagicArmorAttributeHelper.addModifier(
+                builder,
+                AttributeRegistry.SPELL_POWER.get(),
+                amount,
+                AttributeModifier.Operation.MULTIPLY_BASE,
+                "apprenticecodex.chromatic_magia_dress." + typeToken(type) + ".spell_power.1"
+        );
     }
 
     static String typeToken(ArmorItem.Type type) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/EnchantressRobeItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/EnchantressRobeItem.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Multimap;
 import io.redspace.ironsspellbooks.api.spells.IPresetSpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.registry.EnchantmentRegistry;
 import jp.aquafactory.apprenticecodex.renderer.armor.EnchantressRobeRenderer;
 import jp.aquafactory.apprenticecodex.utility.MagicTools;
@@ -118,13 +119,18 @@ public class EnchantressRobeItem extends ArmorItem implements GeoItem, IPresetSp
     @Override
     public Multimap<Attribute, AttributeModifier> getAttributeModifiers(EquipmentSlot slot, ItemStack stack) {
         var baseModifiers = super.getAttributeModifiers(slot, stack);
-        if (slot != armorType.getSlot() || robeAttributeModifiers.isEmpty()) {
+        if (slot != armorType.getSlot()) {
             return baseModifiers;
         }
 
         var builder = ImmutableMultimap.<Attribute, AttributeModifier>builder();
         builder.putAll(baseModifiers);
         builder.putAll(robeAttributeModifiers);
+        EnchantressRobeStats.addSpellPowerModifier(
+                builder,
+                armorType,
+                ApprenticeCodexServerConfig.enchantressRobeSpellPowerBonusPerPiece()
+        );
         addImbuedSchoolSpellPowerModifier(builder, stack);
         return builder.build();
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/EnchantressRobeStats.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/EnchantressRobeStats.java
@@ -51,7 +51,6 @@ public final class EnchantressRobeStats {
 
     private static final List<AttributeBonus> COMMON_ATTRIBUTE_BONUSES = List.of(
             new AttributeBonus(AttributeRegistry.MAX_MANA, MAX_MANA_BONUS_PER_PIECE, AttributeModifier.Operation.ADDITION, "max_mana"),
-            new AttributeBonus(AttributeRegistry.SPELL_POWER, 0.10D, AttributeModifier.Operation.MULTIPLY_BASE, "spell_power"),
             new AttributeBonus(
                     ApprenticeAttributeRegistry.MAX_ENCHANTMENT_TABLE_LEVEL,
                     ENCHANTING_TABLE_LEVEL_BONUS_PER_PIECE,
@@ -101,6 +100,20 @@ public final class EnchantressRobeStats {
             );
         }
         return builder.build();
+    }
+
+    static void addSpellPowerModifier(
+            ImmutableMultimap.Builder<Attribute, AttributeModifier> builder,
+            ArmorItem.Type type,
+            double amount
+    ) {
+        MagicArmorAttributeHelper.addModifier(
+                builder,
+                AttributeRegistry.SPELL_POWER.get(),
+                amount,
+                AttributeModifier.Operation.MULTIPLY_BASE,
+                "apprenticecodex.enchantress_robe." + typeToken(type) + ".spell_power.1"
+        );
     }
 
     private static int durabilityFor(ArmorItem.Type type) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/StealthRuneArmorItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/StealthRuneArmorItem.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Multimap;
 import io.redspace.ironsspellbooks.api.spells.IPresetSpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.registry.EnchantmentRegistry;
 import jp.aquafactory.apprenticecodex.renderer.armor.StealthRuneArmorRenderer;
 import net.minecraft.ChatFormatting;
@@ -136,13 +137,18 @@ public class StealthRuneArmorItem extends ArmorItem implements GeoItem, IPresetS
     @Override
     public Multimap<Attribute, AttributeModifier> getAttributeModifiers(EquipmentSlot slot, ItemStack stack) {
         var baseModifiers = super.getAttributeModifiers(slot, stack);
-        if (slot != armorType.getSlot() || armorAttributeModifiers.isEmpty()) {
+        if (slot != armorType.getSlot()) {
             return baseModifiers;
         }
 
         var builder = ImmutableMultimap.<Attribute, AttributeModifier>builder();
         builder.putAll(baseModifiers);
         builder.putAll(armorAttributeModifiers);
+        StealthRuneArmorStats.addSpellPowerModifier(
+                builder,
+                armorType,
+                ApprenticeCodexServerConfig.stealthRuneArmorSpellPowerBonusPerPiece()
+        );
         return builder.build();
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/StealthRuneArmorStats.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/StealthRuneArmorStats.java
@@ -44,8 +44,7 @@ public final class StealthRuneArmorStats {
     );
 
     private static final List<AttributeBonus> COMMON_ATTRIBUTE_BONUSES = List.of(
-            new AttributeBonus(AttributeRegistry.MAX_MANA, 50.0D, AttributeModifier.Operation.ADDITION, "max_mana"),
-            new AttributeBonus(AttributeRegistry.SPELL_POWER, 0.05D, AttributeModifier.Operation.MULTIPLY_BASE, "spell_power")
+            new AttributeBonus(AttributeRegistry.MAX_MANA, 50.0D, AttributeModifier.Operation.ADDITION, "max_mana")
     );
 
     private static final Map<ArmorItem.Type, List<AttributeBonus>> ATTRIBUTE_BONUSES = Map.of(
@@ -85,6 +84,20 @@ public final class StealthRuneArmorStats {
             );
         }
         return builder.build();
+    }
+
+    static void addSpellPowerModifier(
+            ImmutableMultimap.Builder<Attribute, AttributeModifier> builder,
+            ArmorItem.Type type,
+            double amount
+    ) {
+        MagicArmorAttributeHelper.addModifier(
+                builder,
+                AttributeRegistry.SPELL_POWER.get(),
+                amount,
+                AttributeModifier.Operation.MULTIPLY_BASE,
+                "apprenticecodex.stealth_rune_armor." + typeToken(type) + ".spell_power.1"
+        );
     }
 
     private static int durabilityFor(ArmorItem.Type type) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeConfigState.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeConfigState.java
@@ -1,0 +1,44 @@
+package jp.aquafactory.apprenticecodex.item.manaforceblade;
+
+public final class ManaForceBladeConfigState {
+    public static final float DEFAULT_IMBUE_DAMAGE_MULTIPLIER_SCALE = 1.0F;
+    public static final float DEFAULT_ATTACK_MANA_COST_MULTIPLIER = 3.0F;
+    public static final float DEFAULT_ATTACK_MANA_SCHOOL_MULTIPLIER_SCALE = 1.0F;
+
+    private static float imbueDamageMultiplierScale = DEFAULT_IMBUE_DAMAGE_MULTIPLIER_SCALE;
+    private static float attackManaCostMultiplier = DEFAULT_ATTACK_MANA_COST_MULTIPLIER;
+    private static float attackManaSchoolMultiplierScale = DEFAULT_ATTACK_MANA_SCHOOL_MULTIPLIER_SCALE;
+
+    private ManaForceBladeConfigState() {
+    }
+
+    public static float imbueDamageMultiplierScale() {
+        return imbueDamageMultiplierScale;
+    }
+
+    public static float attackManaCostMultiplier() {
+        return attackManaCostMultiplier;
+    }
+
+    public static float attackManaSchoolMultiplierScale() {
+        return attackManaSchoolMultiplierScale;
+    }
+
+    public static void set(
+            float imbueDamageMultiplierScale,
+            float attackManaCostMultiplier,
+            float attackManaSchoolMultiplierScale
+    ) {
+        ManaForceBladeConfigState.imbueDamageMultiplierScale = imbueDamageMultiplierScale;
+        ManaForceBladeConfigState.attackManaCostMultiplier = attackManaCostMultiplier;
+        ManaForceBladeConfigState.attackManaSchoolMultiplierScale = attackManaSchoolMultiplierScale;
+    }
+
+    public static void reset() {
+        set(
+                DEFAULT_IMBUE_DAMAGE_MULTIPLIER_SCALE,
+                DEFAULT_ATTACK_MANA_COST_MULTIPLIER,
+                DEFAULT_ATTACK_MANA_SCHOOL_MULTIPLIER_SCALE
+        );
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeEvents.java
@@ -4,6 +4,7 @@ import io.redspace.ironsspellbooks.api.events.ChangeManaEvent;
 import io.redspace.ironsspellbooks.api.util.Utils;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightManaForceBladeCompat;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.ManaForceBlade;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.CommonComponents;
@@ -29,6 +30,7 @@ public final class ManaForceBladeEvents {
     private static final String EPICFIGHT_MOD_ID = "epicfight";
     private static final String MAIN_HAND_MODIFIER_KEY = "item.modifiers.mainhand";
     private static final String ATTACK_DAMAGE_MODIFIER_KEY = "attribute.modifier.equals.0";
+    private static final String IMBUE_HELP_KEY = "item.apprenticecodex.mana_force_blade.desc.imbue_help";
 
     private ManaForceBladeEvents() {
     }
@@ -93,13 +95,15 @@ public final class ManaForceBladeEvents {
         }
 
         if (ModList.get().isLoaded(EPICFIGHT_MOD_ID)) {
-            if (player instanceof ServerPlayer serverPlayer && EpicFightManaForceBladeCompat.isGuarding(serverPlayer)) {
+            if (ApprenticeCodexServerConfig.manaForceBladeDisableManaRecoveryWhileGuarding()
+                    && player instanceof ServerPlayer serverPlayer && EpicFightManaForceBladeCompat.isGuarding(serverPlayer)) {
                 event.setNewMana(event.getOldMana());
             }
             return;
         }
 
-        if (player.isUsingItem() && ManaForceBlade.isManaForceBlade(player.getUseItem())) {
+        if (ApprenticeCodexServerConfig.manaForceBladeDisableManaRecoveryWhileGuarding()
+                && player.isUsingItem() && ManaForceBlade.isManaForceBlade(player.getUseItem())) {
             // Iron's 1.20.1 の ChangeManaEvent は回復源を区別しないため、構え中の正の変化をまとめて抑制する。
             event.setNewMana(event.getOldMana());
         }
@@ -112,8 +116,13 @@ public final class ManaForceBladeEvents {
             return;
         }
 
-        var damage = ManaForceBlade.resolveFinalAttackDamage(event.getEntity(), stack);
+        var damage = ManaForceBlade.resolveFinalAttackDamage(
+                event.getEntity(),
+                stack,
+                ManaForceBladeConfigState.imbueDamageMultiplierScale()
+        );
         replaceMainHandAttackDamageTooltip(event.getToolTip(), damage);
+        replaceAttackManaCostTooltip(event.getToolTip(), event.getEntity(), stack);
     }
 
     private static void replaceMainHandAttackDamageTooltip(List<Component> tooltip, float damage) {
@@ -170,6 +179,30 @@ public final class ManaForceBladeEvents {
                 Utils.stringTruncation(damage, 2),
                 Component.translatable(Attributes.ATTACK_DAMAGE.getDescriptionId())
         )).withStyle(ChatFormatting.DARK_GREEN);
+    }
+
+    private static void replaceAttackManaCostTooltip(List<Component> tooltip, LivingEntity entity, net.minecraft.world.item.ItemStack stack) {
+        var manaCost = ManaForceBlade.resolveBladeAttackManaCost(
+                entity,
+                stack,
+                ManaForceBladeConfigState.attackManaCostMultiplier(),
+                ManaForceBladeConfigState.attackManaSchoolMultiplierScale(),
+                ManaForceBladeConfigState.imbueDamageMultiplierScale()
+        );
+        for (var i = 0; i < tooltip.size(); i++) {
+            var translatableContents = findFirstTranslatableContents(tooltip.get(i));
+            if (translatableContents == null || !IMBUE_HELP_KEY.equals(translatableContents.getKey())) {
+                continue;
+            }
+
+            if (manaCost <= 0.0F) {
+                tooltip.remove(i);
+            } else {
+                tooltip.set(i, Component.translatable(IMBUE_HELP_KEY, net.minecraft.util.Mth.ceil(manaCost))
+                        .withStyle(ChatFormatting.AQUA));
+            }
+            return;
+        }
     }
 
     public static void playBlueGuardEffect(ServerPlayer player, Vec3 position, int sparkCount) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeGuardLogic.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeGuardLogic.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.item.manaforceblade;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.item.ManaForceBlade;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
@@ -24,13 +25,9 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
 public final class ManaForceBladeGuardLogic {
-    public static final int PERFECT_GUARD_TICKS = 10;
-
     private static final int COST_INTERVAL_TICKS = 20;
     private static final int ACTION_INTERVAL_TICKS = 5;
-    private static final float RANGED_GUARD_MANA_COST = 20.0F;
     private static final int RANGED_GUARD_DURABILITY_COST = 1;
-    private static final float MELEE_GUARD_MANA_COST = 50.0F;
     private static final int MELEE_GUARD_DURABILITY_COST = 2;
     private static final double RANGED_DISTANCE_SQR = 3.0D * 3.0D;
     private static final double PROJECTILE_SPEED = 2.45D;
@@ -65,7 +62,7 @@ public final class ManaForceBladeGuardLogic {
     }
 
     public static boolean isPerfectGuard(int heldTicks) {
-        return heldTicks <= PERFECT_GUARD_TICKS;
+        return heldTicks <= ApprenticeCodexServerConfig.manaForceBladePerfectGuardTicks();
     }
 
     public static boolean tryHandleGuard(
@@ -114,7 +111,7 @@ public final class ManaForceBladeGuardLogic {
                 stack,
                 RANGED_COST_TICK_TAG,
                 now,
-                RANGED_GUARD_MANA_COST,
+                ApprenticeCodexServerConfig.manaForceBladeRangedGuardManaCost(),
                 RANGED_GUARD_DURABILITY_COST
         )) {
             return false;
@@ -147,7 +144,7 @@ public final class ManaForceBladeGuardLogic {
                 stack,
                 MELEE_COST_TICK_TAG,
                 now,
-                MELEE_GUARD_MANA_COST,
+                ApprenticeCodexServerConfig.manaForceBladeMeleeGuardManaCost(),
                 MELEE_GUARD_DURABILITY_COST
         )) {
             return false;
@@ -176,9 +173,11 @@ public final class ManaForceBladeGuardLogic {
             return true;
         }
 
-        var magicData = MagicData.getPlayerMagicData(player);
-        if (!player.getAbilities().instabuild && (magicData == null || magicData.getMana() < manaCost)) {
-            return false;
+        if (manaCost > 0.0F) {
+            var magicData = MagicData.getPlayerMagicData(player);
+            if (!player.getAbilities().instabuild && (magicData == null || magicData.getMana() < manaCost)) {
+                return false;
+            }
         }
 
         ManaForceBlade.spendMana(player, manaCost);
@@ -213,7 +212,7 @@ public final class ManaForceBladeGuardLogic {
     private static void shootGuardProjectile(ServerPlayer player, ItemStack stack, Vec3 origin, boolean perfectGuard) {
         var projectile = new ManaForceBladeProjectileEntity(EntityRegistry.MANA_FORCE_BLADE_PROJECTILE.get(), player.level(), player);
         projectile.setPos(origin);
-        projectile.setDamage(ManaForceBlade.resolveBladeAttackDamage(stack) * (perfectGuard ? 1.5F : 1.0F));
+        projectile.setDamage(ManaForceBlade.resolveFinalAttackDamage(player, stack) * (perfectGuard ? 1.5F : 1.0F));
         projectile.setColor(resolveProjectileColor(stack));
         projectile.setProjectileVelocity(player.getLookAngle().normalize(), PROJECTILE_SPEED);
         player.level().addFreshEntity(projectile);
@@ -304,7 +303,7 @@ public final class ManaForceBladeGuardLogic {
             try {
                 CombatTools.applyDamage(
                         livingTarget,
-                        ManaForceBlade.resolveBladeAttackDamage(stack),
+                        ManaForceBlade.resolveFinalAttackDamage(player, stack),
                         CombatTools.getDamageSource(player.level(), player, DamageTypes.MANA_FORCE_BLADE),
                         null,
                         CombatTools.KnockbackTypes.NO_KNOCKBACK

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -20,6 +20,7 @@ import jp.aquafactory.apprenticecodex.network.packet.SyncFocusStaffbowCastStateP
 import jp.aquafactory.apprenticecodex.network.packet.SyncFocusStaffbowLoanPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncFocusStaffbowPresentationPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncIsekaiTravelGuidebookConfigPacket;
+import jp.aquafactory.apprenticecodex.network.packet.SyncManaForceBladeConfigPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncPhotonSiphonCombatStatePacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncRemoteEyeStatePacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncScarletThirstHealthPacket;
@@ -35,7 +36,7 @@ import net.minecraftforge.network.PacketDistributor;
 import net.minecraftforge.network.simple.SimpleChannel;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "21";
+    private static final String PROTOCOL_VERSION = "22";
     private static int nextPacketId = 0;
 
     private static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
@@ -125,6 +126,13 @@ public final class Networks {
                 SyncApprenticeDeskConfigPacket::encode,
                 SyncApprenticeDeskConfigPacket::decode,
                 SyncApprenticeDeskConfigPacket::handle
+        );
+        CHANNEL.registerMessage(
+                nextPacketId++,
+                SyncManaForceBladeConfigPacket.class,
+                SyncManaForceBladeConfigPacket::encode,
+                SyncManaForceBladeConfigPacket::decode,
+                SyncManaForceBladeConfigPacket::handle
         );
         CHANNEL.registerMessage(
                 nextPacketId++,

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncManaForceBladeConfigPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncManaForceBladeConfigPacket.java
@@ -1,0 +1,62 @@
+package jp.aquafactory.apprenticecodex.network.packet;
+
+import jp.aquafactory.apprenticecodex.item.manaforceblade.ManaForceBladeConfigState;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.DistExecutor;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public final class SyncManaForceBladeConfigPacket {
+    private final float imbueDamageMultiplierScale;
+    private final float attackManaCostMultiplier;
+    private final float attackManaSchoolMultiplierScale;
+
+    public SyncManaForceBladeConfigPacket(
+            float imbueDamageMultiplierScale,
+            float attackManaCostMultiplier,
+            float attackManaSchoolMultiplierScale
+    ) {
+        this.imbueDamageMultiplierScale = imbueDamageMultiplierScale;
+        this.attackManaCostMultiplier = attackManaCostMultiplier;
+        this.attackManaSchoolMultiplierScale = attackManaSchoolMultiplierScale;
+    }
+
+    public static void encode(SyncManaForceBladeConfigPacket packet, FriendlyByteBuf buffer) {
+        buffer.writeFloat(packet.imbueDamageMultiplierScale);
+        buffer.writeFloat(packet.attackManaCostMultiplier);
+        buffer.writeFloat(packet.attackManaSchoolMultiplierScale);
+    }
+
+    public static SyncManaForceBladeConfigPacket decode(FriendlyByteBuf buffer) {
+        return new SyncManaForceBladeConfigPacket(
+                buffer.readFloat(),
+                buffer.readFloat(),
+                buffer.readFloat()
+        );
+    }
+
+    public static void handle(SyncManaForceBladeConfigPacket packet, Supplier<NetworkEvent.Context> contextSupplier) {
+        var context = contextSupplier.get();
+        context.enqueueWork(() ->
+                DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> ClientHandler.handle(packet))
+        );
+        context.setPacketHandled(true);
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private static final class ClientHandler {
+        private ClientHandler() {
+        }
+
+        private static void handle(SyncManaForceBladeConfigPacket packet) {
+            ManaForceBladeConfigState.set(
+                    packet.imbueDamageMultiplierScale,
+                    packet.attackManaCostMultiplier,
+                    packet.attackManaSchoolMultiplierScale
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- 彩色の魔術師礼装の履歴魔法力上昇値をサーバー設定化
- 魔法防具の共通魔法力ボーナスをサーバー設定化し、彩色の魔術師礼装のデフォルト値を調整
- 魔力の刀の攻撃力倍率、攻撃時マナ消費、ガード時マナ消費などをサーバー設定化し、クライアント表示用の同期パケットを追加

## 確認
- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`（324 tests passed）