### PR TITLE
PR #481 を 1.21.1 へ forward-port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     // 武器関連対応、特殊武器アクション(e.g. 打撃詠唱杖の魔法発動)のコード接続用に参照も含める.
     // 必要に応じてON、デフォルトは入れない(必須前提にはしないため)
     compileOnly "maven.modrinth:epic-fight:${epicfight_version}"
-    runtimeOnly "maven.modrinth:epic-fight:${epicfight_version}"
+    // runtimeOnly "maven.modrinth:epic-fight:${epicfight_version}"
 
     // Lootr.
     // TreasureDivination が Lootr の個人開封済み判定へ接続するためのコンパイル用.

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     // 武器関連対応、特殊武器アクション(e.g. 打撃詠唱杖の魔法発動)のコード接続用に参照も含める.
     // 必要に応じてON、デフォルトは入れない(必須前提にはしないため)
     compileOnly "maven.modrinth:epic-fight:${epicfight_version}"
-    // runtimeOnly "maven.modrinth:epic-fight:${epicfight_version}"
+    runtimeOnly "maven.modrinth:epic-fight:${epicfight_version}"
 
     // Lootr.
     // TreasureDivination が Lootr の個人開封済み判定へ接続するためのコンパイル用.

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
@@ -4,11 +4,19 @@ import com.mojang.blaze3d.platform.InputConstants;
 import jp.aquafactory.apprenticecodex.item.MultipurposeStaffrifle;
 import net.minecraft.client.KeyMapping;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
