### PR TITLE
PR #473 を 1.21.1-main へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -9888,6 +9888,53 @@ public final class ApprenticeCodexGameTestScenarios {
             helper.succeed();
         });
     }
+    static void healingBloomDeathDropsOnlyStoredFruitWithoutPlantingBush(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var relativeAnchorPos = new BlockPos(0, 2, 0);
+            var anchorPos = helper.absolutePos(relativeAnchorPos);
+            helper.setBlock(relativeAnchorPos.below(), Blocks.DIRT);
+
+            var owner = new FakePlayer(level, new GameProfile(UUID.randomUUID(), "healing_bloom_death_drop_test"));
+            var bloom = new HealingBloomEntity(EntityRegistry.HEALING_BLOOM.get(), level);
+            bloom.setOwner(owner);
+            bloom.setAnchorPos(anchorPos);
+            bloom.setBloomMaxHealth(10.0f);
+            setHealingBloomFruitCount(bloom, 3);
+            bloom.moveTo(anchorPos.getX() + 0.5, anchorPos.getY(), anchorPos.getZ() + 0.5, 0.0f, 0.0f);
+            level.addFreshEntity(bloom);
+
+            killHealingBloom(level, bloom);
+
+            helper.assertTrue(!level.getBlockState(anchorPos).is(BlockRegistry.COMFORT_BERRY_BUSH.get()),
+                    "Healing Bloom death should not plant a Comfort Berry Bush");
+            helper.assertTrue(countFreshItemDrops(level, ItemRegistry.COMFORT_BERRIES.get(), anchorPos, 1.5D) == 3,
+                    "Healing Bloom death should drop exactly the stored Comfort Berries");
+        });
+    }
+    static void healingBloomImmediateDeathDropsNothingAndPlantsNoBush(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var relativeAnchorPos = new BlockPos(0, 2, 0);
+            var anchorPos = helper.absolutePos(relativeAnchorPos);
+            helper.setBlock(relativeAnchorPos.below(), Blocks.DIRT);
+
+            var owner = new FakePlayer(level, new GameProfile(UUID.randomUUID(), "healing_bloom_immediate_death_test"));
+            var bloom = new HealingBloomEntity(EntityRegistry.HEALING_BLOOM.get(), level);
+            bloom.setOwner(owner);
+            bloom.setAnchorPos(anchorPos);
+            bloom.setBloomMaxHealth(10.0f);
+            bloom.moveTo(anchorPos.getX() + 0.5, anchorPos.getY(), anchorPos.getZ() + 0.5, 0.0f, 0.0f);
+            level.addFreshEntity(bloom);
+
+            killHealingBloom(level, bloom);
+
+            helper.assertTrue(!level.getBlockState(anchorPos).is(BlockRegistry.COMFORT_BERRY_BUSH.get()),
+                    "Immediate Healing Bloom death should not plant a Comfort Berry Bush");
+            helper.assertTrue(countFreshItemDrops(level, ItemRegistry.COMFORT_BERRIES.get(), anchorPos, 1.5D) == 0,
+                    "Immediate Healing Bloom death should not drop Comfort Berries before fruit has grown");
+        });
+    }
     static void healingBloomSkipsSelfRegenerationAndUsesSlowNaturalHealing(GameTestHelper helper) {
         var level = helper.getLevel();
         var relativeAnchorPos = new BlockPos(0, 2, 0);
@@ -10014,6 +10061,19 @@ public final class ApprenticeCodexGameTestScenarios {
                     "Replacing your own Healing Bloom should not affect blooms owned by other players");
         });
     }
+
+    private static void setHealingBloomFruitCount(HealingBloomEntity bloom, int fruitCount) {
+        var tag = new CompoundTag();
+        bloom.addAdditionalSaveData(tag);
+        tag.putInt("FruitCount", fruitCount);
+        bloom.readAdditionalSaveData(tag);
+    }
+
+    private static void killHealingBloom(ServerLevel level, HealingBloomEntity bloom) {
+        bloom.setHealth(0.0f);
+        bloom.die(level.damageSources().genericKill());
+    }
+
     static void archerMultipleTimeoutWithGreaterConjurersTalismanSkipsCooldown(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var playerPos = new BlockPos(0, 12, 0);
@@ -11004,6 +11064,13 @@ public final class ApprenticeCodexGameTestScenarios {
                 new AABB(pos).inflate(radius),
                 itemEntity -> itemEntity.getAge() <= 1
         );
+    }
+
+    private static int countFreshItemDrops(ServerLevel level, Item item, BlockPos pos, double radius) {
+        return getFreshItemDrops(level, pos, radius).stream()
+                .filter(itemEntity -> itemEntity.getItem().is(item))
+                .mapToInt(itemEntity -> itemEntity.getItem().getCount())
+                .sum();
     }
 
     private static boolean hasItemEntityWithin(ServerLevel level, Item item, Vec3 pos, double radius) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -10032,6 +10032,48 @@ public final class ApprenticeCodexGameTestScenarios {
                     "A missing managed Healing Bloom should not block recasting for the same owner");
         });
     }
