### PR TITLE
Wind Leap自動命中後の打ち上げを維持

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
@@ -318,13 +318,14 @@ public final class EpicFightSmashcastScepterCompat {
             );
 
             // Wind Leap はスマッシュ成立のお膳立てに留め、スマッシュ効果は onDealDamage の既存条件でだけ発火させる。
+            // SWORD_AIR_SLASH は縦移動を持つ ActionAnimation のため、再生すると Wind Leap / Wind Burst の打ち上げを上書きする。
+            // 1.21.1 へ移植する際も、DamageSource の属性付けと攻撃モーション再生を分けて扱う。
             var damageSource = playerpatch.getDamageSource(Animations.SWORD_AIR_SLASH, InteractionHand.MAIN_HAND)
                     .attachArmorNegationModifier(ValueModifier.adder(50.0F))
                     .attachImpactModifier(ValueModifier.multiplier(1.6F))
                     .setStunType(StunType.NONE)
                     .addRuntimeTag(EpicFightDamageTypeTags.WEAPON_INNATE);
             playerpatch.attack(damageSource, target, InteractionHand.MAIN_HAND);
-            playerpatch.playAnimationSynchronized(Animations.SWORD_AIR_SLASH, 0.0F);
         });
     }
 


### PR DESCRIPTION
## 概要
- SmashcastScepter の Wind Leap 自動命中後に `SWORD_AIR_SLASH` を追加再生しないように変更
- `SWORD_AIR_SLASH` は縦移動を持つ ActionAnimation のため、Release / Wind Burst 相当の打ち上げ速度を上書きし得ることをコメントで明示
- DamageSource の属性付けには従来通り `SWORD_AIR_SLASH` を使い、通常の下降基本攻撃側のアニメーション再生は維持

## 確認
- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`（343 required tests passed）

## 1.21.1 申し送り
- 1.21.1 側でも、打ち上げ挙動を優先し、移動を持つ攻撃アニメーションを見た目目的で重ねない方針で扱う