### PR TITLE
EpicFightの1.20.1における要求バージョンを下げる対応

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,8 +159,8 @@ dependencies {
     // Epic Fight.
     // 武器関連対応、特殊武器アクション(e.g. 打撃詠唱杖の魔法発動)のコード接続用に参照も含める.
     // 必要に応じてON、デフォルトは入れない(必須前提にはしないため)
-    compileOnly fg.deobf("curse.maven:epic-fight-mod-405076:8049910")
-    // runtimeOnly fg.deobf("curse.maven:epic-fight-mod-405076:8049910")
+    compileOnly fg.deobf("curse.maven:epic-fight-mod-405076:7919289")
+    // runtimeOnly fg.deobf("curse.maven:epic-fight-mod-405076:7919289")
 
     // Lootr.
     // TreasureDivination が Lootr の個人開封済み判定へ接続するためのコンパイル用.

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,4 +35,4 @@ lodestone_version=1.20.1-1.6.4.1
 malum_version=1.20.1-1.6.7
 lootr_version=0.7.28.67.3
 patchouli_version=1.20.1-84.1-FORGE
-epicfight_version=20.14.17
+epicfight_version=20.14.16

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightChargedTwinBladeStaffCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightChargedTwinBladeStaffCompat.java
@@ -7,13 +7,15 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import yesman.epicfight.api.forgeevent.WeaponCapabilityPresetRegistryEvent;
 import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.WeaponCapability;
-import yesman.epicfight.world.capabilities.item.WeaponCapabilityPresets;
+import yesman.epicfight.world.capabilities.item.WeaponTypeReloadListener;
 
 // リフレクションで参照するため、IDE側の未使用検知を無効化.
 @SuppressWarnings("unused")
 public final class EpicFightChargedTwinBladeStaffCompat {
     public static final ResourceLocation WEAPON_TYPE_ID =
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "charged_twin_blade_staff");
+    private static final ResourceLocation SPEAR_PRESET_ID =
+            ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "spear");
 
     private EpicFightChargedTwinBladeStaffCompat() {
     }
@@ -23,11 +25,14 @@ public final class EpicFightChargedTwinBladeStaffCompat {
     }
 
     private static void onWeaponCapabilityPresetRegistry(WeaponCapabilityPresetRegistryEvent event) {
-        event.getTypeEntry().put(WEAPON_TYPE_ID, EpicFightChargedTwinBladeStaffCompat::buildCapability);
+        event.getTypeEntry().put(
+                WEAPON_TYPE_ID,
+                item -> EpicFightChargedTwinBladeStaffCompat.buildCapability(item, SPEAR_PRESET_ID)
+        );
     }
 
