### PR TITLE
PR #504 指摘の1.20.1側対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/event/errandmage/ErrandMageTradeManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/errandmage/ErrandMageTradeManager.java
@@ -34,6 +34,9 @@ public final class ErrandMageTradeManager extends SimpleJsonResourceReloadListen
 
     private static final Gson GSON = new GsonBuilder().create();
     private static final ErrandMageTradeManager INSTANCE = new ErrandMageTradeManager();
+    private static final Set<ResourceLocation> LEGACY_IGNORE_NBT_PAYMENT_ITEM_IDS = Set.of(
+            ResourceLocation.fromNamespaceAndPath("irons_spellbooks", "tarnished_helmet")
+    );
     private static volatile List<ErrandMageTradeDefinition> definitions = List.of();
     private static volatile Set<Item> ignoreNbtPaymentItems = Set.of();
 
@@ -58,7 +61,9 @@ public final class ErrandMageTradeManager extends SimpleJsonResourceReloadListen
     }
 
     public static boolean shouldIgnorePaymentTags(Item item) {
-        return ignoreNbtPaymentItems.contains(item);
+        // 新規取引から外した後も、既存ワールドの保存済み Tarnished Crown 買い取りはタグ差分なしで成立させる。
+        return ignoreNbtPaymentItems.contains(item)
+                || LEGACY_IGNORE_NBT_PAYMENT_ITEM_IDS.contains(ForgeRegistries.ITEMS.getKey(item));
     }
 
     private static VillagerTrades.ItemListing createListing(ErrandMageTradeDefinition definition) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -635,6 +635,20 @@ public final class ApprenticeCodexGameTestScenarios {
             );
             helper.assertTrue(scrollOffer.satisfiedBy(taggedScroll, new ItemStack(Items.EMERALD, 16)),
                     "Tagged scroll should satisfy the errand mage ink trade even when the saved cost stack has tags");
