### PR TITLE
PR #476 を 1.21.1-main へ forward-port

### DIFF
--- a/.codex/skills/forward-port-1-21-1/SKILL.md
+++ b/.codex/skills/forward-port-1-21-1/SKILL.md
@@ -12,9 +12,10 @@ description: Forward-port tasks from the `main` branch (Minecraft 1.20.1) to `1.
 ## Quick Start
 
 1. 移植対象の非 `merge` コミットを洗い出し、取り込む SHA を確定する。
-2. `references/port-checklist.md` を読み、`cherry-pick`、generated cleanup、`runData`、`runGameTestServer`、build までの順序を固定する。
-3. 取り込み対象に装備・武器・特殊アイテム・修理素材変更が含まれる場合は `references/enchant-repair.md` も読む。
-4. generated JSON の削除範囲に迷う場合は `references/generated-cleanup.md` を読む。
+2. 日本語ファイルや文字化けが疑われる差分を扱う場合は、先に `.codex/skills/text-encoding-hygiene` を読む。
+3. `references/port-checklist.md` を読み、`cherry-pick`、generated cleanup、`runData`、`runGameTestServer`、build までの順序を固定する。
+4. 取り込み対象に装備・武器・特殊アイテム・修理素材変更が含まれる場合は `references/enchant-repair.md` も読む。
+5. generated JSON の削除範囲に迷う場合は `references/generated-cleanup.md` を読む。
 
 ## Workflow
 
@@ -46,7 +47,7 @@ description: Forward-port tasks from the `main` branch (Minecraft 1.20.1) to `1.
 - 必要に応じて `rg -n "forge:conditions|canApplyAtEnchantingTable|isBookEnchantable|supportsEnchantment|isValidRepairItem" src/generated/resources` を実行し、1.20.1 前提が残っていないか確認する。
 - enchant 可否の GameTest を直す場合は、`Item#supportsEnchantment` などの Java 側だけでなく `Enchantment#canEnchant(ItemStack)` も検証対象に含める。
 - forward-port では変更内容に関係なく `./gradlew.bat runGameTestServer` を実行し、GameTest が通ることを確認する。
-- 最後に `./gradlew.bat build` を成功させる。
+- 最後に `./gradlew.bat build` を成功させ、文字化け検査も通す。
 
 ## References
 

--- a/.codex/skills/text-encoding-hygiene/SKILL.md
+++ b/.codex/skills/text-encoding-hygiene/SKILL.md
@@ -61,6 +61,6 @@ $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 ## Mojibake Handling
 
 - The Gradle check catches only obvious cases to avoid false positives.
-- `src/main/resources/assets/apprenticecodex/lang/zh_cn.json` is excluded because simplified Chinese translation text is more likely to collide with simple CJK heuristics.
+- `src/main/resources/assets/apprenticecodex/lang/zh_cn.json` is still checked for UTF-8 BOMs and invalid UTF-8, but skips the simple mojibake fragment heuristic because simplified Chinese translation text can collide with simple CJK heuristics.
 - If the Gradle task reports a file, re-open that file as UTF-8 and fix the source text rather than suppressing the check.
 - Do not add broad exclusions. Add a narrow path exclusion only when a legitimate file is demonstrably unavoidable.

