### PR TITLE
PR #479 の意図を 1.21.1 向けに反映

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -61,6 +61,8 @@ import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeSt
 import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeStaffrifleCastEvent;
 import jp.aquafactory.apprenticecodex.item.NonDamageableAnvilMergeItem;
 import jp.aquafactory.apprenticecodex.item.RestrictedSpellImbuableItem;
+import jp.aquafactory.apprenticecodex.item.SmashcastScepter;
+import jp.aquafactory.apprenticecodex.item.smashcastscepter.SmashcastScepterAttackEvent;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastEvent;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.item.SpellcasterRoundItem;
@@ -235,8 +237,11 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.common.damagesource.DamageContainer;
 import net.neoforged.neoforge.common.util.FakePlayer;
+import net.neoforged.neoforge.event.entity.player.AttackEntityEvent;
 import net.neoforged.neoforge.event.entity.player.ItemEntityPickupEvent;
+import net.neoforged.neoforge.event.entity.living.LivingDamageEvent;
 import net.neoforged.neoforge.event.entity.living.LivingExperienceDropEvent;
 import net.neoforged.neoforge.event.level.BlockDropsEvent;
 import net.neoforged.neoforge.event.ItemAttributeModifierEvent;
@@ -538,6 +543,37 @@ public final class ApprenticeCodexGameTestScenarios {
             EnchantmentHelper.doPostAttackEffectsWithItemSource(level, target, player.damageSources().playerAttack(player), stack);
             helper.assertTrue(player.getDeltaMovement().y > 0.1D,
                     "Smashcast Scepter Wind Burst should trigger vanilla wind burst upward motion but got " + player.getDeltaMovement());
+        });
+    }
+    static void smashcastScepterSmashSetsVanillaImpulseFallProtection(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var player = new FakePlayer(level, new GameProfile(UUID.randomUUID(), "smashcast_impulse_fall_test"));
+            player.setPos(helper.absoluteVec(Vec3.atBottomCenterOf(new BlockPos(0, 3, 0))));
+            player.setOnGround(false);
+            player.fallDistance = 6.0F;
+            player.setDeltaMovement(0.12D, -0.8D, -0.08D);
+            player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(ItemRegistry.SMASHCAST_SCEPTER.get()));
+            level.addFreshEntity(player);
+
+            var target = EntityType.ARMOR_STAND.create(level);
+            helper.assertTrue(target != null, "Armor Stand target could not be created for Smashcast impulse fall test");
+            target.setPos(helper.absoluteVec(Vec3.atBottomCenterOf(new BlockPos(0, 1, 0))));
+            level.addFreshEntity(target);
+
+            SmashcastScepterAttackEvent.onAttackEntity(new AttackEntityEvent(player, target));
+            var damage = new DamageContainer(player.damageSources().playerAttack(player), 1.0F);
+            SmashcastScepterAttackEvent.onLivingDamage(new LivingDamageEvent.Post(target, damage));
+
+            helper.assertTrue(player.fallDistance == 6.0F,
+                    "Smashcast Scepter smash should preserve fall distance for vanilla impulse handling");
+            helper.assertTrue(Math.abs(player.getDeltaMovement().y - SmashcastScepter.WIND_BURST_MOTION_EPSILON) < 1.0E-6D,
+                    "Smashcast Scepter smash should apply vanilla Mace landing motion");
+            helper.assertTrue(player.isIgnoringFallDamageFromCurrentImpulse(),
+                    "Smashcast Scepter smash should enable vanilla impulse fall damage protection");
+            helper.assertTrue(player.currentImpulseImpactPos != null
+                            && player.currentImpulseImpactPos.distanceTo(player.position()) < 1.0E-6D,
+                    "Smashcast Scepter smash should record the current impulse impact position");
         });
     }
     static void searchBeaconRefundLogicOnlyRefundsWhenUnknownStructuresAreAbsent(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -218,4 +218,9 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     public static void smashcastScepterWindBurstUsesVanillaPostAttackEffect(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.smashcastScepterWindBurstUsesVanillaPostAttackEffect(helper);
     }
+
+    @GameTest(template = TEMPLATE, batch = ASSIST_WINGS_ISOLATED_BATCH)
+    public static void smashcastScepterSmashSetsVanillaImpulseFallProtection(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.smashcastScepterSmashSetsVanillaImpulseFallProtection(helper);
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
@@ -5,6 +5,8 @@ import jp.aquafactory.apprenticecodex.item.SmashcastScepter;
 import jp.aquafactory.apprenticecodex.particle.SmashcastTremorBlockParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundSource;
@@ -84,6 +86,7 @@ public final class SmashcastScepterAttackEvent {
         scepter.tryCastSmashSpell(player, stack, pending.fallDistance());
 
         event.getEntity().invulnerableTime = 0;
+        applyImpulseFallDamageProtection(player);
         applyAreaKnockback(player, event.getEntity());
         playSmashVisualEffects(player, event.getEntity(), pending.fallDistance());
         playSmashSound(player, pending.fallDistance());
@@ -125,6 +128,20 @@ public final class SmashcastScepterAttackEvent {
             PENDING_SMASHES.remove(player.serverLevel());
         }
         return pending;
+    }
+
+    public static void applyImpulseFallDamageProtection(ServerPlayer player) {
+        if (player.isIgnoringFallDamageFromCurrentImpulse() && player.currentImpulseImpactPos != null) {
+            if (player.currentImpulseImpactPos.y > player.position().y) {
+                player.currentImpulseImpactPos = player.position();
+            }
+        } else {
+            player.currentImpulseImpactPos = player.position();
+        }
+
+        player.setIgnoreFallDamageFromCurrentImpulse(true);
+        player.setDeltaMovement(player.getDeltaMovement().with(Direction.Axis.Y, SmashcastScepter.WIND_BURST_MOTION_EPSILON));
+        player.connection.send(new ClientboundSetEntityMotionPacket(player));
     }
 
     private static void applyAreaKnockback(ServerPlayer player, LivingEntity impactTarget) {


### PR DESCRIPTION
## 概要
- PR #479 の意図のみを 1.21.1 向けに反映
- 強打詠唱杖のスマッシュ成功後に、Mace と同じ impulse fall damage 保護を設定
- 1.20.1 専用の LivingFallEvent 予約キャンセル実装と Release 翻訳差分は未取り込み

## 確認
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat build`
- `runClient` はローカル確認済み（ユーザー確認）