### PR TITLE
optional MOD連携用の実行構成を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,35 @@
 .\scripts\use-java.ps1
 ./gradlew.bat runGameTestServer
 ```
+- optional MOD 連携 GameTest:
+```powershell
+.\scripts\use-java.ps1
+./gradlew.bat runGameTestServerCompat
+./gradlew.bat runGameTestServerEasyMagic
+./gradlew.bat runGameTestServerBetterCombat
+./gradlew.bat runGameTestServerEpicFight
+```
 - 開発クライアント:
 ```powershell
 .\scripts\use-java.ps1
 ./gradlew.bat runClient
+```
+- optional MOD 付き開発クライアント:
+```powershell
+.\scripts\use-java.ps1
+./gradlew.bat runClientCompat
+./gradlew.bat runClientEasyMagic
+./gradlew.bat runClientBetterCombat
+./gradlew.bat runClientEpicFight
+./gradlew.bat runClientCompatEasyBetter
+```
+- 一時的な optional MOD 追加:
+```powershell
+./gradlew.bat runClient "-PdevRuntimeMods=create,malum"
+```
+- IntelliJ IDEA 実行構成の再生成:
+```powershell
+./gradlew.bat genIntellijRuns
 ```
 - jar 出力確認:
 ```powershell
@@ -51,6 +76,13 @@ Get-ChildItem build\libs\*.jar
 - `runClient` は GUI を起動するため、CI やヘッドレス環境では実行しない。
 - `runGameTestServer` はサーバー側の登録、データ読込、レシピ、生成まわりの検証に使う。renderer / screen など client 専用の起動不良は別途 `runClient` で確認する。
 - `runGameTestServer` は専用 world `run/codex_gametest_clean` を毎回初期化してから起動する。通常の手動確認用 `run/world` は削除しない。
+- `runGameTestServerCompat` は Farmer's Delight / Create / Botania / Lodestone / Malum 連携の確認に使う。
+- `runGameTestServerEasyMagic` は Puzzles Lib / Easy Magic 連携の確認に使う。
+- `runGameTestServerBetterCombat` は Cloth Config / Better Combat 連携の確認に使う。
+- `runGameTestServerEpicFight` は Epic Fight 連携の確認に使う。
+- `runClientCompatEasyBetter` は compat + EasyMagic + Better Combat を入れた実環境寄りの手動バランス確認用。Epic Fight は含めず、自動テスト対象にも含めない。
+- Better Combat と Epic Fight は干渉が大きいため、通常確認では同時投入しない。
+- optional MOD の runtime 切替は Gradle の実行構成または `-PdevRuntimeMods=...` で行う。`build.gradle` の `runtimeOnly` コメントアウト解除運用は使わない。
 - 通常確認で `clean` は付けない。必要時のみ `./gradlew.bat clean build` を使う。
 
 ## 4. コーディング規約
@@ -71,14 +103,22 @@ Get-ChildItem build\libs\*.jar
 5. コード、リソース、依存、datagen に影響する変更では `./gradlew.bat build` を成功させる。このビルドには明らかな文字化けと UTF-8 BOM の検査も含める。ドキュメントのみの変更では省略してよいが、最終報告に理由を残す。
 6. サーバー側の登録、データ読込、レシピ、生成、GameTest 対象構造に影響する変更では `./gradlew.bat runGameTestServer` を成功させる。
 7. client 専用 UI、renderer、screen、入力操作に影響する変更では必要に応じて `./gradlew.bat runClient` で確認する。