-    private static CapabilityItem.Builder buildCapability(Item item) {
-        var builder = (WeaponCapability.Builder) WeaponCapabilityPresets.SPEAR.apply(item);
+    private static CapabilityItem.Builder buildCapability(Item item, ResourceLocation basePresetId) {
+        var builder = (WeaponCapability.Builder) WeaponTypeReloadListener.getOrThrow(basePresetId.toString()).apply(item);
 
         builder.zoomInType(CapabilityItem.ZoomInType.USE_TICK);
         builder.constructor(EpicFightChargedTwinBladeStaffCapability::new);

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightMultipurposeStaffrifleCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightMultipurposeStaffrifleCompat.java
@@ -7,13 +7,15 @@ import net.minecraftforge.eventbus.api.IEventBus;
 import yesman.epicfight.api.forgeevent.WeaponCapabilityPresetRegistryEvent;
 import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.RangedWeaponCapability;
-import yesman.epicfight.world.capabilities.item.WeaponCapabilityPresets;
+import yesman.epicfight.world.capabilities.item.WeaponTypeReloadListener;
 
 // リフレクションで参照するため、IDE側の未使用検知を無効化.
 @SuppressWarnings("unused")
 public final class EpicFightMultipurposeStaffrifleCompat {
     public static final ResourceLocation WEAPON_TYPE_ID =
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "multipurpose_staffrifle");
+    private static final ResourceLocation CROSSBOW_PRESET_ID =
+            ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "crossbow");
 
     private EpicFightMultipurposeStaffrifleCompat() {
     }
@@ -23,11 +25,14 @@ public final class EpicFightMultipurposeStaffrifleCompat {
     }
 
     private static void onWeaponCapabilityPresetRegistry(WeaponCapabilityPresetRegistryEvent event) {
-        event.getTypeEntry().put(WEAPON_TYPE_ID, EpicFightMultipurposeStaffrifleCompat::buildCapability);
+        event.getTypeEntry().put(
+                WEAPON_TYPE_ID,
+                item -> EpicFightMultipurposeStaffrifleCompat.buildCapability(item, CROSSBOW_PRESET_ID)
+        );
     }
 
-    private static CapabilityItem.Builder buildCapability(Item item) {
-        var builder = (RangedWeaponCapability.Builder) WeaponCapabilityPresets.CROSSBOW.apply(item);
+    private static CapabilityItem.Builder buildCapability(Item item, ResourceLocation basePresetId) {
+        var builder = (RangedWeaponCapability.Builder) WeaponTypeReloadListener.getOrThrow(basePresetId.toString()).apply(item);
         builder.constructor(EpicFightMultipurposeStaffrifleCapability::new);
         return builder;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
@@ -28,7 +28,7 @@ import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
 import yesman.epicfight.world.capabilities.item.CapabilityItem;
 import yesman.epicfight.world.capabilities.item.WeaponCapability;
-import yesman.epicfight.world.capabilities.item.WeaponCapabilityPresets;
+import yesman.epicfight.world.capabilities.item.WeaponTypeReloadListener;
 import yesman.epicfight.world.damagesource.EpicFightDamageTypeTags;
 import yesman.epicfight.world.damagesource.StunType;
 import yesman.epicfight.world.entity.eventlistener.BasicAttackEvent;
@@ -49,6 +49,8 @@ public final class EpicFightSmashcastScepterCompat {
     public static final String MOD_ID = "epicfight";
     public static final ResourceLocation WEAPON_TYPE_ID =
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "smashcast_scepter");
+    private static final ResourceLocation SWORD_PRESET_ID =
+            ResourceLocation.fromNamespaceAndPath(MOD_ID, "sword");
 
     static Skill WIND_LEAP;
 
@@ -84,11 +86,14 @@ public final class EpicFightSmashcastScepterCompat {
     }
 
     private static void onWeaponCapabilityPresetRegistry(WeaponCapabilityPresetRegistryEvent event) {
-        event.getTypeEntry().put(WEAPON_TYPE_ID, EpicFightSmashcastScepterCompat::buildCapability);
+        event.getTypeEntry().put(
+                WEAPON_TYPE_ID,
+                item -> EpicFightSmashcastScepterCompat.buildCapability(item, SWORD_PRESET_ID)
+        );
     }
 
-    private static CapabilityItem.Builder buildCapability(Item item) {
-        var builder = (WeaponCapability.Builder) WeaponCapabilityPresets.SWORD.apply(item);
+    private static CapabilityItem.Builder buildCapability(Item item, ResourceLocation basePresetId) {
+        var builder = (WeaponCapability.Builder) WeaponTypeReloadListener.getOrThrow(basePresetId.toString()).apply(item);
 
         builder.constructor(EpicFightSmashcastScepterCapability::new);
         builder.styleProvider(entityPatch -> CapabilityItem.Styles.ONE_HAND);


### PR DESCRIPTION
- 最新版のEpicFightには致命的不具合があるらしい
- 最新版に追従するこだわりはないため、最新版でも動く形でダウングレードを実行
- 1.20.1でのみ起きるようなのでforward-port対応はしない