### PR TITLE
PR #469 を 1.21.1-main へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -2574,6 +2574,63 @@ public final class ApprenticeCodexGameTestScenarios {
             helper.assertTrue(true, "Spectral Hammer ticked without crashing");
         });
     }
+    static void compoundPhialSplashDamageUsesWeakFalloffAndKeepsSelfHit(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+        var owner = EntityType.SHEEP.create(level);
+        helper.assertTrue(owner != null, "Failed to create Compound Phial owner target");
+        owner.setNoAi(true);
+        var ownerPos = helper.absoluteVec(new Vec3(2.0D, 2.0D, 3.0D));
+        owner.moveTo(ownerPos.x, ownerPos.y, ownerPos.z, 0.0F, 0.0F);
+        level.addFreshEntity(owner);
+
+        var fullDamageTarget = EntityType.SHEEP.create(level);
+        helper.assertTrue(fullDamageTarget != null, "Failed to create Compound Phial full-damage target");
+        fullDamageTarget.setNoAi(true);
+        var fullDamageTargetPos = helper.absoluteVec(new Vec3(3.2D, 2.0D, 2.5D));
+        fullDamageTarget.moveTo(fullDamageTargetPos.x, fullDamageTargetPos.y, fullDamageTargetPos.z, 0.0F, 0.0F);
+        level.addFreshEntity(fullDamageTarget);
+
+        var falloffTarget = EntityType.SHEEP.create(level);
+        helper.assertTrue(falloffTarget != null, "Failed to create Compound Phial falloff target");
+        falloffTarget.setNoAi(true);
+        var falloffTargetPos = helper.absoluteVec(new Vec3(4.7D, 2.0D, 2.5D));
+        falloffTarget.moveTo(falloffTargetPos.x, falloffTargetPos.y, falloffTargetPos.z, 0.0F, 0.0F);
+        level.addFreshEntity(falloffTarget);
+
+        var ownerHealth = owner.getHealth();
+        var fullDamageTargetHealth = fullDamageTarget.getHealth();
+        var falloffTargetHealth = falloffTarget.getHealth();
+
+        var projectilePos = helper.absoluteVec(new Vec3(2.5D, 4.0D, 2.5D));
+        var projectile = new CompoundPhialProjectileEntity(EntityRegistry.COMPOUND_PHIAL_PROJECTILE.get(), level, owner);
+        projectile.setPos(projectilePos.x, projectilePos.y, projectilePos.z);
+        projectile.setDeltaMovement(0.0D, -0.8D, 0.0D);
+        projectile.setDamage(4.0F);
+        projectile.setSplashRadius(2.0F);
+        projectile.setPotionColorRandom(level);
+        level.addFreshEntity(projectile);
+
+        helper.runAtTickTime(8, () -> {
+            helper.assertTrue(projectile.isRemoved(), "Compound Phial projectile did not impact during the test");
+
+            var ownerTaken = ownerHealth - owner.getHealth();
+            var fullDamageTaken = fullDamageTargetHealth - fullDamageTarget.getHealth();
+            var falloffTaken = falloffTargetHealth - falloffTarget.getHealth();
+
+            helper.assertTrue(ownerTaken > 0.0F, "Compound Phial should still hit its owner inside the splash");
+            helper.assertTrue(Math.abs(fullDamageTaken - ownerTaken) < 0.1F,
+                    "Compound Phial full-damage band should apply equal damage to nearby targets: target="
+                            + fullDamageTaken + ", owner=" + ownerTaken);
+            helper.assertTrue(falloffTaken >= fullDamageTaken * 0.6F - 0.1F,
+                    "Compound Phial falloff target should keep at least 60% damage: target="
+                            + falloffTaken + ", full=" + fullDamageTaken);
+            helper.assertTrue(falloffTaken < fullDamageTaken,
+                    "Compound Phial falloff target should still take less than full-band damage");
+            helper.assertTrue(Math.abs(falloffTaken - Math.round(falloffTaken)) > 0.05F,
+                    "Compound Phial falloff damage should not be rounded to whole damage steps: " + falloffTaken);
+            helper.succeed();
+        });
+    }
     static void serverBlocksAndEntitiesCanBeInstantiated(GameTestHelper helper) {
         helper.succeedIf(() -> {
             placeAndAssertBlockEntity(helper, new BlockPos(0, 1, 0), BlockRegistry.MAGE_LIGHT_TORCH.get(), BlockEntityRegistry.MAGE_LIGHT_TORCH.get());

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -18,6 +18,7 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     private static final String HARVEST_MOON_ISOLATED_BATCH = "apprenticecodex.harvest_moon_isolated";
     private static final String AUTO_MAGNET_ISOLATED_BATCH = "apprenticecodex.auto_magnet_isolated";
     private static final String EARTH_FORGE_ISOLATED_BATCH = "apprenticecodex.earth_forge_isolated";
+    private static final String COMPOUND_PHIAL_ISOLATED_BATCH = "apprenticecodex.compound_phial_isolated";
 
     private ApprenticeCodexSpellBehaviorGameTests() {
     }
@@ -170,5 +171,10 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     @GameTest(template = TEMPLATE, batch = EARTH_FORGE_ISOLATED_BATCH, timeoutTicks = 60)
     public static void earthForgeReplacesWaterButKeepsUnsafeFluidBlocks(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.earthForgeReplacesWaterButKeepsUnsafeFluidBlocks(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = COMPOUND_PHIAL_ISOLATED_BATCH, timeoutTicks = 40)
+    public static void compoundPhialSplashDamageUsesWeakFalloffAndKeepsSelfHit(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.compoundPhialSplashDamageUsesWeakFalloffAndKeepsSelfHit(helper);
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/compoundphial/CompoundPhial.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/compoundphial/CompoundPhial.java
@@ -42,30 +42,21 @@ public class CompoundPhial extends AbstractSpell {
     public List<MutableComponent> getUniqueInfo(int spellLevel, LivingEntity caster) {
         return List.of(
                 Component.translatable("ui.irons_spellbooks.damage", Utils.stringTruncation(getDamage(spellLevel, caster), 2)),
-                Component.translatable("ui.irons_spellbooks.radius", Utils.stringTruncation(getSplashRadius(spellLevel, caster), 2)),
-                Component.translatable("ui.apprenticecodex.splash_reduce", Utils.stringTruncation(getSplashReducedPercent(spellLevel, caster), 2))
+                Component.translatable("ui.irons_spellbooks.radius", Utils.stringTruncation(getSplashRadius(spellLevel), 2))
         );
     }
 
     private float getDamage(int spellLevel, LivingEntity entity) {
-        var rawDamage = 2 + 2 * getSpellPower(spellLevel, entity) / 100.0f;
+        var rawDamage = 4 + 2 * getSpellPower(spellLevel, entity) / 100.0f;
         return rawDamage * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.COMPOUND_PHIAL);
     }
 
-    private int getSplashReducedPercent(int spellLevel, LivingEntity entity) {
-        return 50 + Math.min(50 , Math.round(15 * getSpellPower(spellLevel, entity) / 100.0f));
-    }
-
-    private float getSplashRadius(int spellLevel, LivingEntity entity) {
-        return 1.5f * getSpellPower(spellLevel, entity) / 100.0f;
+    private float getSplashRadius(int spellLevel) {
+        return 1.75f + Math.max(0, spellLevel - 1) / 9.0f;
     }
 
     private float getSpeed() {
         return 1.0f;
-    }
-
-    private float getSplashDamage(int spellLevel, LivingEntity entity) {
-        return getDamage(spellLevel, entity) * getSplashReducedPercent(spellLevel, entity) / 100.0f;
     }
 
     @Override
@@ -109,8 +100,7 @@ public class CompoundPhial extends AbstractSpell {
         projectile.setPos(entity.getX(), entity.getEyeY() - 0.1, entity.getZ());
         projectile.shootFromRotation(entity, entity.getXRot(), entity.getYRot(), 0.0f, getSpeed(), 0.0f);
         projectile.setDamage(getDamage(spellLevel, entity));
-        projectile.setSplashDamage(getSplashDamage(spellLevel, entity));
-        projectile.setSplashRadius(getSplashRadius(spellLevel, entity));
+        projectile.setSplashRadius(getSplashRadius(spellLevel));
         projectile.setPotionColorRandom(level);
         level.addFreshEntity(projectile);
         super.onCast(level, spellLevel, entity, castSource, playerMagicData);

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/compoundphial/CompoundPhialProjectileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/compoundphial/CompoundPhialProjectileEntity.java
@@ -23,9 +23,13 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.EntityHitResult;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
 
 public class CompoundPhialProjectileEntity extends ThrowableProjectile {
+    private static final float FULL_DAMAGE_RADIUS_SCALE = 0.5f;
+    private static final float MIN_SPLASH_DAMAGE_SCALE = 0.6f;
+
     private static final EntityDataAccessor<Integer> POTION_COLOR =
             SynchedEntityData.defineId(CompoundPhialProjectileEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Float> BURST_RADIUS =
@@ -33,8 +37,7 @@ public class CompoundPhialProjectileEntity extends ThrowableProjectile {
     private static final EntityDataAccessor<ItemStack> POTION_ITEM =
             SynchedEntityData.defineId(CompoundPhialProjectileEntity.class, EntityDataSerializers.ITEM_STACK);
 
-    private float impactDamage;
-    private float splashDamage;
+    private float damage;
     private float splashRadius;
 
     public CompoundPhialProjectileEntity(EntityType<? extends CompoundPhialProjectileEntity> entityType, Level level) {
@@ -55,11 +58,10 @@ public class CompoundPhialProjectileEntity extends ThrowableProjectile {
     @Override
     protected void readAdditionalSaveData(@NotNull CompoundTag tag) {
         super.readAdditionalSaveData(tag);
-        if (tag.contains("impactDamage")) {
-            impactDamage = tag.getFloat("impactDamage");
-        }
-        if (tag.contains("splashDamage")) {
-            splashDamage = tag.getFloat("splashDamage");
+        if (tag.contains("damage")) {
+            damage = tag.getFloat("damage");
+        } else if (tag.contains("impactDamage")) {
+            damage = tag.getFloat("impactDamage");
         }
         if (tag.contains("splashRadius")) {
             splashRadius = tag.getFloat("splashRadius");
@@ -69,8 +71,7 @@ public class CompoundPhialProjectileEntity extends ThrowableProjectile {
     @Override
     protected void addAdditionalSaveData(@NotNull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
-        tag.putFloat("impactDamage", impactDamage);
-        tag.putFloat("splashDamage", splashDamage);
+        tag.putFloat("damage", damage);
         tag.putFloat("splashRadius", splashRadius);
     }
 
@@ -113,12 +114,8 @@ public class CompoundPhialProjectileEntity extends ThrowableProjectile {
         }
     }
 
-    public void setDamage(float impactDamage) {
-        this.impactDamage = impactDamage;
-    }
-
-    public void setSplashDamage(float splashDamage) {
-        this.splashDamage = splashDamage;
+    public void setDamage(float damage) {
+        this.damage = damage;
     }
 
     public void setSplashRadius(float splashRadius) {
@@ -140,43 +137,69 @@ public class CompoundPhialProjectileEntity extends ThrowableProjectile {
 
     @Override
     protected void onHitEntity(@NotNull EntityHitResult hit) {
-        onImpact(hit.getEntity(), level());
+        onImpact(level());
         super.onHitEntity(hit);
         discard();
     }
 
     @Override
     protected void onHitBlock(@NotNull BlockHitResult hit) {
-        onImpact(null, level());
+        onImpact(level());
         super.onHitBlock(hit);
         discard();
     }
 
-    private void onImpact(@Nullable Entity entity, Level level) {
+    private void onImpact(Level level) {
         var owner = getOwner();
-
-        if (entity != null && entity.isAlive()) {
-            var target = CombatTools.resolutePartEntity(entity);
-            var source = CombatTools.getDamageSource(level(), this, owner, DamageTypes.COMPOUND_PHIAL);
-            CombatTools.applyDamage(target, impactDamage, source, SpellRegistry.COMPOUND_PHIAL.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);
-        }
 
         var color = entityData.get(POTION_COLOR);
         level.levelEvent(2002, BlockPos.containing(position()), color);
         level.broadcastEntityEvent(this, (byte) 3);
 
         var box = new AABB(position(), position()).inflate(splashRadius * 2);
-        var entities = level.getEntitiesOfClass(Entity.class, box, e -> e != entity && CombatTools.isValidCombatTarget(e, null) && e.isAlive());
+        var entities = level.getEntitiesOfClass(Entity.class, box, e -> CombatTools.isValidCombatTarget(e, null) && e.isAlive());
+        var damagedTargets = new HashSet<Entity>();
 
         for (var target : entities) {
-            var center = target.getBoundingBox().getCenter();
-            var distance = position().distanceTo(center) - target.getBbWidth();
+            var resolvedTarget = CombatTools.resolutePartEntity(target);
+            var distance = distanceToBoundingBox(target.getBoundingBox());
             if (distance <= splashRadius) {
-                var scale = 0.5 + 0.5 * (1 - distance / splashRadius);
+                var scale = getSplashDamageScale(distance);
                 var source = CombatTools.getDamageSource(level(), this, owner, DamageTypes.COMPOUND_PHIAL);
-                CombatTools.applyDamage(target, Math.round(splashDamage * scale), source, SpellRegistry.COMPOUND_PHIAL.get().getSchoolType(), CombatTools.KnockbackTypes.NO_KNOCKBACK);
+                if (damagedTargets.add(resolvedTarget)) {
+                    CombatTools.applyDamage(resolvedTarget, damage * scale, source, SpellRegistry.COMPOUND_PHIAL.get().getSchoolType(), CombatTools.KnockbackTypes.NO_KNOCKBACK);
+                }
             }
         }
+    }
+
+    private float getSplashDamageScale(double distance) {
+        var fullDamageRadius = splashRadius * FULL_DAMAGE_RADIUS_SCALE;
+        if (distance <= fullDamageRadius) {
+            return 1.0f;
+        }
+
+        var falloffRange = Math.max(splashRadius - fullDamageRadius, 0.001f);
+        var falloffProgress = Math.min(1.0, (distance - fullDamageRadius) / falloffRange);
+        return (float) (1.0 - (1.0 - MIN_SPLASH_DAMAGE_SCALE) * falloffProgress);
+    }
+
+    private double distanceToBoundingBox(AABB box) {
+        var p = position();
+        var x = distanceOutsideAxis(p.x, box.minX, box.maxX);
+        var y = distanceOutsideAxis(p.y, box.minY, box.maxY);
+        var z = distanceOutsideAxis(p.z, box.minZ, box.maxZ);
+        return Math.sqrt(x * x + y * y + z * z);
+    }
+
+    private static double distanceOutsideAxis(double point, double min, double max) {
+        if (point < min) {
+            return min - point;
+        }
+        if (point > max) {
+            return point - max;
+        }
+        return 0.0;
     }
 
     private float[] getColorArray() {

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -513,7 +513,6 @@
 
   "ui.apprenticecodex.headshot_damage_multiplier": "Headshot Damage Multiplier: %d%%",
   "ui.apprenticecodex.sneak_damage_multiplier": "Sneak Damage Multiplier: %d%%",
-  "ui.apprenticecodex.splash_reduce": "Splash Damage Multiplier: %d%%",
   "ui.apprenticecodex.start_up_time": "Start up time: %s ",
   "ui.apprenticecodex.warm_up_time": "Max warm up time: %s ",
   "ui.apprenticecodex.tree_cut_time": "Minimum Tree cut time: %s ",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -523,7 +523,6 @@
 
   "ui.apprenticecodex.headshot_damage_multiplier": "ヘッドショット倍率: %d%%",
   "ui.apprenticecodex.sneak_damage_multiplier": "隠密ダメージ倍率: %d%%",
-  "ui.apprenticecodex.splash_reduce": "範囲ダメージ割合: %d%%",
   "ui.apprenticecodex.start_up_time": "起動時間: %s ",
   "ui.apprenticecodex.warm_up_time": "最高速度までの時間: %s ",
   "ui.apprenticecodex.tree_cut_time": "伐採にかかる最短時間: %s ",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -513,7 +513,6 @@
 
   "ui.apprenticecodex.headshot_damage_multiplier": "爆头伤害倍率：%d%%",
   "ui.apprenticecodex.sneak_damage_multiplier": "潜行伤害倍率：%d%%",
-  "ui.apprenticecodex.splash_reduce": "喷溅伤害倍率：%d%%",
   "ui.apprenticecodex.start_up_time": "启动时间：%s ",
   "ui.apprenticecodex.warm_up_time": "最大蓄力时间：%s ",
   "ui.apprenticecodex.tree_cut_time": "最小伐木时间：%s ",


### PR DESCRIPTION
## 概要
- PR #469 のコンパウンドファイアル範囲ダメージ再調整を `1.21.1-main` へ forward-port
- 1.21.1 側の `SynchedEntityData.Builder` / `CustomData` / `ColorParticleOption` 実装を維持して競合解消
- 不要になった範囲ダメージ割合表示の翻訳キーを削除

## 検証
- `./gradlew.bat runData`（generated 差分なし）
- `./gradlew.bat runGameTestServer`（327 required tests passed）
- `./gradlew.bat build`