-8. コミットはレビューしやすく、forward-port しやすい粒度に分ける。無関係な整形や広域整理を混ぜない。
-9. `main` へ反映する変更は必ずブランチ + PR で流し、直 push しない。
-10. PR では GitHub Actions の `PR CI / build-and-gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
-11. 通常は merge commit で取り込む。バージョン更新だけは rebase merge を使ってよい。squash merge は使わない。
+8. optional MOD 連携に影響する変更では、対象に応じて特殊 GameTest / client 構成を追加実行する。
+   - Create / Botania / Lodestone / Malum / Farmer's Delight: `./gradlew.bat runGameTestServerCompat`
+   - EasyMagic / エンチャントメニュー: `./gradlew.bat runGameTestServerEasyMagic`
+   - Better Combat / offhand / weapon_attributes: `./gradlew.bat runGameTestServerBetterCombat`
+   - Epic Fight / mixin / capabilities / item_skins: `./gradlew.bat runGameTestServerEpicFight`
+   - client 側の連携確認: 対応する `runClient...` 構成
+   - 組み合わせバランス確認: `./gradlew.bat runClientCompatEasyBetter`
+9. コミットはレビューしやすく、forward-port しやすい粒度に分ける。無関係な整形や広域整理を混ぜない。
+10. `main` へ反映する変更は必ずブランチ + PR で流し、直 push しない。
+11. PR では GitHub Actions の `PR CI / build-and-gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
+12. 通常は merge commit で取り込む。バージョン更新だけは rebase merge を使ってよい。squash merge は使わない。
 
 ## 6. レビューチェックリスト
 - Java 17 環境で必要な検証が通っていること。コード/リソース変更では `./gradlew.bat build` を必須とする。
 - サーバー側の登録、データ読込、レシピ、生成に影響する変更では `./gradlew.bat runGameTestServer` が成功していること。
