### PR TITLE
PR #495 対応の1.21.1-forward-port対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -11410,12 +11410,15 @@ public final class ApprenticeCodexGameTestScenarios {
 
     static void companionTrunkClimbsOneBlockStepWhenFollowingOwner(GameTestHelper helper) {
         var trunkPos = new BlockPos(-2, 12, 0);
-        var ownerPos = new BlockPos(2, 13, 0);
+        var ownerPos = new BlockPos(3, 13, 0);
         prepareSummonedEntityIsolationArea(helper, trunkPos);
-        for (var x = 0; x <= 2; ++x) {
-            helper.setBlock(new BlockPos(x, 12, 0), Blocks.STONE);
-            helper.setBlock(new BlockPos(x, 13, 0), Blocks.AIR);
-            helper.setBlock(new BlockPos(x, 14, 0), Blocks.AIR);
+        for (var x = 0; x <= 4; ++x) {
+            for (var z = -1; z <= 1; ++z) {
+                helper.setBlock(new BlockPos(x, 12, z), Blocks.STONE);
+                helper.setBlock(new BlockPos(x, 13, z), Blocks.AIR);
+                helper.setBlock(new BlockPos(x, 14, z), Blocks.AIR);
+                helper.setBlock(new BlockPos(x, 15, z), Blocks.AIR);
+            }
         }
 
         var owner = createCompanionTrunkPlayer(helper, ownerPos);
@@ -11424,9 +11427,11 @@ public final class ApprenticeCodexGameTestScenarios {
 
         helper.succeedWhen(() -> {
             helper.assertTrue(trunk.onGround(),
-                    "Companion Trunk should land on the raised step after following its owner");
+                    "Companion Trunk should land on the raised step after following its owner: "
+                            + describeCompanionTrunkMovement(trunk));
             helper.assertTrue(trunk.blockPosition().getY() >= absoluteOwnerPos.getY(),
-                    "Companion Trunk should climb onto the one block step while following its owner");
+                    "Companion Trunk should climb onto the one block step while following its owner: "
+                            + describeCompanionTrunkMovement(trunk));
         });
     }
 
@@ -12219,6 +12224,14 @@ public final class ApprenticeCodexGameTestScenarios {
         trunk.moveTo(absolutePos.x, absolutePos.y, absolutePos.z, 0.0f, 0.0f);
         helper.getLevel().addFreshEntity(trunk);
         return trunk;
+    }
+
+    private static String describeCompanionTrunkMovement(CompanionTrunkEntity trunk) {
+        return "blockPos=" + trunk.blockPosition()
+                + ", position=" + trunk.position()
+                + ", delta=" + trunk.getDeltaMovement()
+                + ", onGround=" + trunk.onGround()
+                + ", tickCount=" + trunk.tickCount;
     }
 
     private static CompanionTrunkEntity getSingleCompanionTrunk(GameTestHelper helper, FakePlayer owner) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -149,7 +149,7 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
         ApprenticeCodexGameTestScenarios.companionTrunkIgnoresFireAndRescuesFromVoid(helper);
     }
 
-    @GameTest(template = TEMPLATE, batch = COMPANION_TRUNK_ISOLATED_BATCH, timeoutTicks = 80)
+    @GameTest(template = TEMPLATE, batch = COMPANION_TRUNK_ISOLATED_BATCH, timeoutTicks = 120)
     public static void companionTrunkClimbsOneBlockStepWhenFollowingOwner(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.companionTrunkClimbsOneBlockStepWhenFollowingOwner(helper);
     }


### PR DESCRIPTION
## 概要
- PR #495 の GameTest 安定化変更を `1.21.1-main` へ forward-port
- コンパニオントランクの段差追従 GameTest の足場・タイムアウト・失敗時ログを調整

## 検証
- `./gradlew.bat runGameTestServer`（352 required tests passed）
- `./gradlew.bat build`