+
+            var taggedTarnishedCrown = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get());
+            taggedTarnishedCrown.getOrCreateTag().putString("apprenticecodex_test", "tagged");
+            var taggedTarnishedCrownCost = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get());
+            taggedTarnishedCrownCost.getOrCreateTag().putString("apprenticecodex_test", "legacy_cost");
+            var tarnishedCrownOffer = new MerchantOffer(
+                    taggedTarnishedCrownCost,
+                    new ItemStack(Items.EMERALD, 32),
+                    3,
+                    5,
+                    0.05F
+            );
+            helper.assertTrue(tarnishedCrownOffer.satisfiedBy(taggedTarnishedCrown, ItemStack.EMPTY),
+                    "Tagged Tarnished Crown should satisfy saved legacy errand mage buy trades");
         });
     }
     static void errandMageTradesMatchExpectedOffers(GameTestHelper helper) {
@@ -10286,6 +10300,18 @@ public final class ApprenticeCodexGameTestScenarios {
 
     static void initialSpellContainerHelperSkipsUnavailablePresetSpell(GameTestHelper helper) {
         helper.succeedIf(() -> {
+            var unboundSpell = RegistryObject.<AbstractSpell, AbstractSpell>create(
+                    ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "missing_initial_spell_for_gametest"),
+                    io.redspace.ironsspellbooks.api.registry.SpellRegistry.SPELL_REGISTRY_KEY,
+                    ApprenticeCodex.MODID
+            );
+            var unboundStack = new ItemStack(ItemRegistry.GRIMOIRE_MANIFEST.get());
+            InitialSpellContainerHelper.setInitialContainer(unboundStack, 1, true, false, unboundSpell, 1);
+            var unboundContainer = ISpellContainer.get(unboundStack);
+            helper.assertTrue(unboundContainer != null, "Initial helper should create a container for unbound RegistryObject spells");
+            helper.assertTrue(unboundContainer.getActiveSpellCount() == 0,
+                    "Initial helper should skip unbound RegistryObject preset spells");
+
             var stack = new ItemStack(ItemRegistry.GRIMOIRE_MANIFEST.get());
             InitialSpellContainerHelper.setInitialContainer(
                     stack,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
@@ -130,7 +130,7 @@ public abstract class AbstractOffhandMagicItem extends Item
                     1,
                     true,
                     false,
-                    configuredSpell.get(),
+                    configuredSpell,
                     configuredSpellLevel
             );
             return;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractRightClickMagicWeaponItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractRightClickMagicWeaponItem.java
@@ -189,7 +189,7 @@ public abstract class AbstractRightClickMagicWeaponItem extends Item implements 
         if (startsWithPresetSpell) {
             InitialSpellContainerHelper.addInitialSpellIfEnabled(
                     spellContainer,
-                    configuredSpell.get(),
+                    configuredSpell,
                     configuredSpellLevel,
                     0,
                     true

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSpellGunItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSpellGunItem.java
@@ -177,7 +177,7 @@ public abstract class AbstractSpellGunItem extends Item implements IPresetSpellC
         if (startsWithPresetSpell) {
             InitialSpellContainerHelper.addInitialSpellIfEnabled(
                     spellContainer,
-                    configuredSpell.get(),
+                    configuredSpell,
                     configuredSpellLevel,
                     0,
                     true

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/GrimoireManifest.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/GrimoireManifest.java
@@ -36,7 +36,7 @@ public class GrimoireManifest extends Item implements IPresetSpellContainer, Uni
                 1,
                 true,
                 false,
-                SpellRegistry.MANIFESTATION_GRIMOIRE.get(),
+                SpellRegistry.MANIFESTATION_GRIMOIRE,
                 1
         );
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
@@ -106,7 +106,7 @@ public class PastelStaff extends StaffItem implements GeoItem, IPresetSpellConta
         }
 
         var spellContainer = ISpellContainer.create(1, true, false).mutableCopy();
-        InitialSpellContainerHelper.addInitialSpellIfEnabled(spellContainer, SpellRegistry.PALETTE_SHIFT.get(), 1, 0, true);
+        InitialSpellContainerHelper.addInitialSpellIfEnabled(spellContainer, SpellRegistry.PALETTE_SHIFT, 1, 0, true);
         ISpellContainer.set(itemStack, spellContainer.toImmutable());
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/flask/AlchemistsFlask.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/flask/AlchemistsFlask.java
@@ -42,7 +42,7 @@ public class AlchemistsFlask extends AbstractPotionFlaskItem
         }
 
         var spellContainer = ISpellContainer.create(1, false, false).mutableCopy();
-        InitialSpellContainerHelper.addInitialSpellIfEnabled(spellContainer, SpellRegistry.EXTRACT.get(), 1, 0, true);
+        InitialSpellContainerHelper.addInitialSpellIfEnabled(spellContainer, SpellRegistry.EXTRACT, 1, 0, true);
         ISpellContainer.set(itemStack, spellContainer.toImmutable());
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/InitialSpellContainerHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/InitialSpellContainerHelper.java
@@ -5,7 +5,10 @@ import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainerMutable;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.RegistryObject;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Supplier;
 
 public final class InitialSpellContainerHelper {
     private InitialSpellContainerHelper() {
@@ -26,6 +29,22 @@ public final class InitialSpellContainerHelper {
                 && spellContainer.addSpellAtIndex(spell, spellLevel, index, locked);
     }
 
+    public static boolean addInitialSpellIfEnabled(
+            ISpellContainerMutable spellContainer,
+            @Nullable Supplier<? extends AbstractSpell> spellSupplier,
+            int spellLevel,
+            int index,
+            boolean locked
+    ) {
+        return addInitialSpellIfEnabled(
+                spellContainer,
+                resolveInitialSpell(spellSupplier),
+                spellLevel,
+                index,
+                locked
+        );
+    }
+
     public static void setInitialContainer(
             ItemStack stack,
             int maxSpellCount,
@@ -37,5 +56,28 @@ public final class InitialSpellContainerHelper {
         var spellContainer = ISpellContainer.create(maxSpellCount, addsToSpellWheel, mustBeEquipped).mutableCopy();
         addInitialSpellIfEnabled(spellContainer, spell, spellLevel, 0, true);
         ISpellContainer.set(stack, spellContainer.toImmutable());
+    }
+
+    public static void setInitialContainer(
+            ItemStack stack,
+            int maxSpellCount,
+            boolean addsToSpellWheel,
+            boolean mustBeEquipped,
+            @Nullable Supplier<? extends AbstractSpell> spellSupplier,
+            int spellLevel
+    ) {
+        var spellContainer = ISpellContainer.create(maxSpellCount, addsToSpellWheel, mustBeEquipped).mutableCopy();
+        addInitialSpellIfEnabled(spellContainer, spellSupplier, spellLevel, 0, true);
+        ISpellContainer.set(stack, spellContainer.toImmutable());
+    }
+
+    private static @Nullable AbstractSpell resolveInitialSpell(@Nullable Supplier<? extends AbstractSpell> spellSupplier) {
+        if (spellSupplier == null) {
+            return null;
+        }
+        if (spellSupplier instanceof RegistryObject<?> registryObject && !registryObject.isPresent()) {
+            return null;
+        }
+        return spellSupplier.get();
     }
 }


### PR DESCRIPTION
## 概要
- PR #504 で指摘された Tarnished Crown 旧 Errand Mage 取引互換を 1.20.1 側にも反映
- 初期 Imbue / 初期呪文 container 生成で未バインド `RegistryObject` を `get()` しないよう helper と呼び出し側を調整
- それぞれ GameTest で回帰確認を追加

## 確認
- `./gradlew.bat compileJava`
- `./gradlew.bat runData`
- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`（368 tests passed）

## 備考
- `runData` 実行で generated JSON の EOF 改行差分だけが出たため、今回の修正範囲外として戻しています。