+- optional MOD 連携に影響する変更では、該当する `runGameTestServerCompat` / `runGameTestServerEasyMagic` / `runGameTestServerBetterCombat` / `runGameTestServerEpicFight`、または対応する `runClient...` の実行結果が説明されていること。
 - `main` へ送る PR では GitHub Actions の `PR CI / build-and-gametest` が成功していること。
 - Codex Cloud のスマートトリガーレビューで指摘が出ている場合、対応または明示的な見送り理由があること。
 - 追加・変更した要素の登録漏れ（Registry/EventBus）がないこと。

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 ```
 
 - `runGameTestServer` は専用 world `run/codex_gametest_clean` を毎回初期化してから起動します。通常の手動確認用 `run/world` は削除しません。
+- optional MOD 連携を含む GameTest は、通常 CI には入れず必要時に個別実行します。
+
+```powershell
+./gradlew.bat runGameTestServerCompat
+./gradlew.bat runGameTestServerEasyMagic
+./gradlew.bat runGameTestServerBetterCombat
+./gradlew.bat runGameTestServerEpicFight
+```
+
+- `runGameTestServerCompat` は Farmer's Delight / Create / Botania / Lodestone / Malum 連携を確認します。
+- `runGameTestServerEasyMagic` は Puzzles Lib / Easy Magic 連携を確認します。
+- `runGameTestServerBetterCombat` は Cloth Config / Better Combat 連携を確認します。
+- `runGameTestServerEpicFight` は Epic Fight 連携を確認します。
+- これらの特殊 GameTest では、対象 optional MOD が読み込まれていない場合に失敗します。
 - `runGameTestServer` では現在、次の項目を確認します。
 - Registry と動的登録の確認:
   item / block / block entity / entity / mob effect / enchantment / attribute / potion / recipe serializer / recipe type / creative tab / apprenticecodex の spell / School Affinity の動的 effect・potion・catalyst
@@ -77,10 +91,36 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 - 注意:
   これらはサーバー側の起動・読込・登録ミスの検知が主目的です。renderer や screen など client 専用の起動不良は別途 `runClient` で確認が必要です。
 
+### optional MOD 付き client 起動
+
+- IntelliJ IDEA で実行構成を再生成する場合:
+
+```powershell
+./gradlew.bat genIntellijRuns
+```
+
+- `genIntellijRuns` 後、通常の `runClient` に加えて次の client 構成を使えます。
+  - `runClientCompat`
+  - `runClientEasyMagic`
+  - `runClientBetterCombat`
+  - `runClientEpicFight`
+  - `runClientCompatEasyBetter`
+- `runClientCompatEasyBetter` は compat + EasyMagic + Better Combat を入れた実環境寄りの手動バランス確認用です。Epic Fight は含めず、自動テスト対象にもしていません。
+- 一時的な組み合わせ確認では Gradle プロパティでも追加できます。
+
+```powershell
+./gradlew.bat runClient "-PdevRuntimeMods=create,malum"
+./gradlew.bat runClient "-PdevRuntimeMods=epic_fight"
+```
+
+- `devRuntimeMods` には `compat`, `easy_magic`, `better_combat`, `epic_fight`, `compat_easy_better` または個別名（`create`, `botania`, `malum` など）をカンマ区切りで指定できます。
+- Better Combat と Epic Fight は干渉が大きいため、同時投入は通常確認では避けます。
+
 ## GitHub 運用
 
 - `main` への反映は、バージョン更新を含めてすべて PR 経由で行います。
 - PR では GitHub Actions の `PR CI / build-and-gametest` が必須です。`build` と `runGameTestServer` の両方が成功しない限りマージしません。
+- optional MOD 付きの特殊 GameTest / client 起動は required CI に含めません。必要な変更ではローカルまたは Codex 実行結果を PR コメントや最終報告に残します。
 - Codex Cloud のスマートトリガーレビューをレビュー補助として使います。人間の判断と CI 通過を置き換えるものではありません。
 - CI は GitHub-hosted runner 上で `pull_request` イベントだけを使い、repository secrets は使いません。
 - workflow の action はフル SHA pin を前提にし、`GITHUB_TOKEN` は read-only に制限します。

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,83 @@ println "Java: ${System.getProperty 'java.version'}, JVM: ${System.getProperty '
 
 def gameTestServerWorldName = 'codex_gametest_clean'
 def gameTestServerWorldDir = layout.projectDirectory.dir("run/${gameTestServerWorldName}")
+def requiredOptionalModsProperty = 'apprenticecodex.requiredOptionalMods'
+
+def optionalRuntimeModuleConfigurations = [
+        farmers_delight: 'farmersDelightRuntimeOnly',
+        create         : 'createRuntimeOnly',
+        botania        : 'botaniaRuntimeOnly',
+        puzzles_lib    : 'puzzlesLibRuntimeOnly',
+        easy_magic     : 'easyMagicRuntimeOnly',
+        cloth_config   : 'clothConfigRuntimeOnly',
+        better_combat  : 'betterCombatRuntimeOnly',
+        epic_fight     : 'epicFightRuntimeOnly',
+        lodestone      : 'lodestoneRuntimeOnly',
+        malum          : 'malumRuntimeOnly',
+]
+
+def optionalRuntimeProfileModules = [
+        compat              : ['farmers_delight', 'create', 'botania', 'lodestone', 'malum'],
+        easy_magic          : ['puzzles_lib', 'easy_magic'],
+        better_combat       : ['cloth_config', 'better_combat'],
+        epic_fight          : ['epic_fight'],
+        compat_easy_better  : ['farmers_delight', 'create', 'botania', 'lodestone', 'malum', 'puzzles_lib', 'easy_magic', 'cloth_config', 'better_combat'],
+]
+
+def optionalRuntimeSelectorModules = optionalRuntimeProfileModules + [
+        farmersdelight: ['farmers_delight'],
+        farmer        : ['farmers_delight'],
+        puzzleslib    : ['puzzles_lib'],
+        easymagic     : ['puzzles_lib', 'easy_magic'],
+        bettercombat  : ['cloth_config', 'better_combat'],
+        epicfight     : ['epic_fight'],
+        create        : ['create'],
+        botania       : ['botania'],
+        lodestone     : ['lodestone'],
+        malum         : ['lodestone', 'malum'],
+]
+
+def optionalRuntimeRequiredModIds = [
+        compat        : 'farmersdelight,create,botania,lodestone,malum',
+        easy_magic    : 'puzzleslib,easymagic',
+        better_combat : 'cloth_config,bettercombat',
+        epic_fight    : 'epicfight',
+]
+
+def optionalRuntimeModuleModIds = [
+        farmers_delight: 'farmersdelight',
+        create         : 'create',
+        botania        : 'botania',
+        puzzles_lib    : 'puzzleslib',
+        easy_magic     : 'easymagic',
+        cloth_config   : 'cloth_config',
+        better_combat  : 'bettercombat',
+        epic_fight     : 'epicfight',
+        lodestone      : 'lodestone',
+        malum          : 'malum',
+]
+
+def expandOptionalRuntimeModules = { Collection<String> selectors ->
+    selectors.collectMany { selector ->
+        def normalizedSelector = selector.trim().toLowerCase(Locale.ROOT).replace('-', '_')
+        def modules = optionalRuntimeSelectorModules[normalizedSelector]
+        if (modules == null) {
+            throw new GradleException("Unknown optional runtime MOD/profile '${selector}'. Available: ${optionalRuntimeSelectorModules.keySet().sort().join(', ')}")
+        }
+        modules
+    }.unique()
+}
+
+def optionalRuntimeModClassesTokenForModules = { Collection<String> modules ->
+    { ->
+        modules.findAll { module -> module != 'farmers_delight' }.collectMany { module ->
+            def modId = optionalRuntimeModuleModIds[module]
+            configurations.named(optionalRuntimeModuleConfigurations[module]).get().files.collect { file ->
+                "${modId}%%${file.absolutePath}"
+            }
+        }.join(File.pathSeparator)
+    }
+}
 
 minecraft {
     mappings channel: mapping_channel, version: mapping_version
@@ -54,6 +131,73 @@ minecraft {
             args '--world', gameTestServerWorldName
         }
 
+        clientCompat {
+            parent null, 'client'
+            taskName 'runClientCompat'
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['compat']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        clientEasyMagic {
+            parent null, 'client'
+            taskName 'runClientEasyMagic'
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['easy_magic']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        clientBetterCombat {
+            parent null, 'client'
+            taskName 'runClientBetterCombat'
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['better_combat']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        clientEpicFight {
+            parent null, 'client'
+            taskName 'runClientEpicFight'
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['epic_fight']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        clientCompatEasyBetter {
+            parent null, 'client'
+            taskName 'runClientCompatEasyBetter'
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['compat_easy_better']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        gameTestServerCompat {
+            parent null, 'gameTestServer'
+            taskName 'runGameTestServerCompat'
+            property requiredOptionalModsProperty, optionalRuntimeRequiredModIds.compat
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['compat']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        gameTestServerEasyMagic {
+            parent null, 'gameTestServer'
+            taskName 'runGameTestServerEasyMagic'
+            property requiredOptionalModsProperty, optionalRuntimeRequiredModIds.easy_magic
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['easy_magic']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        gameTestServerBetterCombat {
+            parent null, 'gameTestServer'
+            taskName 'runGameTestServerBetterCombat'
+            property requiredOptionalModsProperty, optionalRuntimeRequiredModIds.better_combat
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['better_combat']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
+        gameTestServerEpicFight {
+            parent null, 'gameTestServer'
+            taskName 'runGameTestServerEpicFight'
+            property requiredOptionalModsProperty, optionalRuntimeRequiredModIds.epic_fight
+            lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(expandOptionalRuntimeModules(['epic_fight']))
+            environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+        }
+
         data {
             workingDirectory project.file('run-data')
             args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
@@ -63,14 +207,33 @@ minecraft {
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
+configurations {
+    optionalRuntimeModuleConfigurations.values().each { configurationName ->
+        create(configurationName) {
+            canBeConsumed = false
+            canBeResolved = true
+            transitive = true
+        }
+    }
+}
+
 tasks.register('cleanGameTestServerWorld', Delete) {
     group = 'verification'
     description = 'Deletes the dedicated GameTest world so runGameTestServer starts from clean world state.'
     delete gameTestServerWorldDir
 }
 
-tasks.matching { it.name == 'runGameTestServer' }.configureEach {
+tasks.matching { it.name.startsWith('runGameTestServer') }.configureEach {
     dependsOn tasks.named('cleanGameTestServerWorld')
+}
+
+def devRuntimeMods = providers.gradleProperty('devRuntimeMods').orNull
+if (devRuntimeMods != null && !devRuntimeMods.trim().isEmpty()) {
+    def devRuntimeModules = expandOptionalRuntimeModules(devRuntimeMods.split(',').collect { it.trim() }.findAll { !it.isEmpty() })
+    minecraft.runs.named('client').configure {
+        lazyToken 'optional_mod_classes', optionalRuntimeModClassesTokenForModules(devRuntimeModules)
+        environment 'MOD_CLASSES', "{source_roots}${File.pathSeparator}{optional_mod_classes}"
+    }
 }
 
 // 依存のmavenをココに追加していく.
@@ -144,49 +307,49 @@ dependencies {
 
     // Create.
     // Create 連携のコンパイル用.
-    // ランタイム検証時のみ必要に応じてON.
+    // ランタイム検証では compat profile から読み込む.
     compileOnly fg.deobf("curse.maven:create-328085:7178761")
     compileOnly fg.deobf("com.tterrag.registrate:Registrate:MC1.20-1.3.3")
-    // runtimeOnly fg.deobf("curse.maven:create-328085:7178761")
+    add(optionalRuntimeModuleConfigurations.create, fg.deobf("curse.maven:create-328085:7178761"))
 
     // Botania.
     // Solegnolia 判定だけを optional compat から参照する。
     compileOnly fg.deobf("vazkii.botania:Botania:${botania_version}:api")
-    // runtimeOnly fg.deobf("vazkii.botania:Botania:${botania_version}")
+    add(optionalRuntimeModuleConfigurations.botania, fg.deobf("vazkii.botania:Botania:${botania_version}"))
 
     // EasyMagic.
-    // 必要に応じてON、デフォルトは入れない(前提にはしないため)
-    // runtimeOnly fg.deobf("maven.modrinth:puzzles-lib:V4g0yKzo")
-    // runtimeOnly fg.deobf("maven.modrinth:easy-magic:W2xPEG9I")
+    // easy_magic profile から読み込む。通常開発ではエンチャント挙動の変化を避ける.
+    add(optionalRuntimeModuleConfigurations.puzzles_lib, fg.deobf("maven.modrinth:puzzles-lib:V4g0yKzo"))
+    add(optionalRuntimeModuleConfigurations.easy_magic, fg.deobf("maven.modrinth:easy-magic:W2xPEG9I"))
 
     // Farmer's Delight.
-    // 必要に応じてON、デフォルトは入れない(前提にはしないため)
-    // HarvestMoon の互換回帰を GameTest で検証するため、開発環境では読み込む.
+    // HarvestMoon の互換回帰を既存の標準 GameTest で検証するため、開発環境では読み込む.
+    add(optionalRuntimeModuleConfigurations.farmers_delight, fg.deobf("maven.modrinth:farmers-delight:bCtijHxU"))
     runtimeOnly fg.deobf("maven.modrinth:farmers-delight:bCtijHxU")
 
     // Better Combat.
     // Better Combat の攻撃開始フックへ接続する互換コードのコンパイル用.
-    // ランタイム検証時は Better Combat の前提である Cloth Config も合わせて入れる.
+    // better_combat profile では前提である Cloth Config も合わせて読み込む.
     compileOnly fg.deobf("maven.modrinth:better-combat:rnhiaw3t")
-    // runtimeOnly fg.deobf("maven.modrinth:cloth-config:t8TXrZvZ")
-    // runtimeOnly fg.deobf("maven.modrinth:better-combat:rnhiaw3t")
+    add(optionalRuntimeModuleConfigurations.cloth_config, fg.deobf("maven.modrinth:cloth-config:t8TXrZvZ"))
+    add(optionalRuntimeModuleConfigurations.better_combat, fg.deobf("maven.modrinth:better-combat:rnhiaw3t"))
 
     // Epic Fight.
     // コンパイルは最低対応版に固定し、新しいAPIの誤使用を検出する.
-    // ランタイムは20.14系最新を使い、通常の起動確認では最新側の挙動を見る.
+    // ランタイムは epic_fight profile で20.14系最新を使い、最新側の挙動を見る.
     compileOnly fg.deobf("maven.modrinth:epic-fight:${epicfight_compile_version}")
-    // runtimeOnly fg.deobf("curse.maven:epic-fight-mod-405076:${epicfight_runtime_file_id}")
+    add(optionalRuntimeModuleConfigurations.epic_fight, fg.deobf("curse.maven:epic-fight-mod-405076:${epicfight_runtime_file_id}"))
 
     // Lootr.
     // TreasureDivination が Lootr の個人開封済み判定へ接続するためのコンパイル用.
     compileOnly fg.deobf("noobanidus.mods.lootr:lootr-${minecraft_version}:${lootr_version}")
 
     // Lodestone / Malum.
-    // 必要に応じてON、デフォルトは入れない(必須前提にはしないため)
+    // compat profile から読み込む。通常開発では追加要素による調査ノイズを避ける.
     compileOnly fg.deobf("curse.maven:lodestone-616457:6213794")
     compileOnly fg.deobf("curse.maven:malum-484064:6646111")
-    // runtimeOnly fg.deobf("curse.maven:lodestone-616457:6213794")
-    // runtimeOnly fg.deobf("curse.maven:malum-484064:6646111")
+    add(optionalRuntimeModuleConfigurations.lodestone, fg.deobf("curse.maven:lodestone-616457:6213794"))
+    add(optionalRuntimeModuleConfigurations.malum, fg.deobf("curse.maven:malum-484064:6646111"))
 
     // JEI.
     compileOnly fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}")

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexCoreGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexCoreGameTests.java
@@ -16,6 +16,11 @@ public final class ApprenticeCodexCoreGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void requiredOptionalModsAreLoaded(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.requiredOptionalModsAreLoaded(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void registriesAndDynamicContentAreRegistered(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.registriesAndDynamicContentAreRegistered(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -280,6 +280,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.lang.reflect.Method;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -297,6 +298,7 @@ public final class ApprenticeCodexGameTestScenarios {
 
     private static final String CREATE_GAMETEST_HOOKS_CLASS =
             "jp.aquafactory.apprenticecodex.gametest.create.CreateGameTestHooks";
+    private static final String REQUIRED_OPTIONAL_MODS_PROPERTY = "apprenticecodex.requiredOptionalMods";
     private static final String VANILLA_NAMESPACE = "minecraft";
     private static final String FARMERS_DELIGHT_MOD_ID = "farmersdelight";
     private static final String LODESTONE_MOD_ID = "lodestone";
@@ -349,6 +351,24 @@ public final class ApprenticeCodexGameTestScenarios {
 
     private ApprenticeCodexGameTestScenarios() {
     }
+
+    static void requiredOptionalModsAreLoaded(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var requiredModsProperty = System.getProperty(REQUIRED_OPTIONAL_MODS_PROPERTY, "").trim();
+            if (requiredModsProperty.isEmpty()) {
+                return;
+            }
+
+            var missingModIds = Arrays.stream(requiredModsProperty.split(","))
+                    .map(String::trim)
+                    .filter(modId -> !modId.isEmpty())
+                    .filter(modId -> !ModList.get().isLoaded(modId))
+                    .toList();
+            helper.assertTrue(missingModIds.isEmpty(),
+                    "Required optional MODs are missing for this GameTest run: " + missingModIds);
+        });
+    }
+
     static void registriesAndDynamicContentAreRegistered(GameTestHelper helper) {
         helper.succeedIf(() -> {
             assertForgeRegistryEntries(helper, "item", net.minecraftforge.registries.ForgeRegistries.ITEMS, ItemRegistry.ITEMS.getEntries());


### PR DESCRIPTION
## 概要
- optional MOD を `runtimeOnly` コメントアウト運用ではなく Gradle の profile / 実行構成で切り替えられるようにしました。
- compat / Easy Magic / Better Combat / Epic Fight 用の GameTest server 構成と、対応する client 構成を追加しました。
- IntelliJ IDEA 向けには `genIntellijRuns` で `MOD_CLASSES` に optional MOD を渡す形にし、`runClientCompatEasyBetter` も追加しました。
- README / AGENTS.md に運用手順を追記しました。

## 確認
- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat runGameTestServerCompat`
- `./gradlew.bat runGameTestServerEasyMagic`
- `./gradlew.bat runGameTestServerBetterCombat`
- `./gradlew.bat runGameTestServerEpicFight`
- `./gradlew.bat runClient "-PdevRuntimeMods=create,malum" --dry-run`
- `./gradlew.bat runClientCompatEasyBetter --dry-run`
- `./gradlew.bat genIntellijRuns`

## 補足
- `runClientCompatEasyBetter` は compat + Easy Magic + Better Combat の手動バランス確認用で、Epic Fight は含めていません。
- 特殊 GameTest は現状 required CI には含めず、必要に応じてローカル / Codex で個別実行する想定です。
- Farmer's Delight は標準 runtime 側に既に入っているため、`MOD_CLASSES` へ重複登録しない扱いにしています。