--- a/.codex/skills/text-encoding-hygiene/SKILL.md
+++ b/.codex/skills/text-encoding-hygiene/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: text-encoding-hygiene
+description: Prevent and diagnose UTF-8 mojibake in this repository. Use when Codex sees garbled Japanese text, edits Japanese comments, translations, Markdown, or resources, works from Windows PowerShell, changes AGENTS.md or other skills, or validates text encoding before committing.
+---
+
+# Text Encoding Hygiene
+
+## Purpose
+
+Use this skill before editing Japanese text, after seeing garbled output, or before committing changes that touched comments, translations, Markdown, JSON resources, Gradle files, or skill files. This skill is intentionally written in English so it remains readable when Japanese instructions are affected by display mojibake.
+
+## PowerShell Reading Rules
+
+- Treat Windows PowerShell 5.1 default text I/O as unsafe for Japanese UTF-8 files.
+- Before reading Japanese text in PowerShell, set:
+
+```powershell
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+```
+
+- Prefer one of these explicit UTF-8 reads:
+
+```powershell
+Get-Content -Encoding UTF8 path\to\file.md
+[System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)
+```
+
+- If output shows garbled Japanese, stop editing that file. Re-read it with explicit UTF-8 and confirm the text is readable before making changes.
+- If a Python validation script fails while reading Japanese files under the local default encoding, set `PYTHONUTF8=1` for that command.
+
+## Writing Rules
+
+- Do not use default `Set-Content` or `Out-File` in Windows PowerShell 5.1 for repository text files.
+- Prefer Codex file editing tools for source changes.
+- If shell writing is unavoidable, write UTF-8 without BOM explicitly:
+
+```powershell
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+[System.IO.File]::WriteAllText($path, $text, $utf8NoBom)
+```
+
+- Keep edits narrow. Avoid whole-file rewrites when only a few lines need to change.
+
+## Required Checks
+
+- Run `git diff --name-status` and confirm the changed files match the request.
+- Inspect `git diff` for unintended deletion of Japanese comments or documentation.
+- For code, resource, dependency, or datagen changes, run:
+
+```powershell
+.\scripts\use-java.ps1
+./gradlew.bat build
+```
+
+- For a faster encoding-only check, run:
+
+```powershell
+./gradlew.bat checkTextEncodingHygiene
+```
+
+## Mojibake Handling
+
+- The Gradle check catches only obvious cases to avoid false positives.
+- `src/main/resources/assets/apprenticecodex/lang/zh_cn.json` is excluded because simplified Chinese translation text is more likely to collide with simple CJK heuristics.
+- If the Gradle task reports a file, re-open that file as UTF-8 and fix the source text rather than suppressing the check.
+- Do not add broad exclusions. Add a narrow path exclusion only when a legitimate file is demonstrably unavoidable.

--- a/.codex/skills/text-encoding-hygiene/agents/openai.yaml
+++ b/.codex/skills/text-encoding-hygiene/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Text Encoding Hygiene"
+  short_description: "Prevent and diagnose UTF-8 mojibake in repository files."
+  default_prompt: "Use this skill when repository text appears mojibake, when editing Japanese UTF-8 files from PowerShell, or when validating encoding hygiene before committing."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,13 +67,14 @@ Get-ChildItem build\libs\*.jar
 - データ駆動で表現できる内容は `src/generated/resources` と datagen を優先し、ハードコードを最小化する。
 - コメントは「何をしているか」より「なぜそうするか」を優先する。外部 MOD 仕様依存、ワークアラウンド、クライアント/サーバー差分、実行順依存、魔法値には日本語コメントを残す。
 - テキストファイルは UTF-8（BOM なし）を原則とする。
+- 日本語を含むファイルや文字化けが疑われるファイルを扱う場合は、英語で書かれた `.codex/skills/text-encoding-hygiene` を先に確認する。
 - 依存関係の追加・更新は `gradle.properties` に集約し、必須依存を追加する場合は `neoforge.mods.toml` も更新する。外部アセット/ライブラリ利用時は `THIRD_PARTY_NOTICES.md` の追記要否を確認する。
 
 ## 5. 変更フロー
 1. 変更内容を 1〜2 文で決める（何を、なぜ変えるか）。
 2. 実装する。
 3. `git diff` / `git diff --name-status` で、依頼範囲外の整形、rename、コメント削除、文字化け差分が混ざっていないことを確認する。