+import yesman.epicfight.api.event.EpicFightEventHooks;
+import yesman.epicfight.api.event.IdentifierProvider;
+import yesman.epicfight.api.event.types.player.SkillCastEvent;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.config.ItemsPreferenceScreen;
 
 public final class EpicFightClientCompat {
     public static final String MOD_ID = "epicfight";
+    private static final IdentifierProvider SMASHCAST_SCEPTER_CLIENT_EVENT_ID = IdentifierProvider.constant(
+            "apprenticecodex:smashcast_scepter_client"
+    );
+
+    private static java.util.UUID installedSmashcastScepterPlayerId;
 
     private EpicFightClientCompat() {
     }
@@ -22,8 +30,47 @@ public final class EpicFightClientCompat {
         ItemsPreferenceScreen.registerWeaponCategorizedItemClasses(MultipurposeStaffrifle.class);
     }
 
+    public static void tick() {
+        installSmashcastScepterEvents();
+    }
+
+    public static void clear() {
+        installedSmashcastScepterPlayerId = null;
+    }
+
     public static boolean matchesAttackInput(InputConstants.Type type, int value) {
         return matchesKey(EpicFightInputAction.ATTACK.keyMapping(), type, value);
+    }
+
+    @SuppressWarnings("removal")
+    private static void installSmashcastScepterEvents() {
+        var clientEngine = ClientEngine.getInstance();
+        var playerpatch = clientEngine != null ? clientEngine.getPlayerPatch() : null;
+        if (playerpatch == null || playerpatch.getOriginal() == null || !playerpatch.getOriginal().isAlive()) {
+            installedSmashcastScepterPlayerId = null;
+            return;
+        }
+
+        var playerId = playerpatch.getOriginal().getUUID();
+        if (playerId.equals(installedSmashcastScepterPlayerId)) {
+            return;
+        }
+
+        playerpatch.getEventListener().registerEvent(
+                EpicFightEventHooks.Player.CAST_SKILL,
+                EpicFightClientCompat::onSkillCast,
+                SMASHCAST_SCEPTER_CLIENT_EVENT_ID
+        );
+        installedSmashcastScepterPlayerId = playerId;
+    }
+
+    private static void onSkillCast(SkillCastEvent event) {
+        if (EpicFightSmashcastScepterCompat.shouldAllowDescendingBasicAttack(
+                event.getSkillContainer(),
+                event.getPlayerPatch().getOriginal()
+        )) {
+            event.setStateExecutable(true);
+        }
     }
 
     private static boolean matchesKey(KeyMapping keyMapping, InputConstants.Type type, int value) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightCompat.java
@@ -10,6 +10,8 @@ public final class EpicFightCompat {
             "jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightChargedTwinBladeStaffCompat";
     private static final String MULTIPURPOSE_STAFFRIFLE_COMPAT_CLASS =
             "jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightMultipurposeStaffrifleCompat";
+    private static final String SMASHCAST_SCEPTER_COMPAT_CLASS =
+            "jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightSmashcastScepterCompat";
 
     private EpicFightCompat() {
     }
@@ -22,6 +24,7 @@ public final class EpicFightCompat {
         try {
             registerCompat(CHARGED_TWIN_BLADE_STAFF_COMPAT_CLASS, modEventBus);
             registerCompat(MULTIPURPOSE_STAFFRIFLE_COMPAT_CLASS, modEventBus);
+            registerCompat(SMASHCAST_SCEPTER_COMPAT_CLASS, modEventBus);
         } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("Epic Fight 互換の初期化に失敗しました", exception);
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCapability.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCapability.java
@@ -1,0 +1,22 @@
+package jp.aquafactory.apprenticecodex.compat.epicfight;
+
+import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
+import yesman.epicfight.world.capabilities.item.CapabilityItem;
+import yesman.epicfight.world.capabilities.item.Style;
+import yesman.epicfight.world.capabilities.item.WeaponCapability;
+
+public final class EpicFightSmashcastScepterCapability extends WeaponCapability {
+    public EpicFightSmashcastScepterCapability(WeaponCapability.Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public Style getStyle(LivingEntityPatch<?> entityPatch) {
+        return CapabilityItem.Styles.ONE_HAND;
+    }
+
+    @Override
+    public boolean canHoldInOffhandAlone() {
+        return false;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
@@ -3,29 +3,45 @@ package jp.aquafactory.apprenticecodex.compat.epicfight;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.item.SmashcastScepter;
 import jp.aquafactory.apprenticecodex.item.smashcastscepter.SmashcastScepterAttackEvent;
+import jp.aquafactory.apprenticecodex.utility.RaycastTools;
+import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.registries.DeferredHolder;
+import net.neoforged.neoforge.registries.DeferredRegister;
 import yesman.epicfight.api.event.EpicFightEventHooks;
 import yesman.epicfight.api.event.IdentifierProvider;
 import yesman.epicfight.api.event.types.entity.DealDamageEvent;
 import yesman.epicfight.api.event.types.player.ComboAttackEvent;
 import yesman.epicfight.api.event.types.player.SkillCastEvent;
 import yesman.epicfight.api.event.types.registry.WeaponCapabilityPresetRegistryEvent;
+import yesman.epicfight.api.ex_cap.modules.core.data.MoveSet;
+import yesman.epicfight.api.utils.math.ValueModifier;
 import yesman.epicfight.gameasset.Animations;
+import yesman.epicfight.registry.EpicFightRegistries;
+import yesman.epicfight.skill.Skill;
 import yesman.epicfight.skill.SkillContainer;
 import yesman.epicfight.skill.SkillSlots;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
 import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.WeaponCapability;
+import yesman.epicfight.world.damagesource.EpicFightDamageTypeTags;
+import yesman.epicfight.world.damagesource.StunType;
 
+import java.util.Comparator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,8 +53,17 @@ public final class EpicFightSmashcastScepterCompat {
     public static final ResourceLocation WEAPON_TYPE_ID =
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "smashcast_scepter");
 
+    private static final DeferredRegister<Skill> SKILLS =
+            DeferredRegister.create(EpicFightRegistries.Keys.SKILL, ApprenticeCodex.MODID);
+    static final DeferredHolder<Skill, EpicFightWindLeapSkill> WIND_LEAP = SKILLS.register(
+            "wind_leap",
+            key -> EpicFightWindLeapSkill.createWindLeapBuilder().build(key)
+    );
+
     private static final ResourceLocation SWORD_TYPE_ID =
             ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "sword");
+    private static final ResourceLocation SWORD_ONE_HAND_MOVESET_ID =
+            ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "sword_1h");
     private static final IdentifierProvider SMASHCAST_SCEPTER_EVENT_ID = IdentifierProvider.constant(
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "smashcast_scepter")
     );
@@ -46,13 +71,17 @@ public final class EpicFightSmashcastScepterCompat {
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "smashcast_scepter_epicfight_attack_speed");
     private static final double DESCENDING_ATTACK_Y_VELOCITY = -0.05D;
     private static final long DESCENDING_ATTACK_CONTEXT_TICKS = 20L;
+    private static final long WIND_LEAP_CONTEXT_TICKS = 120L;
+    private static final double WIND_LEAP_AUTO_HIT_INFLATE = 0.75D;
     private static final Set<UUID> INSTALLED_PLAYERS = ConcurrentHashMap.newKeySet();
     private static final Map<UUID, DescendingAttackContext> DESCENDING_ATTACK_CONTEXTS = new ConcurrentHashMap<>();
+    private static final Map<UUID, WindLeapContext> WIND_LEAP_CONTEXTS = new ConcurrentHashMap<>();
 
     private EpicFightSmashcastScepterCompat() {
     }
 
     public static void register(IEventBus modEventBus) {
+        SKILLS.register(modEventBus);
         EpicFightEventHooks.Registry.WEAPON_CAPABILITY_PRESET.registerEvent(
                 EpicFightSmashcastScepterCompat::onWeaponCapabilityPresetRegistry,
                 "apprenticecodex:smashcast_scepter"
@@ -73,6 +102,12 @@ public final class EpicFightSmashcastScepterCompat {
         builder.styleProvider(entityPatch -> CapabilityItem.Styles.ONE_HAND);
         builder.canBePlacedOffhand(false);
         builder.weaponCombinationPredicator(entityPatch -> false);
+        builder.addMoveSet(
+                CapabilityItem.Styles.ONE_HAND,
+                MoveSet.builder()
+                        .parent(SWORD_ONE_HAND_MOVESET_ID)
+                        .addInnateSkill((stack, playerPatch) -> WIND_LEAP.get())
+        );
         builder.addStyleAttibutes(
                 CapabilityItem.Styles.ONE_HAND,
                 Attributes.ATTACK_SPEED,
@@ -115,6 +150,102 @@ public final class EpicFightSmashcastScepterCompat {
     public static void clear(ServerPlayer player) {
         INSTALLED_PLAYERS.remove(player.getUUID());
         DESCENDING_ATTACK_CONTEXTS.remove(player.getUUID());
+        WIND_LEAP_CONTEXTS.remove(player.getUUID());
+    }
+
+    public static void tick(ServerPlayer player) {
+        var context = WIND_LEAP_CONTEXTS.get(player.getUUID());
+        if (context == null) {
+            return;
+        }
+
+        var currentGameTime = player.serverLevel().getGameTime();
+        if (!player.isAlive()
+                || player.onGround()
+                || currentGameTime - context.gameTime() > WIND_LEAP_CONTEXT_TICKS
+                || !(player.getMainHandItem().getItem() instanceof SmashcastScepter)) {
+            WIND_LEAP_CONTEXTS.remove(player.getUUID());
+            return;
+        }
+
+        if (!isSmashAttack(player, player.fallDistance)) {
+            return;
+        }
+
+        findNearestWindLeapTarget(player).ifPresent(target -> {
+            WIND_LEAP_CONTEXTS.remove(player.getUUID());
+            attackWithWindLeap(player, target);
+        });
+    }
+
+    static void launchWindLeap(ServerPlayerPatch playerpatch, int chargeTicks) {
+        var player = playerpatch.getOriginal();
+        if (!(player.getMainHandItem().getItem() instanceof SmashcastScepter)) {
+            return;
+        }
+
+        var direction = resolveWindLeapDirection(playerpatch);
+        if (direction.lengthSqr() < 1.0E-6D) {
+            direction = Vec3.ZERO;
+        }
+
+        var chargeRatio = Math.min(1.0D, Math.max(0.0D, chargeTicks / (double) EpicFightWindLeapSkill.MAX_CHARGING_TICKS));
+        var upward = EpicFightWindLeapSkill.MIN_UPWARD_IMPULSE
+                + (EpicFightWindLeapSkill.MAX_UPWARD_IMPULSE - EpicFightWindLeapSkill.MIN_UPWARD_IMPULSE) * chargeRatio;
+        var horizontalSpeed = direction.lengthSqr() < 1.0E-6D ? 0.0D : estimateWindLeapHorizontalSpeed(upward);
+        var movement = direction.scale(horizontalSpeed).add(0.0D, upward, 0.0D);
+
+        player.setDeltaMovement(movement);
+        player.hasImpulse = true;
+        player.hurtMarked = true;
+        player.connection.send(new ClientboundSetEntityMotionPacket(player));
+        playerpatch.playAnimationSynchronized(Animations.BIPED_DEMOLITION_LEAP, 0.0F);
+        player.serverLevel().playSound(
+                null,
+                player.getX(),
+                player.getY(),
+                player.getZ(),
+                io.redspace.ironsspellbooks.registries.SoundRegistry.GUST_CAST.get(),
+                SoundSource.PLAYERS,
+                0.8F,
+                1.05F
+        );
+        WIND_LEAP_CONTEXTS.put(player.getUUID(), new WindLeapContext(player.serverLevel().getGameTime()));
+    }
+
+    private static Vec3 resolveWindLeapDirection(ServerPlayerPatch playerpatch) {
+        var player = playerpatch.getOriginal();
+        var target = playerpatch.getTarget();
+        if (isValidWindLeapTarget(player, target)) {
+            return horizontalDirection(player.position(), target.position());
+        }
+
+        var raycast = RaycastTools.raycastFromEye(
+                player,
+                EpicFightWindLeapSkill.TARGET_RAYCAST_DISTANCE,
+                1.25D,
+                entity -> entity instanceof LivingEntity livingEntity && isValidWindLeapTarget(player, livingEntity)
+        );
+        if (raycast.hitEntity() instanceof LivingEntity livingEntity) {
+            return horizontalDirection(player.position(), livingEntity.position());
+        }
+
+        var look = player.getLookAngle().multiply(1.0D, 0.0D, 1.0D);
+        if (look.lengthSqr() < 1.0E-6D) {
+            look = Vec3.directionFromRotation(0.0F, player.getYRot()).multiply(1.0D, 0.0D, 1.0D);
+        }
+        return look.lengthSqr() < 1.0E-6D ? Vec3.ZERO : look.normalize();
+    }
+
+    private static Vec3 horizontalDirection(Vec3 from, Vec3 to) {
+        var horizontal = to.subtract(from).multiply(1.0D, 0.0D, 1.0D);
+        return horizontal.lengthSqr() < 1.0E-6D ? Vec3.ZERO : horizontal.normalize();
+    }
+
+    private static double estimateWindLeapHorizontalSpeed(double upward) {
+        var chargeRatio = (upward - EpicFightWindLeapSkill.MIN_UPWARD_IMPULSE)
+                / (EpicFightWindLeapSkill.MAX_UPWARD_IMPULSE - EpicFightWindLeapSkill.MIN_UPWARD_IMPULSE);
+        return EpicFightWindLeapSkill.TARGET_DISTANCE * (0.075D + 0.012D * Math.max(0.0D, Math.min(1.0D, chargeRatio)));
     }
 
     private static void onSkillCast(SkillCastEvent event) {
@@ -168,6 +299,46 @@ public final class EpicFightSmashcastScepterCompat {
         }
     }
 
+    private static Optional<LivingEntity> findNearestWindLeapTarget(ServerPlayer player) {
+        var playerHitBox = player.getBoundingBox().inflate(WIND_LEAP_AUTO_HIT_INFLATE);
+        var searchArea = playerHitBox.inflate(0.5D);
+        return player.serverLevel()
+                .getEntitiesOfClass(
+                        LivingEntity.class,
+                        searchArea,
+                        target -> isValidWindLeapTarget(player, target)
+                                && target.getBoundingBox().intersects(playerHitBox)
+                )
+                .stream()
+                .min(Comparator.comparingDouble(target -> target.getBoundingBox().getCenter().distanceToSqr(player.position())));
+    }
+
+    private static boolean isValidWindLeapTarget(Player player, LivingEntity target) {
+        return target != null
+                && target != player
+                && target.isAlive()
+                && !target.isSpectator()
+                && !player.isAlliedTo(target);
+    }
+
+    private static void attackWithWindLeap(ServerPlayer player, LivingEntity target) {
+        EpicFightCapabilities.getUnparameterizedEntityPatch(player, ServerPlayerPatch.class).ifPresent(playerpatch -> {
+            DESCENDING_ATTACK_CONTEXTS.put(
+                    player.getUUID(),
+                    new DescendingAttackContext(player.serverLevel().getGameTime(), Math.max(0.0F, player.fallDistance))
+            );
+
+            // Wind Leap はスマッシュ成立のお膳立てに留め、スマッシュ効果は onDealDamagePre の既存条件でだけ発火させる。
+            var damageSource = playerpatch.getDamageSource(Animations.SWORD_AIR_SLASH, InteractionHand.MAIN_HAND)
+                    .attachArmorNegationModifier(ValueModifier.adder(50.0F))
+                    .attachImpactModifier(ValueModifier.multiplier(1.6F))
+                    .setStunType(StunType.NONE)
+                    .addRuntimeTag(EpicFightDamageTypeTags.WEAPON_INNATE);
+            playerpatch.attack(damageSource, target, InteractionHand.MAIN_HAND);
+            playerpatch.playAnimationSynchronized(Animations.SWORD_AIR_SLASH, 0.0F);
+        });
+    }
+
     public static boolean shouldAllowDescendingBasicAttack(SkillContainer skillContainer, Player player) {
         return skillContainer != null
                 && skillContainer.getSlot() == SkillSlots.BASIC_ATTACK
@@ -205,5 +376,8 @@ public final class EpicFightSmashcastScepterCompat {
     }
 
     private record DescendingAttackContext(long gameTime, float fallDistance) {
+    }
+
+    private record WindLeapContext(long gameTime) {
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
@@ -1,0 +1,209 @@
+package jp.aquafactory.apprenticecodex.compat.epicfight;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.SmashcastScepter;
+import jp.aquafactory.apprenticecodex.item.smashcastscepter.SmashcastScepterAttackEvent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.neoforged.bus.api.IEventBus;
+import yesman.epicfight.api.event.EpicFightEventHooks;
+import yesman.epicfight.api.event.IdentifierProvider;
+import yesman.epicfight.api.event.types.entity.DealDamageEvent;
+import yesman.epicfight.api.event.types.player.ComboAttackEvent;
+import yesman.epicfight.api.event.types.player.SkillCastEvent;
+import yesman.epicfight.api.event.types.registry.WeaponCapabilityPresetRegistryEvent;
+import yesman.epicfight.gameasset.Animations;
+import yesman.epicfight.skill.SkillContainer;
+import yesman.epicfight.skill.SkillSlots;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
+import yesman.epicfight.world.capabilities.item.CapabilityItem;
+import yesman.epicfight.world.capabilities.item.WeaponCapability;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+// リフレクションで参照するため、IDE側の未使用検知を無効化.
+@SuppressWarnings("unused")
+public final class EpicFightSmashcastScepterCompat {
+    public static final String MOD_ID = "epicfight";
+    public static final ResourceLocation WEAPON_TYPE_ID =
+            ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "smashcast_scepter");
+
+    private static final ResourceLocation SWORD_TYPE_ID =
+            ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "sword");
+    private static final IdentifierProvider SMASHCAST_SCEPTER_EVENT_ID = IdentifierProvider.constant(
+            ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "smashcast_scepter")
+    );
+    private static final ResourceLocation EPIC_FIGHT_ATTACK_SPEED_MODIFIER_ID =
+            ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "smashcast_scepter_epicfight_attack_speed");
+    private static final double DESCENDING_ATTACK_Y_VELOCITY = -0.05D;
+    private static final long DESCENDING_ATTACK_CONTEXT_TICKS = 20L;
+    private static final Set<UUID> INSTALLED_PLAYERS = ConcurrentHashMap.newKeySet();
+    private static final Map<UUID, DescendingAttackContext> DESCENDING_ATTACK_CONTEXTS = new ConcurrentHashMap<>();
+
+    private EpicFightSmashcastScepterCompat() {
+    }
+
+    public static void register(IEventBus modEventBus) {
+        EpicFightEventHooks.Registry.WEAPON_CAPABILITY_PRESET.registerEvent(
+                EpicFightSmashcastScepterCompat::onWeaponCapabilityPresetRegistry,
+                "apprenticecodex:smashcast_scepter"
+        );
+    }
+
+    private static void onWeaponCapabilityPresetRegistry(WeaponCapabilityPresetRegistryEvent event) {
+        event.getTypeEntry().put(WEAPON_TYPE_ID, item -> buildCapability(event, item));
+    }
+
+    private static CapabilityItem.Builder<?> buildCapability(WeaponCapabilityPresetRegistryEvent event, Item item) {
+        var swordFactory = event.getTypeEntry().get(SWORD_TYPE_ID);
+        var builder = swordFactory != null
+                ? (WeaponCapability.Builder) swordFactory.apply(item)
+                : WeaponCapability.builder();
+
+        builder.constructor(EpicFightSmashcastScepterCapability::new);
+        builder.styleProvider(entityPatch -> CapabilityItem.Styles.ONE_HAND);
+        builder.canBePlacedOffhand(false);
+        builder.weaponCombinationPredicator(entityPatch -> false);
+        builder.addStyleAttibutes(
+                CapabilityItem.Styles.ONE_HAND,
+                Attributes.ATTACK_SPEED,
+                new AttributeModifier(
+                        EPIC_FIGHT_ATTACK_SPEED_MODIFIER_ID,
+                        1.0D,
+                        AttributeModifier.Operation.ADD_VALUE
+                )
+        );
+
+        return builder;
+    }
+
+    public static void install(ServerPlayer player) {
+        if (!player.isAlive() || INSTALLED_PLAYERS.contains(player.getUUID())) {
+            return;
+        }
+
+        EpicFightCapabilities.getUnparameterizedEntityPatch(player, ServerPlayerPatch.class).ifPresent(playerpatch -> {
+            // 下降中の基本攻撃は Epic Fight 標準では弾かれるため、SmashcastScepter 装備時だけ入力を通す。
+            playerpatch.getEventListener().registerEvent(
+                    EpicFightEventHooks.Player.CAST_SKILL,
+                    EpicFightSmashcastScepterCompat::onSkillCast,
+                    SMASHCAST_SCEPTER_EVENT_ID
+            );
+            playerpatch.getEventListener().registerEvent(
+                    EpicFightEventHooks.Player.COMBO_ATTACK,
+                    EpicFightSmashcastScepterCompat::onComboAttack,
+                    SMASHCAST_SCEPTER_EVENT_ID
+            );
+            playerpatch.getEventListener().registerEvent(
+                    EpicFightEventHooks.Entity.DELIVER_DAMAGE_PRE,
+                    EpicFightSmashcastScepterCompat::onDealDamagePre,
+                    SMASHCAST_SCEPTER_EVENT_ID
+            );
+            INSTALLED_PLAYERS.add(player.getUUID());
+        });
+    }
+
+    public static void clear(ServerPlayer player) {
+        INSTALLED_PLAYERS.remove(player.getUUID());
+        DESCENDING_ATTACK_CONTEXTS.remove(player.getUUID());
+    }
+
+    private static void onSkillCast(SkillCastEvent event) {
+        var player = event.getPlayerPatch().getOriginal();
+        if (shouldAllowDescendingBasicAttack(event.getSkillContainer(), player)) {
+            event.setStateExecutable(true);
+        }
+    }
+
+    private static void onComboAttack(ComboAttackEvent event) {
+        var playerpatch = event.getPlayerPatch();
+        if (!isDescendingSmashcastAttack(playerpatch.getOriginal())) {
+            return;
+        }
+
+        // ComboAttack 本体は下降中を air attack として扱わないため、ここで片手剣標準の空中攻撃へ差し替える。
+        var player = playerpatch.getOriginal();
+        var fallDistance = Math.max(0.0F, player.fallDistance);
+        DESCENDING_ATTACK_CONTEXTS.put(
+                player.getUUID(),
+                new DescendingAttackContext(player.serverLevel().getGameTime(), fallDistance)
+        );
+        event.cancel();
+        playerpatch.playAnimationSynchronized(Animations.SWORD_AIR_SLASH, 0.0F);
+    }
+
+    private static void onDealDamagePre(DealDamageEvent.Pre event) {
+        if (!(event.getEntityPatch() instanceof ServerPlayerPatch playerpatch)) {
+            return;
+        }
+
+        var player = playerpatch.getOriginal();
+        if (!(player.getMainHandItem().getItem() instanceof SmashcastScepter)) {
+            return;
+        }
+
+        var storedFallDistance = consumeStoredFallDistance(player);
+        var effectiveFallDistance = Math.max(player.fallDistance, storedFallDistance);
+        if (!isSmashAttack(player, effectiveFallDistance)) {
+            return;
+        }
+
+        var bonusDamage = SmashcastScepterAttackEvent.registerEpicFightSmashcastImpact(
+                player,
+                event.getTarget(),
+                event.getDamageSource(),
+                effectiveFallDistance
+        );
+        if (bonusDamage > 0.0F) {
+            event.setModifiedDamage(event.getModifiedDamage() + bonusDamage);
+        }
+    }
+
+    public static boolean shouldAllowDescendingBasicAttack(SkillContainer skillContainer, Player player) {
+        return skillContainer != null
+                && skillContainer.getSlot() == SkillSlots.BASIC_ATTACK
+                && isDescendingSmashcastAttack(player);
+    }
+
+    private static boolean isDescendingSmashcastAttack(Player player) {
+        return player != null
+                && player.getMainHandItem().getItem() instanceof SmashcastScepter
+                && !player.onGround()
+                && !player.isFallFlying()
+                && !player.isInWater()
+                && !player.hasEffect(MobEffects.SLOW_FALLING)
+                && player.getDeltaMovement().y < DESCENDING_ATTACK_Y_VELOCITY;
+    }
+
+    private static float consumeStoredFallDistance(ServerPlayer player) {
+        var context = DESCENDING_ATTACK_CONTEXTS.remove(player.getUUID());
+        if (context == null) {
+            return 0.0F;
+        }
+        if (player.serverLevel().getGameTime() - context.gameTime() > DESCENDING_ATTACK_CONTEXT_TICKS) {
+            return 0.0F;
+        }
+        return context.fallDistance();
+    }
+
+    private static boolean isSmashAttack(Player player, float fallDistance) {
+        return player != null
+                && fallDistance > SmashcastScepter.SMASH_ATTACK_FALL_DISTANCE_THRESHOLD
+                && !player.onGround()
+                && !player.isFallFlying()
+                && !player.isInWater()
+                && !player.hasEffect(MobEffects.SLOW_FALLING);
+    }
+
+    private record DescendingAttackContext(long gameTime, float fallDistance) {
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
@@ -341,7 +341,7 @@ public final class EpicFightSmashcastScepterCompat {
 
     public static boolean shouldAllowDescendingBasicAttack(SkillContainer skillContainer, Player player) {
         return skillContainer != null
-                && skillContainer.getSlot() == SkillSlots.BASIC_ATTACK
+                && skillContainer.getSlot() == SkillSlots.COMBO_ATTACKS
                 && isDescendingSmashcastAttack(player);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightWindLeapSkill.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightWindLeapSkill.java
@@ -22,7 +22,7 @@ public final class EpicFightWindLeapSkill extends WeaponInnateSkill implements C
     static final double TARGET_DISTANCE = 2.0D;
     static final double TARGET_RAYCAST_DISTANCE = 8.0D;
     static final double MIN_UPWARD_IMPULSE = 1.0D;
-    static final double MAX_UPWARD_IMPULSE = SmashcastScepter.calculateReleaseBounceImpulse(1);
+    static final double MAX_UPWARD_IMPULSE = 1.2D;
 
     public EpicFightWindLeapSkill(WeaponInnateSkill.Builder<?> builder) {
         super(builder);

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightWindLeapSkill.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightWindLeapSkill.java
@@ -1,0 +1,99 @@
+package jp.aquafactory.apprenticecodex.compat.epicfight;
+
+import jp.aquafactory.apprenticecodex.item.SmashcastScepter;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.resources.ResourceLocation;
+import yesman.epicfight.client.input.EpicFightKeyMappings;
+import yesman.epicfight.gameasset.Animations;
+import yesman.epicfight.network.server.SPSkillFeedback;
+import yesman.epicfight.skill.Skill;
+import yesman.epicfight.skill.SkillContainer;
+import yesman.epicfight.skill.modules.ChargeableSkill;
+import yesman.epicfight.skill.weaponinnate.WeaponInnateSkill;
+import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
+
+public final class EpicFightWindLeapSkill extends WeaponInnateSkill implements ChargeableSkill {
+    private static final ResourceLocation SKILL_TEXTURE =
+            ResourceLocation.fromNamespaceAndPath("epicfight", "textures/gui/skills/weapon_innate/sweeping_edge.png");
+
+    static final int MIN_CHARGING_TICKS = 0;
+    static final int MAX_CHARGING_TICKS = 30;
+    static final int ALLOWED_MAX_CHARGING_TICKS = 60;
+    static final double TARGET_DISTANCE = 2.0D;
+    static final double TARGET_RAYCAST_DISTANCE = 8.0D;
+    static final double MIN_UPWARD_IMPULSE = 1.0D;
+    static final double MAX_UPWARD_IMPULSE = SmashcastScepter.calculateReleaseBounceImpulse(1);
+
+    public EpicFightWindLeapSkill(WeaponInnateSkill.Builder<?> builder) {
+        super(builder);
+    }
+
+    public static WeaponInnateSkill.Builder<?> createWindLeapBuilder() {
+        return WeaponInnateSkill.createWeaponInnateBuilder(EpicFightWindLeapSkill::new)
+                .setActivateType(Skill.ActivateType.HELD)
+                .setResource(Skill.Resource.WEAPON_CHARGE);
+    }
+
+    @Override
+    public boolean isExecutableState(PlayerPatch<?> playerpatch) {
+        return super.isExecutableState(playerpatch)
+                && playerpatch.getOriginal().onGround()
+                && playerpatch.getOriginal().getMainHandItem().getItem() instanceof SmashcastScepter;
+    }
+
+    @Override
+    public void startHolding(SkillContainer skillContainer) {
+        var playerpatch = skillContainer.getExecutor();
+        if (!playerpatch.isLogicalClient()) {
+            playerpatch.playAnimationSynchronized(Animations.STEEL_WHIRLWIND_CHARGING, 0.0F);
+        }
+    }
+
+    @Override
+    public void resetHolding(SkillContainer skillContainer) {
+        var playerpatch = skillContainer.getExecutor();
+        if (playerpatch.isLogicalClient()) {
+            playerpatch.getAnimator().stopPlaying(Animations.STEEL_WHIRLWIND_CHARGING);
+        } else {
+            playerpatch.stopPlaying(Animations.STEEL_WHIRLWIND_CHARGING);
+        }
+    }
+
+    @Override
+    public void onStopHolding(SkillContainer skillContainer, SPSkillFeedback feedback) {
+        var playerpatch = skillContainer.getServerExecutor();
+        var chargeTicks = Math.min(playerpatch.getAccumulatedChargeTicks(), getMaxChargingTicks());
+        EpicFightSmashcastScepterCompat.launchWindLeap(playerpatch, Math.max(0, chargeTicks));
+        cancelOnServer(skillContainer, null);
+    }
+
+    @Override
+    public int getAllowedMaxChargingTicks() {
+        return ALLOWED_MAX_CHARGING_TICKS;
+    }
+
+    @Override
+    public int getMaxChargingTicks() {
+        return MAX_CHARGING_TICKS;
+    }
+
+    @Override
+    public int getMinChargingTicks() {
+        return MIN_CHARGING_TICKS;
+    }
+
+    @Override
+    public void holdTick(SkillContainer skillContainer) {
+        ChargeableSkill.super.holdTick(skillContainer);
+    }
+
+    @Override
+    public KeyMapping getKeyMapping() {
+        return EpicFightKeyMappings.WEAPON_INNATE_SKILL;
+    }
+
+    @Override
+    public ResourceLocation getSkillTexture() {
+        return SKILL_TEXTURE;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientEpicFightCompatEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientEpicFightCompatEvents.java
@@ -1,0 +1,32 @@
+package jp.aquafactory.apprenticecodex.event.client;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightClientCompat;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+
+@EventBusSubscriber(modid = ApprenticeCodex.MODID, value = Dist.CLIENT)
+public final class ClientEpicFightCompatEvents {
+    private ClientEpicFightCompatEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onClientTick(ClientTickEvent.Post event) {
+        if (!ModList.get().isLoaded(EpicFightClientCompat.MOD_ID)) {
+            return;
+        }
+
+        EpicFightClientCompat.tick();
+    }
+
+    @SubscribeEvent
+    public static void onClientLoggedOut(ClientPlayerNetworkEvent.LoggingOut event) {
+        if (ModList.get().isLoaded(EpicFightClientCompat.MOD_ID)) {
+            EpicFightClientCompat.clear();
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -535,6 +535,11 @@ public final class ApprenticeCodexGameTestScenarios {
             target.setPos(helper.absoluteVec(Vec3.atBottomCenterOf(new BlockPos(0, 1, 0))));
             level.addFreshEntity(target);
 
+            var secondTarget = EntityType.ARMOR_STAND.create(level);
+            helper.assertTrue(secondTarget != null, "Second Armor Stand target could not be created for Smashcast Wind Burst test");
+            secondTarget.setPos(helper.absoluteVec(Vec3.atBottomCenterOf(new BlockPos(1, 1, 0))));
+            level.addFreshEntity(secondTarget);
+
             var stack = new ItemStack(ItemRegistry.SMASHCAST_SCEPTER.get());
             var windBurst = level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT)
                     .getOrThrow(net.minecraft.world.item.enchantment.Enchantments.WIND_BURST);
@@ -547,16 +552,36 @@ public final class ApprenticeCodexGameTestScenarios {
             player.setItemInHand(InteractionHand.MAIN_HAND, stack);
             player.fallDistance = 0.0F;
             player.setDeltaMovement(Vec3.ZERO);
-            SmashcastScepterAttackEvent.registerEpicFightSmashcastImpact(
+            var firstEpicFightBonus = SmashcastScepterAttackEvent.registerEpicFightSmashcastImpact(
                     player,
                     target,
                     player.damageSources().playerAttack(player),
                     4.0F
             );
+            helper.assertTrue(firstEpicFightBonus > 0.0F,
+                    "Epic Fight Smashcast should apply bonus damage to the first target");
             helper.assertTrue(player.fallDistance == 0.0F,
                     "Epic Fight Smashcast Wind Burst should restore the player's original fall distance");
             helper.assertTrue(player.getDeltaMovement().y > 0.1D,
                     "Epic Fight Smashcast Wind Burst should use the stored fall distance but got " + player.getDeltaMovement());
+
+            var duplicateEpicFightBonus = SmashcastScepterAttackEvent.registerEpicFightSmashcastImpact(
+                    player,
+                    target,
+                    player.damageSources().playerAttack(player),
+                    4.0F
+            );
+            helper.assertTrue(duplicateEpicFightBonus == 0.0F,
+                    "Epic Fight Smashcast should not apply duplicate bonus damage to the same target in one tick");
+
+            var secondEpicFightBonus = SmashcastScepterAttackEvent.registerEpicFightSmashcastImpact(
+                    player,
+                    secondTarget,
+                    player.damageSources().playerAttack(player),
+                    4.0F
+            );
+            helper.assertTrue(secondEpicFightBonus > 0.0F,
+                    "Epic Fight Smashcast should keep bonus damage for a different target in the same tick");
         });
     }
     static void smashcastScepterSmashSetsVanillaImpulseFallProtection(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -543,6 +543,20 @@ public final class ApprenticeCodexGameTestScenarios {
             EnchantmentHelper.doPostAttackEffectsWithItemSource(level, target, player.damageSources().playerAttack(player), stack);
             helper.assertTrue(player.getDeltaMovement().y > 0.1D,
                     "Smashcast Scepter Wind Burst should trigger vanilla wind burst upward motion but got " + player.getDeltaMovement());
+
+            player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+            player.fallDistance = 0.0F;
+            player.setDeltaMovement(Vec3.ZERO);
+            SmashcastScepterAttackEvent.registerEpicFightSmashcastImpact(
+                    player,
+                    target,
+                    player.damageSources().playerAttack(player),
+                    4.0F
+            );
+            helper.assertTrue(player.fallDistance == 0.0F,
+                    "Epic Fight Smashcast Wind Burst should restore the player's original fall distance");
+            helper.assertTrue(player.getDeltaMovement().y > 0.1D,
+                    "Epic Fight Smashcast Wind Burst should use the stored fall distance but got " + player.getDeltaMovement());
         });
     }
     static void smashcastScepterSmashSetsVanillaImpulseFallProtection(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
@@ -135,7 +135,10 @@ public final class SmashcastScepterAttackEvent {
 
     @SubscribeEvent
     public static void onLevelTick(LevelTickEvent.Post event) {
-        var serverLevel = event.getLevel();
+        if (!(event.getLevel() instanceof ServerLevel serverLevel)) {
+            return;
+        }
+
         var smashes = PENDING_SMASHES.get(serverLevel);
         if (smashes == null || smashes.isEmpty()) {
             cleanupEpicFightSmashcastImpacts(serverLevel);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
@@ -35,7 +35,8 @@ import java.util.WeakHashMap;
 @EventBusSubscriber(modid = ApprenticeCodex.MODID)
 public final class SmashcastScepterAttackEvent {
     private static final Map<ServerLevel, Map<UUID, PendingSmash>> PENDING_SMASHES = new WeakHashMap<>();
-    private static final Map<ServerLevel, Map<UUID, Long>> EPIC_FIGHT_SMASHCAST_IMPACT_TICKS = new WeakHashMap<>();
+    private static final Map<ServerLevel, Map<UUID, Long>> EPIC_FIGHT_SMASHCAST_EFFECT_TICKS = new WeakHashMap<>();
+    private static final Map<ServerLevel, Map<EpicFightSmashcastImpactKey, Long>> EPIC_FIGHT_SMASHCAST_DAMAGE_TICKS = new WeakHashMap<>();
     private static final int MACE_SMASH_LEVEL_EVENT = 2013;
     private static final int MACE_SMASH_LEVEL_EVENT_DATA = 750;
     private static final int TREMOR_BLOCK_LIMIT = 16;
@@ -94,10 +95,18 @@ public final class SmashcastScepterAttackEvent {
 
         var level = player.serverLevel();
         var gameTime = level.getGameTime();
-        var lastImpactTick = EPIC_FIGHT_SMASHCAST_IMPACT_TICKS
+        var impactKey = new EpicFightSmashcastImpactKey(player.getUUID(), target.getUUID());
+        var lastDamageTick = EPIC_FIGHT_SMASHCAST_DAMAGE_TICKS
+                .computeIfAbsent(level, ignored -> new HashMap<>())
+                .put(impactKey, gameTime);
+        if (lastDamageTick != null && lastDamageTick == gameTime) {
+            return 0.0F;
+        }
+
+        var lastEffectTick = EPIC_FIGHT_SMASHCAST_EFFECT_TICKS
                 .computeIfAbsent(level, ignored -> new HashMap<>())
                 .put(player.getUUID(), gameTime);
-        if (lastImpactTick != null && lastImpactTick == gameTime) {
+        if (lastEffectTick != null && lastEffectTick == gameTime) {
             return bonusDamage;
         }
 
@@ -156,15 +165,20 @@ public final class SmashcastScepterAttackEvent {
     }
 
     private static void cleanupEpicFightSmashcastImpacts(ServerLevel serverLevel) {
-        var impacts = EPIC_FIGHT_SMASHCAST_IMPACT_TICKS.get(serverLevel);
-        if (impacts == null || impacts.isEmpty()) {
+        var expireBefore = serverLevel.getGameTime() - 1L;
+        cleanupTickMap(EPIC_FIGHT_SMASHCAST_EFFECT_TICKS, serverLevel, expireBefore);
+        cleanupTickMap(EPIC_FIGHT_SMASHCAST_DAMAGE_TICKS, serverLevel, expireBefore);
+    }
+
+    private static <T> void cleanupTickMap(Map<ServerLevel, Map<T, Long>> tickMaps, ServerLevel serverLevel, long expireBefore) {
+        var ticks = tickMaps.get(serverLevel);
+        if (ticks == null || ticks.isEmpty()) {
             return;
         }
 
-        var expireBefore = serverLevel.getGameTime() - 1L;
-        impacts.entrySet().removeIf(entry -> entry.getValue() < expireBefore);
-        if (impacts.isEmpty()) {
-            EPIC_FIGHT_SMASHCAST_IMPACT_TICKS.remove(serverLevel);
+        ticks.entrySet().removeIf(entry -> entry.getValue() < expireBefore);
+        if (ticks.isEmpty()) {
+            tickMaps.remove(serverLevel);
         }
     }
 
@@ -328,5 +342,8 @@ public final class SmashcastScepterAttackEvent {
         private boolean matches(LivingEntity target, long currentGameTime) {
             return target.getUUID().equals(targetUuid) && currentGameTime - gameTime <= 1L;
         }
+    }
+
+    private record EpicFightSmashcastImpactKey(UUID playerUuid, UUID targetUuid) {
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
@@ -15,6 +15,7 @@ import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -104,6 +105,7 @@ public final class SmashcastScepterAttackEvent {
         scepter.tryCastSmashSpell(player, stack, effectiveFallDistance);
         target.invulnerableTime = 0;
         applyImpulseFallDamageProtection(player);
+        applyEpicFightPostAttackEnchantmentEffects(player, target, source, stack, effectiveFallDistance);
         applyAreaKnockback(player, target);
         playSmashVisualEffects(player, target, effectiveFallDistance);
         playSmashSound(player, effectiveFallDistance);
@@ -201,6 +203,22 @@ public final class SmashcastScepterAttackEvent {
         player.setIgnoreFallDamageFromCurrentImpulse(true);
         player.setDeltaMovement(player.getDeltaMovement().with(Direction.Axis.Y, SmashcastScepter.WIND_BURST_MOTION_EPSILON));
         player.connection.send(new ClientboundSetEntityMotionPacket(player));
+    }
+
+    private static void applyEpicFightPostAttackEnchantmentEffects(
+            ServerPlayer player,
+            LivingEntity target,
+            DamageSource source,
+            ItemStack stack,
+            float fallDistance
+    ) {
+        var originalFallDistance = player.fallDistance;
+        player.fallDistance = Math.max(originalFallDistance, fallDistance);
+        try {
+            EnchantmentHelper.doPostAttackEffectsWithItemSource(player.serverLevel(), target, source, stack);
+        } finally {
+            player.fallDistance = originalFallDistance;
+        }
     }
 
     private static void applyAreaKnockback(ServerPlayer player, LivingEntity impactTarget) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterAttackEvent.java
@@ -10,6 +10,7 @@ import net.minecraft.network.protocol.game.ClientboundSetEntityMotionPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
@@ -33,6 +34,7 @@ import java.util.WeakHashMap;
 @EventBusSubscriber(modid = ApprenticeCodex.MODID)
 public final class SmashcastScepterAttackEvent {
     private static final Map<ServerLevel, Map<UUID, PendingSmash>> PENDING_SMASHES = new WeakHashMap<>();
+    private static final Map<ServerLevel, Map<UUID, Long>> EPIC_FIGHT_SMASHCAST_IMPACT_TICKS = new WeakHashMap<>();
     private static final int MACE_SMASH_LEVEL_EVENT = 2013;
     private static final int MACE_SMASH_LEVEL_EVENT_DATA = 750;
     private static final int TREMOR_BLOCK_LIMIT = 16;
@@ -69,6 +71,45 @@ public final class SmashcastScepterAttackEvent {
         return stack.getItem() instanceof SmashcastScepter scepter && scepter.canStartSmashcast(player, stack);
     }
 
+    public static float registerEpicFightSmashcastImpact(
+            ServerPlayer player,
+            LivingEntity target,
+            DamageSource source,
+            float fallDistance
+    ) {
+        var stack = player.getMainHandItem();
+        if (!(stack.getItem() instanceof SmashcastScepter scepter)) {
+            return 0.0F;
+        }
+
+        var effectiveFallDistance = Math.max(0.0F, fallDistance);
+        var bonusDamage = SmashcastScepter.calculateSmashBonusDamage(
+                stack,
+                effectiveFallDistance,
+                player.serverLevel(),
+                target,
+                source
+        );
+
+        var level = player.serverLevel();
+        var gameTime = level.getGameTime();
+        var lastImpactTick = EPIC_FIGHT_SMASHCAST_IMPACT_TICKS
+                .computeIfAbsent(level, ignored -> new HashMap<>())
+                .put(player.getUUID(), gameTime);
+        if (lastImpactTick != null && lastImpactTick == gameTime) {
+            return bonusDamage;
+        }
+
+        scepter.triggerSmashAnimation(player, stack);
+        scepter.tryCastSmashSpell(player, stack, effectiveFallDistance);
+        target.invulnerableTime = 0;
+        applyImpulseFallDamageProtection(player);
+        applyAreaKnockback(player, target);
+        playSmashVisualEffects(player, target, effectiveFallDistance);
+        playSmashSound(player, effectiveFallDistance);
+        return bonusDamage;
+    }
+
     @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onLivingDamage(LivingDamageEvent.Post event) {
         var player = resolveDirectPlayerAttack(event.getSource());
@@ -97,6 +138,7 @@ public final class SmashcastScepterAttackEvent {
         var serverLevel = event.getLevel();
         var smashes = PENDING_SMASHES.get(serverLevel);
         if (smashes == null || smashes.isEmpty()) {
+            cleanupEpicFightSmashcastImpacts(serverLevel);
             return;
         }
 
@@ -104,6 +146,20 @@ public final class SmashcastScepterAttackEvent {
         smashes.entrySet().removeIf(uuidPendingSmashEntry -> uuidPendingSmashEntry.getValue().gameTime() < expireBefore);
         if (smashes.isEmpty()) {
             PENDING_SMASHES.remove(serverLevel);
+        }
+        cleanupEpicFightSmashcastImpacts(serverLevel);
+    }
+
+    private static void cleanupEpicFightSmashcastImpacts(ServerLevel serverLevel) {
+        var impacts = EPIC_FIGHT_SMASHCAST_IMPACT_TICKS.get(serverLevel);
+        if (impacts == null || impacts.isEmpty()) {
+            return;
+        }
+
+        var expireBefore = serverLevel.getGameTime() - 1L;
+        impacts.entrySet().removeIf(entry -> entry.getValue() < expireBefore);
+        if (impacts.isEmpty()) {
+            EPIC_FIGHT_SMASHCAST_IMPACT_TICKS.remove(serverLevel);
         }
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterEpicFightEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterEpicFightEvents.java
@@ -1,0 +1,44 @@
+package jp.aquafactory.apprenticecodex.item.smashcastscepter;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightSmashcastScepterCompat;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
+
+@EventBusSubscriber(modid = ApprenticeCodex.MODID)
+public final class SmashcastScepterEpicFightEvents {
+    private SmashcastScepterEpicFightEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(PlayerTickEvent.Post event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+        if (!ModList.get().isLoaded(EpicFightSmashcastScepterCompat.MOD_ID)) {
+            return;
+        }
+
+        EpicFightSmashcastScepterCompat.install(player);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player
+                && ModList.get().isLoaded(EpicFightSmashcastScepterCompat.MOD_ID)) {
+            EpicFightSmashcastScepterCompat.clear(player);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerClone(PlayerEvent.Clone event) {
+        if (event.getOriginal() instanceof ServerPlayer player
+                && ModList.get().isLoaded(EpicFightSmashcastScepterCompat.MOD_ID)) {
+            EpicFightSmashcastScepterCompat.clear(player);
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterEpicFightEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/smashcastscepter/SmashcastScepterEpicFightEvents.java
@@ -24,6 +24,7 @@ public final class SmashcastScepterEpicFightEvents {
         }
 
         EpicFightSmashcastScepterCompat.install(player);
+        EpicFightSmashcastScepterCompat.tick(player);
     }
 
     @SubscribeEvent

--- a/src/main/resources/assets/apprenticecodex/item_skins/mana_force_blade.json
+++ b/src/main/resources/assets/apprenticecodex/item_skins/mana_force_blade.json
@@ -14,10 +14,10 @@
     ],
     "end_pos": [
       0.0,
-      -0.22,
-      -1.25
+      -0.32,
+      -1.8
     ],
-    "lifetime": 3,
+    "lifetime": 4,
     "interpolations": 6,
     "texture_path": "epicfight:textures/particle/swing_trail.png",
     "particle_type": "epicfight:swing_trail"

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -425,6 +425,8 @@
   "jade.apprenticecodex.healing_bloom.next_fruit": "Next fruit in: %1$d s",
   "jade.apprenticecodex.remaining_ammo": "Remaining ammo: %1$d",
   "jade.apprenticecodex.search_beacon.targets": "Targets: %1$s",
+  "skill.apprenticecodex.wind_leap": "Wind Leap",
+  "skill.apprenticecodex.wind_leap.tooltip": "Leap high enough to prepare a smash, then strike just before landing. The leap itself does not protect you from falling.",
   "spell.apprenticecodex.sky_edge": "Sky Edge",
   "spell.apprenticecodex.archer_multiple": "Archer Multiple",
   "spell.apprenticecodex.commence_fire": "Commence Fire",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -433,6 +433,9 @@
   "jade.apprenticecodex.remaining_ammo": "残り弾数: %1$d",
   "jade.apprenticecodex.search_beacon.targets": "探索対象: %1$s",
 
+  "skill.apprenticecodex.wind_leap": "ウィンドリープ",
+  "skill.apprenticecodex.wind_leap.tooltip": "強打を行えるほど高く跳躍し、着地寸前に殴打を行う。この跳躍自体が落下を保護することはない。",
+
   "spell.apprenticecodex.sky_edge": "スカイエッジ",
   "spell.apprenticecodex.archer_multiple": "アーチャーオプション",
   "spell.apprenticecodex.commence_fire": "コメンスファイア",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -425,6 +425,8 @@
   "jade.apprenticecodex.healing_bloom.next_fruit": "下次结果：%1$d 秒",
   "jade.apprenticecodex.remaining_ammo": "剩余弹药：%1$d",
   "jade.apprenticecodex.search_beacon.targets": "目标：%1$s",
+  "skill.apprenticecodex.wind_leap": "风跃",
+  "skill.apprenticecodex.wind_leap.tooltip": "高高跃起以准备强打，并在即将落地时进行殴打。此次跳跃本身不会保护你免受坠落伤害。",
   "spell.apprenticecodex.sky_edge": "天穹之刃",
   "spell.apprenticecodex.archer_multiple": "多重魔弓",
   "spell.apprenticecodex.commence_fire": "开火指令",

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/smashcast_scepter.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/smashcast_scepter.json
@@ -1,0 +1,6 @@
+{
+  "type": "epicfight:sword",
+  "hit_particle": "epicfight:hit_blunt",
+  "hit_sound": "epicfight:entity.hit.blunt",
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/smashcast_scepter.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/smashcast_scepter.json
@@ -1,5 +1,5 @@
 {
-  "type": "epicfight:sword",
+  "type": "apprenticecodex:smashcast_scepter",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
   "swing_sound": "epicfight:entity.weapon.whoosh_rod"

--- a/src/main/resources/data/apprenticecodex/skill_parameters/wind_leap.json
+++ b/src/main/resources/data/apprenticecodex/skill_parameters/wind_leap.json
@@ -1,0 +1,3 @@
+{
+  "consumption": 24.0
+}


### PR DESCRIPTION
## 概要
- PR #481 の Epic Fight 対応を `1.21.1-main` 向けに forward-port しました。
- Smashcast Scepter の Epic Fight weapon capability / innate skill / 下降中攻撃接続を 1.21.1 API に合わせました。
- 動作確認で見つかった 1.21.1 特有の Wind Burst 不発を補正しました。
- 確認後、Epic Fight の `runtimeOnly` はコメントアウト済みです。

## 補足
- 1.20.1 側の Release エンチャントでも同様に発生する既存不具合は、forward-port 起因ではないためこの PR では扱いません。
- `tmp/_ItemStack.java` は ignored かつ encoding hygiene check の妨げになっていたため削除しました（tracked 差分なし）。

## 検証
- `./gradlew.bat compileJava`
- `./gradlew.bat runGameTestServer`（344 required tests passed）
- `./gradlew.bat build`