+    static void healingBloomOfflineDeathDoesNotBlockRecast(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createHealingBloomPlayer(helper, new BlockPos(0, 2, 0), "healing_bloom_offline_death_recast_test");
+            var firstAnchor = new BlockPos(0, 2, 0);
+            var secondAnchor = new BlockPos(2, 2, 0);
+            helper.setBlock(firstAnchor.below(), Blocks.STONE);
+            helper.setBlock(secondAnchor.below(), Blocks.STONE);
+
+            var deadBloomUuid = prepareHealingBloomDeadWhileOwnerOffline(helper, owner, firstAnchor);
+
+            castHealingBloom(helper, owner, 1, secondAnchor, false);
+
+            var currentBloom = getSingleLivingHealingBloom(helper, owner);
+            helper.assertTrue(currentBloom.blockPosition().equals(helper.absolutePos(secondAnchor)),
+                    "A Healing Bloom that died while its owner was offline should not block normal recasting");
+            assertManagedHealingBloomUuid(helper, owner, currentBloom.getUUID(),
+                    "Healing Bloom stale state should be replaced by the newly placed bloom");
+            helper.assertTrue(!deadBloomUuid.equals(currentBloom.getUUID()),
+                    "The recast Healing Bloom should not reuse the dead bloom UUID");
+        });
+    }
+    static void healingBloomSneakCastRecoversOfflineDeathState(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createHealingBloomPlayer(helper, new BlockPos(0, 2, 0), "healing_bloom_offline_death_sneak_test");
+            var firstAnchor = new BlockPos(0, 2, 0);
+            var replacementAnchor = new BlockPos(2, 2, 0);
+            helper.setBlock(firstAnchor.below(), Blocks.STONE);
+            helper.setBlock(replacementAnchor.below(), Blocks.STONE);
+
+            var deadBloomUuid = prepareHealingBloomDeadWhileOwnerOffline(helper, owner, firstAnchor);
+
+            castHealingBloom(helper, owner, 1, replacementAnchor, true);
+
+            var currentBloom = getSingleLivingHealingBloom(helper, owner);
+            helper.assertTrue(currentBloom.blockPosition().equals(helper.absolutePos(replacementAnchor)),
+                    "Sneak casting should recover a stale Healing Bloom state left by offline death");
+            assertManagedHealingBloomUuid(helper, owner, currentBloom.getUUID(),
+                    "Sneak casting should replace the stale Healing Bloom UUID with the new bloom UUID");
+            helper.assertTrue(!deadBloomUuid.equals(currentBloom.getUUID()),
+                    "The replacement Healing Bloom should not reuse the dead bloom UUID");
+        });
+    }
     static void healingBloomSneakCastReplacesOnlyOwnersPreviousBloom(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var firstOwner = createHealingBloomPlayer(helper, new BlockPos(0, 2, 0), "healing_bloom_force_owner_a_test");
@@ -10067,6 +10109,34 @@ public final class ApprenticeCodexGameTestScenarios {
         bloom.addAdditionalSaveData(tag);
         tag.putInt("FruitCount", fruitCount);
         bloom.readAdditionalSaveData(tag);
+    }
+
+    private static UUID prepareHealingBloomDeadWhileOwnerOffline(GameTestHelper helper, FakePlayer owner, BlockPos anchorPos) {
+        castHealingBloom(helper, owner, 1, anchorPos, false);
+        var bloom = getSingleLivingHealingBloom(helper, owner);
+        var bloomUuid = bloom.getUUID();
+        assertManagedHealingBloomUuid(helper, owner, bloomUuid,
+                "Healing Bloom offline-death setup should start with a managed bloom");
+
+        // オフライン中の死亡では owner を ServerPlayer として引けず、即時解除されない state が残る。
+        clearHealingBloomCachedOwner(bloom);
+        killHealingBloom(helper.getLevel(), bloom);
+        assertManagedHealingBloomUuid(helper, owner, bloomUuid,
+                "Healing Bloom state should still contain the dead bloom UUID until the owner recasts");
+        return bloomUuid;
+    }
+
+    private static void clearHealingBloomCachedOwner(HealingBloomEntity bloom) {
+        var tag = new CompoundTag();
+        bloom.addAdditionalSaveData(tag);
+        bloom.readAdditionalSaveData(tag);
+    }
+
+    private static void assertManagedHealingBloomUuid(GameTestHelper helper, FakePlayer owner, UUID expectedUuid, String message) {
+        var spellData = Capabilities.getSpellDataOrNull(owner);
+        helper.assertTrue(spellData != null, "Healing Bloom state assertion could not resolve spell data capability");
+        helper.assertTrue(expectedUuid.equals(spellData.get(CodexSpellStateTypeRegister.HEALING_BLOOM_STATE).getBloomUuid()),
+                message);
     }
 
     private static void killHealingBloom(ServerLevel level, HealingBloomEntity bloom) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -84,6 +84,16 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     }
 
     @GameTest(template = TEMPLATE, batch = HEALING_BLOOM_ISOLATED_BATCH)