-4. コード、リソース、依存、datagen に影響する変更では `./gradlew.bat build` を成功させる。ドキュメントのみの変更では省略してよいが、最終報告に理由を残す。
+4. コード、リソース、依存、datagen に影響する変更では `./gradlew.bat build` を成功させる。このビルドには明らかな文字化けと UTF-8 BOM の検査も含める。ドキュメントのみの変更では省略してよいが、最終報告に理由を残す。
 5. サーバー側の登録、データ読込、レシピ、生成、GameTest 対象構造に影響する変更では `./gradlew.bat runGameTestServer` を成功させる。
 6. `main` から `1.21.1-main` への forward-port では、実装内容に関係なく `./gradlew.bat runGameTestServer` と `./gradlew.bat build` を成功させる。
 7. client 専用 UI、renderer、screen、入力操作に影響する変更では必要に応じて `./gradlew.bat runClient` で確認する。
@@ -127,9 +128,16 @@ Get-ChildItem build\libs\*.jar
 - bootstrap 詰まりを避けるため、workflow を target branch に載せる前に required check を有効化しない。手順は `docs/github-pr-protection.md` に従う。
 
 ## 9. Codex運用上の注意
+- PowerShell 5.1 などの環境では、UTF-8 の日本語ファイルでも既定の `Get-Content` 表示が文字化けすることがある。この環境差は完全には解消できないため、運用でカバーする。
 - 日本語を含むファイルは UTF-8 として読み書きし、文字化け表示が出た状態では編集しない。
+- 日本語を含むファイルを PowerShell で読む前に `[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)` を設定し、`Get-Content -Encoding UTF8` または `[System.IO.File]::ReadAllText($path, [System.Text.Encoding]::UTF8)` を使う。
+- PowerShell 5.1 では `Set-Content` / `Out-File` の既定エンコーディング書き込みを使わない。シェル経由で保存が必要な場合は UTF-8 BOM なしを明示する。
+- Python などの検証ツールが既定エンコーディングで日本語ファイルを読めない場合は、`PYTHONUTF8=1` を一時設定して UTF-8 読みを強制する。
+- 文字化け表示（例: `縺`）が見えた場合は編集を中断し、UTF-8 指定で再読込して正常表示を確認してから作業する。
+- 文字化けが疑われる場合や日本語コメント・翻訳・ドキュメントを広く触る場合は、英語で書かれた `.codex/skills/text-encoding-hygiene` を先に確認する。
 - 編集は必要最小限の差分に限定し、ファイル全体の再書き込みや無関係なコメント整理を避ける。
 - 変更後は `git diff` を確認し、依頼範囲外のコメント削除や日本語の文字化け差分があれば修正してから完了する。
+- コード、リソース、依存、datagen に影響する変更では `./gradlew.bat build` を通し、`checkTextEncodingHygiene` による明らかな文字化け検査も成功させる。
 - ユーザーが事前確認やローカルレビューを明示した作業では、明示指示があるまで push、PR 作成、リモート操作を行わない。
 
 ## 10. 直近の注意傾向

--- a/build.gradle
+++ b/build.gradle
@@ -268,9 +268,12 @@ def textEncodingHygieneExcludes = [
         'out/**',
         'run/**',
         'run-data/**',
-        // 中国語は文字化けか正しいのかチェックできなさそうなので意図的に除外.
-        'src/main/resources/assets/apprenticecodex/lang/zh_cn.json',
 ]
+
+def textEncodingMojibakeHeuristicSkips = [
+        // 中国語本文は単純な CJK 断片ヒューリスティックと衝突しやすいため、BOM/UTF-8 検査だけ行う.
+        'src/main/resources/assets/apprenticecodex/lang/zh_cn.json',
+] as Set
 
 def textEncodingHygieneRootDir = layout.projectDirectory.asFile
 def textEncodingHygieneRootPath = textEncodingHygieneRootDir.toPath()
