### PR TITLE
PR #483 を 1.21.1 へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
@@ -329,13 +329,14 @@ public final class EpicFightSmashcastScepterCompat {
             );
 
             // Wind Leap はスマッシュ成立のお膳立てに留め、スマッシュ効果は onDealDamagePre の既存条件でだけ発火させる。
+            // SWORD_AIR_SLASH は縦移動を持つ ActionAnimation のため、再生すると Wind Leap / Wind Burst の打ち上げを上書きする。
+            // DamageSource の属性付けと攻撃モーション再生は分けて扱う。
             var damageSource = playerpatch.getDamageSource(Animations.SWORD_AIR_SLASH, InteractionHand.MAIN_HAND)
                     .attachArmorNegationModifier(ValueModifier.adder(50.0F))
                     .attachImpactModifier(ValueModifier.multiplier(1.6F))
                     .setStunType(StunType.NONE)
                     .addRuntimeTag(EpicFightDamageTypeTags.WEAPON_INNATE);
             playerpatch.attack(damageSource, target, InteractionHand.MAIN_HAND);
-            playerpatch.playAnimationSynchronized(Animations.SWORD_AIR_SLASH, 0.0F);
         });
     }
 


### PR DESCRIPTION
## 概要
- PR #483 の Wind Leap 自動命中後の打ち上げ維持対応を 1.21.1 側へ forward-port
- 自動命中後は `SWORD_AIR_SLASH` を見た目目的で追加再生せず、DamageSource の属性付けだけに使用
- 1.21.1 側の `onDealDamagePre` 文脈に合わせてコメントを調整

## 確認
- `./gradlew.bat runGameTestServer`（344 required tests passed）
- `./gradlew.bat build`
- ローカル実挙動確認済み（Wind Leap 自動命中後の打ち上げに問題なし）

## 備考
- `cherry-pick -x` により `6a70c198785b2a3fb34f221460e322e82ecd2dbd` を取り込み
- PR 作成前の `git status` はクリーン