+    public static void healingBloomOfflineDeathDoesNotBlockRecast(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.healingBloomOfflineDeathDoesNotBlockRecast(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = HEALING_BLOOM_ISOLATED_BATCH)
+    public static void healingBloomSneakCastRecoversOfflineDeathState(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.healingBloomSneakCastRecoversOfflineDeathState(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = HEALING_BLOOM_ISOLATED_BATCH)
     public static void healingBloomSneakCastReplacesOnlyOwnersPreviousBloom(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.healingBloomSneakCastReplacesOnlyOwnersPreviousBloom(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -49,6 +49,16 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     }
 
     @GameTest(template = TEMPLATE, batch = HEALING_BLOOM_ISOLATED_BATCH)
+    public static void healingBloomDeathDropsOnlyStoredFruitWithoutPlantingBush(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.healingBloomDeathDropsOnlyStoredFruitWithoutPlantingBush(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = HEALING_BLOOM_ISOLATED_BATCH)
+    public static void healingBloomImmediateDeathDropsNothingAndPlantsNoBush(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.healingBloomImmediateDeathDropsNothingAndPlantsNoBush(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = HEALING_BLOOM_ISOLATED_BATCH)
     public static void healingBloomSkipsSelfRegenerationAndUsesSlowNaturalHealing(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.healingBloomSkipsSelfRegenerationAndUsesSlowNaturalHealing(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/healingbloom/HealingBloom.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/healingbloom/HealingBloom.java
@@ -45,7 +45,7 @@ public class HealingBloom extends AbstractSpell implements IClientBlockTargeting
             .setMinRarity(SpellRarity.RARE)
             .setSchoolResource(SchoolRegistry.NATURE_RESOURCE)
             .setMaxLevel(3)
-            .setCooldownSeconds(60)
+            .setCooldownSeconds(300)
             .build();
 
     public HealingBloom() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/healingbloom/HealingBloomEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/healingbloom/HealingBloomEntity.java
@@ -1,7 +1,6 @@
 package jp.aquafactory.apprenticecodex.spell.healingbloom;
 
 import io.redspace.ironsspellbooks.registries.SoundRegistry;
-import jp.aquafactory.apprenticecodex.block.comfortberrybush.ComfortBerryBushBlock;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
@@ -379,35 +378,20 @@ public class HealingBloomEntity extends PathfinderMob implements GeoEntity {
 
     @Override
     public void die(@NotNull DamageSource damageSource) {
-        if (!level().isClientSide && level() instanceof ServerLevel serverLevel) {
-            handleDeathDrops(serverLevel);
+        if (!level().isClientSide && level() instanceof ServerLevel) {
+            handleDeathDrops();
         }
         super.die(damageSource);
     }
 
-    private void handleDeathDrops(ServerLevel level) {
+    private void handleDeathDrops() {
         if (deathHandled) {
             return;
         }
 
         deathHandled = true;
-        var droppedFruit = getFruitCount();
-        if (!placeComfortBerryBush(level)) {
-            ++droppedFruit;
-        }
-        dropComfortBerries(droppedFruit);
+        dropComfortBerries(getFruitCount());
         setFruitCount(0);
-    }
-
-    private boolean placeComfortBerryBush(ServerLevel level) {
-        var bushState = BlockRegistry.COMFORT_BERRY_BUSH.get()
-                .defaultBlockState()
-                .setValue(ComfortBerryBushBlock.AGE, ComfortBerryBushBlock.MAX_AGE);
-        if (!bushState.canSurvive(level, anchorPos) || !level.getBlockState(anchorPos).canBeReplaced()) {
-            return false;
-        }
-
-        return level.setBlock(anchorPos, bushState, 3);
     }
 
     private void dropComfortBerries(int count) {


### PR DESCRIPTION
## 概要
- PR #473 を 1.21.1-main へ forward-port
- 癒しの花のクールダウン延長と死亡時ドロップ仕様変更を反映
- 追加 GameTest を 1.21.1 側へ反映

## 取り込みコミット
- e933e2d1 癒しの花が成長より短いクールダウンなのは違和感があるため大幅に延長
- 4e89deb1 癒しの花の低木設置挙動が仕様の虚として悪用されるため、仕様そのものを削除
- 42987847 癒しの花がオフライン中にキルされた時に再設置できない不具合報告を調査し、そもそも発生しない状態だったためそれを検証できるテストのみを追加

## 確認
- ./gradlew.bat runGameTestServer
- ./gradlew.bat build