### PR TITLE
PR #506 の1.21.1-forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/event/errandmage/ErrandMageTradeManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/errandmage/ErrandMageTradeManager.java
@@ -36,9 +36,6 @@ public final class ErrandMageTradeManager extends SimpleJsonResourceReloadListen
 
     private static final Gson GSON = new GsonBuilder().create();
     private static final ErrandMageTradeManager INSTANCE = new ErrandMageTradeManager();
-    private static final Set<ResourceLocation> LEGACY_IGNORE_NBT_PAYMENT_ITEM_IDS = Set.of(
-            ResourceLocation.fromNamespaceAndPath("irons_spellbooks", "tarnished_helmet")
-    );
     private static volatile List<ErrandMageTradeDefinition> definitions = List.of();
     private static volatile Set<Item> ignoreNbtPaymentItems = Set.of();
 
@@ -63,8 +60,7 @@ public final class ErrandMageTradeManager extends SimpleJsonResourceReloadListen
     }
 
     public static boolean shouldIgnorePaymentTags(Item item) {
-        return ignoreNbtPaymentItems.contains(item)
-                || LEGACY_IGNORE_NBT_PAYMENT_ITEM_IDS.contains(BuiltInRegistries.ITEM.getKey(item));
+        return ignoreNbtPaymentItems.contains(item);
     }
 
     private static VillagerTrades.ItemListing createListing(ErrandMageTradeDefinition definition) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -42,6 +42,7 @@ import jp.aquafactory.apprenticecodex.datagen.DamageTypeTagGenerator;
 import jp.aquafactory.apprenticecodex.effect.CastingMoveSpeedAdjustment;
 import jp.aquafactory.apprenticecodex.enchantment.Enchantments;
 import jp.aquafactory.apprenticecodex.event.ErrandMageVillagerTradesEvent;
+import jp.aquafactory.apprenticecodex.event.errandmage.ErrandMageTradeManager;
 import jp.aquafactory.apprenticecodex.event.ScrollcasterGauntletGrindstoneEvent;
 import jp.aquafactory.apprenticecodex.network.packet.SenseEvilHighlightsPacket;
 import jp.aquafactory.apprenticecodex.item.AbstractOffhandMagicItem;
@@ -791,24 +792,25 @@ public final class ApprenticeCodexGameTestScenarios {
             helper.assertTrue(scrollOffer.satisfiedBy(taggedScroll, new ItemStack(Items.EMERALD, 16)),
                     "Tagged scroll should satisfy the errand mage ink trade even when the saved cost stack has tags");
 
+            var trades = createEmptyVillagerTrades();
+            ErrandMageVillagerTradesEvent.onVillagerTrades(
+                    new VillagerTradesEvent(
+                            trades,
+                            VillagerProfessionRegistry.ERRAND_MAGE.get(),
+                            helper.getLevel().registryAccess()
+                    )
+            );
+            var tarnishedCrownOffer = createOffers(trades.get(4), 0L).stream()
+                    .filter(offer -> offer.getBaseCostA().is(io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get()))
+                    .findFirst()
+                    .orElse(null);
+            helper.assertTrue(tarnishedCrownOffer != null, "Errand Mage level 4 should buy Tarnished Crowns");
+            helper.assertTrue(ErrandMageTradeManager.shouldIgnorePaymentTags(io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get()),
+                    "Errand Mage Tarnished Crown trade should ignore payment tags");
             var taggedTarnishedCrown = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get());
             CustomData.update(DataComponents.CUSTOM_DATA, taggedTarnishedCrown, tag -> tag.putString("apprenticecodex_test", "tagged"));
-            var taggedTarnishedCrownCost = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get());
-            CustomData.update(DataComponents.CUSTOM_DATA, taggedTarnishedCrownCost, tag -> tag.putString("apprenticecodex_test", "cost"));
-            var taggedTarnishedCrownItemCost = new ItemCost(
-                    taggedTarnishedCrownCost.getItemHolder(),
-                    taggedTarnishedCrownCost.getCount(),
-                    DataComponentPredicate.allOf(taggedTarnishedCrownCost.getComponents())
-            );
-            var legacyTarnishedCrownOffer = new MerchantOffer(
-                    taggedTarnishedCrownItemCost,
-                    new ItemStack(Items.EMERALD, 64),
-                    3,
-                    5,
-                    0.05F
-            );
-            helper.assertTrue(legacyTarnishedCrownOffer.satisfiedBy(taggedTarnishedCrown, ItemStack.EMPTY),
-                    "Tagged Tarnished Crown should still satisfy saved legacy errand mage trades");
+            helper.assertTrue(tarnishedCrownOffer.satisfiedBy(taggedTarnishedCrown, ItemStack.EMPTY),
+                    "Tagged Tarnished Crown should satisfy the current errand mage buy trade");
 
             var healingPotion = PotionContentsHelper.createPotionStack(Items.POTION, net.minecraft.world.item.alchemy.Potions.HEALING.value());
             var regenerationPotion = PotionContentsHelper.createPotionStack(Items.POTION, net.minecraft.world.item.alchemy.Potions.REGENERATION.value());
@@ -864,9 +866,12 @@ public final class ApprenticeCodexGameTestScenarios {
                     12,
                     "Errand Mage level 2 trades should always sell Basic Spellcaster Rounds");
 
-            helper.assertFalse(hasBaseCostItem(createOffers(trades.get(4), 0L),
-                            io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get()),
-                    "Errand Mage level 4 trades should not buy Tarnished Crowns");
+            assertContainsOffer(helper, createOffers(trades.get(4), 0L),
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.TARNISHED_CROWN.get()),
+                    ItemStack.EMPTY,
+                    new ItemStack(Items.EMERALD, 2),
+                    16,
+                    "Errand Mage level 4 trades should buy Tarnished Crowns for two Emeralds");
             assertContainsOffer(helper, createOffers(trades.get(4), 0L),
                     new ItemStack(Items.EMERALD, 32),
                     ItemStack.EMPTY,

--- a/src/main/resources/data/apprenticecodex/errand_mage_trades/default.json
+++ b/src/main/resources/data/apprenticecodex/errand_mage_trades/default.json
@@ -102,6 +102,23 @@
       "price_multiplier": 0.05
     },
     {
+      "type": "buy",
+      "level": 4,
+      "costs": [
+        {
+          "item": "irons_spellbooks:tarnished_helmet",
+          "ignore_nbt": true
+        }
+      ],
+      "result": {
+        "item": "minecraft:emerald",
+        "count": 2
+      },
+      "max_uses": 16,
+      "xp": 2,
+      "price_multiplier": 0.05
+    },
+    {
       "type": "sell",
       "level": 4,
       "costs": [


### PR DESCRIPTION
## 概要
- `main` の PR #506 / commit `4cd9dca52ae0375e68f9b2d50080d206a596eaed` を `1.21.1-main` に forward-port しました。
- 使い走り魔術師の Tarnished Crown 買い取りを、復活前の旧価格 1 エメラルドではなく 2 エメラルドへ調整した形で復活させました。
- Tarnished Crown 用の固定救済コード削除を 1.21.1 API に合わせて反映しました。

## 検証
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat build`