@@ -321,9 +324,11 @@ tasks.register('checkTextEncodingHygiene') {
             }
 
             text.readLines().eachWithIndex { line, index ->
+                boolean skipMojibakeHeuristic = textEncodingMojibakeHeuristicSkips.contains(relativePath)
                 boolean hasReplacementCharacter = line.indexOf('\uFFFD') >= 0
                 int fragmentHitCount = suspiciousFragments.count { fragment -> line.contains(fragment) }
-                boolean hasLikelyMojibake = fragmentHitCount >= 2 || (fragmentHitCount >= 1 && line ==~ halfwidthKatakana)
+                boolean hasLikelyMojibake = !skipMojibakeHeuristic
+                        && (fragmentHitCount >= 2 || (fragmentHitCount >= 1 && line ==~ halfwidthKatakana))
 
                 if (hasReplacementCharacter || hasLikelyMojibake) {
                     String excerpt = line.trim()

--- a/build.gradle
+++ b/build.gradle
@@ -272,14 +272,18 @@ def textEncodingHygieneExcludes = [
         'src/main/resources/assets/apprenticecodex/lang/zh_cn.json',
 ]
 
+def textEncodingHygieneRootDir = layout.projectDirectory.asFile
+def textEncodingHygieneRootPath = textEncodingHygieneRootDir.toPath()
+def textEncodingHygieneFiles = fileTree(textEncodingHygieneRootDir) {
+    include textEncodingHygieneIncludes
+    exclude textEncodingHygieneExcludes
+}
+
 tasks.register('checkTextEncodingHygiene') {
     group = 'verification'
     description = 'Fails on UTF-8 BOMs or obvious mojibake in repository text files.'
 
-    inputs.files(fileTree(projectDir) {
-        include textEncodingHygieneIncludes
-        exclude textEncodingHygieneExcludes
-    })
+    inputs.files(textEncodingHygieneFiles)
 
     doLast {
         def failures = []
@@ -294,12 +298,9 @@ tasks.register('checkTextEncodingHygiene') {
         ]
         def halfwidthKatakana = ~/.*[\uFF66-\uFF9F].*/
 
-        fileTree(projectDir) {
-            include textEncodingHygieneIncludes
-            exclude textEncodingHygieneExcludes
-        }.files.findAll { it.isFile() }.sort { it.path }.each { file ->
+        textEncodingHygieneFiles.files.findAll { it.isFile() }.sort { it.path }.each { file ->
             byte[] bytes = file.bytes
-            String relativePath = projectDir.toPath().relativize(file.toPath()).toString().replace(File.separator, '/')
+            String relativePath = textEncodingHygieneRootPath.relativize(file.toPath()).toString().replace(File.separator, '/')
 
             if (bytes.length >= 3
                     && (bytes[0] & 0xFF) == 0xEF

--- a/build.gradle
+++ b/build.gradle
@@ -243,6 +243,110 @@ tasks.named('processResources', ProcessResources).configure {
     }
 }
 
+def textEncodingHygieneIncludes = [
+        '**/*.cfg',
+        '**/*.gradle',
+        '**/*.java',
+        '**/*.json',
+        '**/*.mcmeta',
+        '**/*.md',
+        '**/*.properties',
+        '**/*.ps1',
+        '**/*.toml',
+        '**/*.txt',
+        '**/*.yaml',
+        '**/*.yml',
+]
+
+def textEncodingHygieneExcludes = [
+        '.git/**',
+        '.gradle/**',
+        '.idea/**',
+        'build/**',
+        'bin/**',
+        'mcmodsrepo/**',
+        'out/**',
+        'run/**',
+        'run-data/**',
+        // 中国語は文字化けか正しいのかチェックできなさそうなので意図的に除外.
+        'src/main/resources/assets/apprenticecodex/lang/zh_cn.json',
+]
+
+tasks.register('checkTextEncodingHygiene') {
+    group = 'verification'
+    description = 'Fails on UTF-8 BOMs or obvious mojibake in repository text files.'
+
+    inputs.files(fileTree(projectDir) {
+        include textEncodingHygieneIncludes
+        exclude textEncodingHygieneExcludes
+    })
+
+    doLast {
+        def failures = []
+        def suspiciousFragments = [
+                '\u7E3A',
+                '\u7E67',
+                '\u7E5D',
+                '\u8B41',
+                '\u8B4C',
+                '\u873F',
+                '\u8B5B',
+        ]
+        def halfwidthKatakana = ~/.*[\uFF66-\uFF9F].*/
+
+        fileTree(projectDir) {
+            include textEncodingHygieneIncludes
+            exclude textEncodingHygieneExcludes
+        }.files.findAll { it.isFile() }.sort { it.path }.each { file ->
+            byte[] bytes = file.bytes
+            String relativePath = projectDir.toPath().relativize(file.toPath()).toString().replace(File.separator, '/')
+
+            if (bytes.length >= 3
+                    && (bytes[0] & 0xFF) == 0xEF
+                    && (bytes[1] & 0xFF) == 0xBB
+                    && (bytes[2] & 0xFF) == 0xBF) {
+                failures << "${relativePath}:1 UTF-8 BOM is not allowed"
+            }
+
+            def decoder = java.nio.charset.StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+            String text
+            try {
+                text = decoder.decode(java.nio.ByteBuffer.wrap(bytes)).toString()
+            } catch (java.nio.charset.CharacterCodingException ignored) {
+                failures << "${relativePath}:1 invalid UTF-8 byte sequence"
+                return
+            }
+
+            text.readLines().eachWithIndex { line, index ->
+                boolean hasReplacementCharacter = line.indexOf('\uFFFD') >= 0
+                int fragmentHitCount = suspiciousFragments.count { fragment -> line.contains(fragment) }
+                boolean hasLikelyMojibake = fragmentHitCount >= 2 || (fragmentHitCount >= 1 && line ==~ halfwidthKatakana)
+
+                if (hasReplacementCharacter || hasLikelyMojibake) {
+                    String excerpt = line.trim()
+                    if (excerpt.length() > 120) {
+                        excerpt = excerpt.substring(0, 120) + '...'
+                    }
+                    failures << "${relativePath}:${index + 1} possible mojibake: ${excerpt}"
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            def shownFailures = failures.take(50).join(System.lineSeparator())
+            def omittedCount = failures.size() - Math.min(failures.size(), 50)
+            def omittedMessage = omittedCount > 0 ? "${System.lineSeparator()}... and ${omittedCount} more" : ''
+            throw new GradleException("Text encoding hygiene check failed:${System.lineSeparator()}${shownFailures}${omittedMessage}")
+        }
+    }
+}
+
+tasks.named('check').configure {
+    dependsOn tasks.named('checkTextEncodingHygiene')
+}
+
 tasks.named('jar', Jar).configure {
     // GameTest 用のクラス/structure は dev 実行だけで使い、配布 jar には含めない。
     exclude('jp/aquafactory/apprenticecodex/gametest/**')

--- a/src/main/resources/assets/apprenticecodex/models/block/mage_light_torch.json
+++ b/src/main/resources/assets/apprenticecodex/models/block/mage_light_torch.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "parent": "block/block",
   "textures": {
     "particle": "minecraft:block/torch",


### PR DESCRIPTION
## 概要
- PR #476 の文字化け対策を 1.21.1-main へ forward-port
- `checkTextEncodingHygiene` を追加し、Gradle 9 の configuration cache に対応
- `mage_light_torch.json` の UTF-8 BOM を削除

## 補足
- 1.21.1-main で削除済みの `.codex/skills/forward-port-ready-development` は復活させていません
- `src` 配下の変更は `mage_light_torch.json` の BOM 削除と末尾改行補正のみです
- datagen 対象変更はないため `runData` は実行していません

## 検証
- `./gradlew.bat checkTextEncodingHygiene`
- `./gradlew.bat runGameTestServer`（343 required tests passed）
- `./gradlew.bat build`
- `git diff --check origin/1.21.1-main..HEAD`