### PR TITLE
PR #497を1.20.1へbackportする

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,4 +354,47 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
+    options.compilerArgs.addAll(['-Xlint:removal', '-Werror'])
+}
+
+def removalWarningSuppressionFiles = fileTree(layout.projectDirectory.dir('src/main/java')) {
+    include '**/*.java'
+}
+def removalWarningSuppressionRootPath = layout.projectDirectory.asFile.toPath()
+
+tasks.register('checkRemovalWarningSuppressions') {
+    group = 'verification'
+    description = 'Fails when @SuppressWarnings("removal") hides forRemoval deprecation warnings.'
+
+    inputs.files(removalWarningSuppressionFiles)
+
+    doLast {
+        def failures = []
+        def suppressWarningsPattern = ~/(?s)@(?:[A-Za-z_$][\w$]*\.)*SuppressWarnings\s*\((.*?)\)/
+        def removalLiteralPattern = ~/["']removal["']/
+
+        removalWarningSuppressionFiles.files.findAll { it.isFile() }.sort { it.path }.each { file ->
+            def text = file.getText('UTF-8')
+            def matcher = suppressWarningsPattern.matcher(text)
+
+            while (matcher.find()) {
+                if (removalLiteralPattern.matcher(matcher.group(1)).find()) {
+                    def relativePath = removalWarningSuppressionRootPath.relativize(file.toPath()).toString().replace(File.separator, '/')
+                    def lineNumber = text.substring(0, matcher.start()).count('\n') + 1
+                    failures << "${relativePath}:${lineNumber} @SuppressWarnings(\"removal\") is not allowed"
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException(
+                    "@Deprecated(forRemoval = true) warnings must be fixed instead of suppressed:\n" +
+                            failures.join('\n')
+            )
+        }
+    }
+}
+
+tasks.named('check').configure {
+    dependsOn tasks.named('checkRemovalWarningSuppressions')
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
@@ -3,9 +3,11 @@ package jp.aquafactory.apprenticecodex.compat.epicfight;
 import com.mojang.blaze3d.platform.InputConstants;
 import jp.aquafactory.apprenticecodex.item.MultipurposeStaffrifle;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.config.ItemsPreferenceScreen;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 import yesman.epicfight.world.entity.eventlistener.PlayerEventListener.EventType;
 import yesman.epicfight.world.entity.eventlistener.SkillCastEvent;
 
@@ -42,10 +44,9 @@ public final class EpicFightClientCompat {
         return matchesKey(EpicFightInputAction.ATTACK.keyMapping(), type, value);
     }
 
-    @SuppressWarnings("removal")
     private static void installSmashcastScepterEvents() {
-        var clientEngine = ClientEngine.getInstance();
-        var playerpatch = clientEngine != null ? clientEngine.getPlayerPatch() : null;
+        var player = Minecraft.getInstance().player;
+        var playerpatch = player != null ? EpicFightCapabilities.getLocalPlayerPatch(player) : null;
         if (playerpatch == null || playerpatch.getOriginal() == null || !playerpatch.getOriginal().isAlive()) {
             installedSmashcastScepterPlayerId = null;
             return;

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSmashcastScepterCompat.java
@@ -44,7 +44,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 // リフレクションで参照するため、IDE側の未使用検知を無効化.
-@SuppressWarnings({"unused", "removal"})
+@SuppressWarnings("unused")
 public final class EpicFightSmashcastScepterCompat {
     public static final String MOD_ID = "epicfight";
     public static final ResourceLocation WEAPON_TYPE_ID =

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientModBusEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientModBusEvents.java
@@ -22,7 +22,6 @@ import jp.aquafactory.apprenticecodex.particle.ReticleDotParticle;
 import jp.aquafactory.apprenticecodex.particle.SmashcastDustPillarParticle;
 import jp.aquafactory.apprenticecodex.particle.SmashcastTremorBlockParticle;
 import jp.aquafactory.apprenticecodex.registry.BlockEntityRegistry;
-import jp.aquafactory.apprenticecodex.registry.BlockRegistry;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.MenuRegistry;
@@ -86,8 +85,6 @@ import jp.aquafactory.apprenticecodex.entity.spelldispenser.SpellDispenserAnchor
 import jp.aquafactory.apprenticecodex.block.apprenticedesk.ApprenticeDeskScreen;
 import jp.aquafactory.apprenticecodex.block.spellcasterworkbench.SpellcasterWorkbenchScreen;
 import net.minecraft.client.renderer.item.ItemProperties;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.client.event.EntityRenderersEvent;
@@ -116,7 +113,6 @@ public final class ClientModBusEvents {
         modEventBus.addListener(ClientModBusEvents::registerItemColors);
     }
 
-    @SuppressWarnings("removal")
     private static void onClientSetup(FMLClientSetupEvent event) {
         if (ModList.get().isLoaded("patchouli")) {
             event.enqueueWork(PatchouliBuiltinTemplateSupport::registerBuiltinTemplates);
@@ -137,30 +133,29 @@ public final class ClientModBusEvents {
         event.enqueueWork(() -> CuriosRendererRegistry.register(ItemRegistry.SPELLCASTER_QUIVER.get(), SpellcasterQuiverCurioRenderer::new));
         event.enqueueWork(() -> CuriosRendererRegistry.register(ItemRegistry.ASHEN_CIRCLET.get(), AshenCircletCurioRenderer::new));
         event.enqueueWork(() -> CuriosRendererRegistry.register(ItemRegistry.ENCHANTED_CIRCLET.get(), CircletCurioRenderer::new));
-        event.enqueueWork(() -> ItemBlockRenderTypes.setRenderLayer(BlockRegistry.ESSENCE_SMOKER.get(), RenderType.cutout()));
         event.enqueueWork(() -> ItemProperties.register(
                 ItemRegistry.REFLECTCAST_SHIELD.get(),
-                new ResourceLocation("blocking"),
+                ResourceLocation.withDefaultNamespace("blocking"),
                 (stack, level, living, seed) -> living != null && living.isUsingItem() && living.getUseItem() == stack ? 1.0f : 0.0f
         ));
         event.enqueueWork(() -> ItemProperties.register(
                 ItemRegistry.MANA_FORCE_BLADE.get(),
-                new ResourceLocation("blocking"),
+                ResourceLocation.withDefaultNamespace("blocking"),
                 (stack, level, living, seed) -> living != null && living.isUsingItem() && living.getUseItem() == stack ? 1.0f : 0.0f
         ));
         event.enqueueWork(() -> ItemProperties.register(
                 ItemRegistry.SPELLCASTERS_FLASK.get(),
-                new ResourceLocation("filled"),
+                ResourceLocation.withDefaultNamespace("filled"),
                 (stack, level, living, seed) -> SpellcastersFlask.isFilled(stack) ? 1.0F : 0.0F
         ));
         event.enqueueWork(() -> ItemProperties.register(
                 ItemRegistry.ALCHEMISTS_FLASK.get(),
-                new ResourceLocation("filled"),
+                ResourceLocation.withDefaultNamespace("filled"),
                 (stack, level, living, seed) -> SpellcastersFlask.isFilled(stack) ? 1.0F : 0.0F
         ));
         event.enqueueWork(() -> ItemProperties.register(
                 ItemRegistry.CHARGED_TWIN_BLADE_STAFF.get(),
-                new ResourceLocation("throwing"),
+                ResourceLocation.withDefaultNamespace("throwing"),
                 (stack, level, living, seed) -> living != null && living.isUsingItem() && living.getUseItem() == stack ? 1.0F : 0.0F
         ));
         event.enqueueWork(() -> {

--- a/src/main/resources/assets/apprenticecodex/models/block/essence_smoker.json
+++ b/src/main/resources/assets/apprenticecodex/models/block/essence_smoker.json
@@ -1,6 +1,7 @@
 {
 	"format_version": "1.9.0",
 	"credit": "Made with Blockbench",
+	"render_type": "minecraft:cutout",
 	"ambientocclusion": false,
 	"texture_size": [128, 128],
 	"textures": {


### PR DESCRIPTION
## 概要
- PR #497 の forRemoval 警告を無視できないようにする対応を 1.20.1 / Forge 側へ backport
- `-Xlint:removal` / `-Werror` と `checkRemovalWarningSuppressions` を追加
- 1.20.1 側で残っていた forRemoval 利用を suppression なしで代替 API へ置き換え

## 確認
- `./gradlew.bat build` 成功
- `runClient` による動作チェック問題なし（ユーザー確認済み）

## 補足
- Epic Fight 周りは `ClientEngine#getPlayerPatch()` を `EpicFightCapabilities.getLocalPlayerPatch(...)` に置き換え、代替不能な removal は残りませんでした。