### PR TITLE
PR #512 の1.21.1-forward-port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Get-ChildItem build\libs\*.jar
 ```
 - `runClient` は GUI を起動するため、CI やヘッドレス環境では実行しない。
 - `runGameTestServer` はサーバー側の登録、データ読込、レシピ、生成まわりの検証に使う。renderer / screen など client 専用の起動不良は別途 `runClient` で確認する。
+- `runGameTestServer` は専用 world `run/codex_gametest_clean` を毎回初期化してから起動する。通常の手動確認用 `run/world` は削除しない。
 - 通常確認で `clean` は付けない。必要時のみ `./gradlew.bat clean build` を使う。
 - `runData` の出力先は `src/generated/resources` であり、`src/generated/resources/.cache` に記録された生成物だけが再生成・差分管理される前提で扱う。
 - `src/generated/resources/.cache` は Git 管理外のため、branch 切替・`cherry-pick`・手動コピーで持ち込んだ古い JSON は `runData` だけでは削除されない場合がある。

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 ./gradlew.bat runGameTestServer
 ```
 
+- `runGameTestServer` は専用 world `run/codex_gametest_clean` を毎回初期化してから起動します。通常の手動確認用 `run/world` は削除しません。
 - `runGameTestServer` では現在、次の項目を確認します。
 - Registry と動的登録の確認:
   item / block / block entity / entity / mob effect / enchantment / attribute / potion / recipe serializer / recipe type / creative tab / apprenticecodex の spell / School Affinity の動的 effect・potion・catalyst

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ base {
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
+def gameTestServerWorldName = 'codex_gametest_clean'
+def gameTestServerWorldDir = layout.projectDirectory.dir("run/${gameTestServerWorldName}")
+
 neoForge {
     version = project.neo_version
 
@@ -85,6 +88,7 @@ neoForge {
         gameTestServer {
             type = "gameTestServer"
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            programArguments.addAll '--world', gameTestServerWorldName
         }
 
         data {
@@ -106,6 +110,16 @@ neoForge {
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
+
+tasks.register('cleanGameTestServerWorld', Delete) {
+    group = 'verification'
+    description = 'Deletes the dedicated GameTest world so runGameTestServer starts from clean world state.'
+    delete gameTestServerWorldDir
+}
+
+tasks.matching { it.name == 'runGameTestServer' }.configureEach {
+    dependsOn tasks.named('cleanGameTestServerWorld')
+}
 
 configurations {
     runtimeClasspath.extendsFrom localRuntime


### PR DESCRIPTION
## 概要
- PR #512 の内容を 1.21.1 側の Gradle 構成に合わせて再実装
- `runGameTestServer` を専用 world `run/codex_gametest_clean` で起動し、実行前にその world だけ削除するように変更
- README / AGENTS.md に GameTest 専用 world の運用を追記

## 検証
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat build`