### PR TITLE
コード変更不要でEpicFightの要求バージョンを下げられるだけ下げた

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,10 +157,10 @@ dependencies {
     // runtimeOnly fg.deobf("maven.modrinth:better-combat:rnhiaw3t")
 
     // Epic Fight.
-    // 武器関連対応、特殊武器アクション(e.g. 打撃詠唱杖の魔法発動)のコード接続用に参照も含める.
-    // 必要に応じてON、デフォルトは入れない(必須前提にはしないため)
-    compileOnly fg.deobf("curse.maven:epic-fight-mod-405076:7919289")
-    // runtimeOnly fg.deobf("curse.maven:epic-fight-mod-405076:7919289")
+    // コンパイルは最低対応版に固定し、新しいAPIの誤使用を検出する.
+    // ランタイムは20.14系最新を使い、通常の起動確認では最新側の挙動を見る.
+    compileOnly "maven.modrinth:epic-fight:${epicfight_compile_version}"
+    // runtimeOnly fg.deobf("curse.maven:epic-fight-mod-405076:${epicfight_runtime_file_id}")
 
     // Lootr.
     // TreasureDivination が Lootr の個人開封済み判定へ接続するためのコンパイル用.

--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     // Epic Fight.
     // コンパイルは最低対応版に固定し、新しいAPIの誤使用を検出する.
     // ランタイムは20.14系最新を使い、通常の起動確認では最新側の挙動を見る.
-    compileOnly "maven.modrinth:epic-fight:${epicfight_compile_version}"
+    compileOnly fg.deobf("maven.modrinth:epic-fight:${epicfight_compile_version}")
     // runtimeOnly fg.deobf("curse.maven:epic-fight-mod-405076:${epicfight_runtime_file_id}")
 
     // Lootr.

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,4 +35,9 @@ lodestone_version=1.20.1-1.6.4.1
 malum_version=1.20.1-1.6.7
 lootr_version=0.7.28.67.3
 patchouli_version=1.20.1-84.1-FORGE
-epicfight_version=20.14.16
+
+# Epic Fightは"要求は極力ユーザー層の厚いバージョンを拾う"にしつつ、"動作そのものは最新版で破綻しないことを確認する"を目的とするため、
+# ビルド用と実行確認用は分ける。(今のfile_idは"20.14.17")
+epicfight_version=20.14.1
+epicfight_compile_version=20.14.1-1.20.1
+epicfight_runtime_file_id=8049910


### PR DESCRIPTION
- forward-portは行わない(1.20.1のバージョン関係だけのため)