### PR TITLE
PR 528のoptional MOD実行構成を1.21.1へ移植

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,36 @@
 .\scripts\use-java.ps1
 ./gradlew.bat runGameTestServer
 ```
+- optional MOD 連携 GameTest:
+```powershell
+.\scripts\use-java.ps1
+./gradlew.bat runGameTestServerCompat
+./gradlew.bat runGameTestServerEasyMagic
+./gradlew.bat runGameTestServerBetterCombat
+./gradlew.bat runGameTestServerEpicFight
+```
 - 開発クライアント:
 ```powershell
 .\scripts\use-java.ps1
 ./gradlew.bat runClient
+```
+- optional MOD 付き開発クライアント:
+```powershell
+.\scripts\use-java.ps1
+./gradlew.bat runClientCompat
+./gradlew.bat runClientEasyMagic
+./gradlew.bat runClientBetterCombat
+./gradlew.bat runClientEpicFight
+./gradlew.bat runClientCompatEasyBetter
+```
+- 一時的な optional MOD 追加:
+```powershell
+./gradlew.bat runClient "-PdevRuntimeMods=create,malum"
+```
+- IntelliJ IDEA 実行構成の同期:
+```powershell
+.\scripts\use-java.ps1
+./gradlew.bat neoForgeIdeSync
 ```
 - Datagen 再生成:
 ```powershell
@@ -56,6 +82,15 @@ Get-ChildItem build\libs\*.jar
 - `runClient` は GUI を起動するため、CI やヘッドレス環境では実行しない。
 - `runGameTestServer` はサーバー側の登録、データ読込、レシピ、生成まわりの検証に使う。renderer / screen など client 専用の起動不良は別途 `runClient` で確認する。
 - `runGameTestServer` は専用 world `run/codex_gametest_clean` を毎回初期化してから起動する。通常の手動確認用 `run/world` は削除しない。
+- `runGameTestServerCompat` は Farmer's Delight / Create / Lodestone / Malum 連携の確認に使う。
+- `runGameTestServerEasyMagic` は Puzzles Lib / Easy Magic 連携の確認に使う。
+- `runGameTestServerBetterCombat` は Cloth Config / Better Combat 連携の確認に使う。
+- `runGameTestServerEpicFight` は Epic Fight 連携の確認に使う。
+- `runClientCompatEasyBetter` は compat + Easy Magic + Better Combat を入れた実環境寄りの手動バランス確認用。Epic Fight は含めず、自動テスト対象にも含めない。
+- IntelliJ IDEA から client 構成を起動して `Unsupported major.minor version 65.0` が出る場合は、Project SDK / Gradle JVM / 古い実行構成が Java 17 を参照している。IDEA 側を JDK 21 にそろえ、`neoForgeIdeSync` を再実行し、必要なら古い Minecraft run configuration を削除して再生成する。
+- Botania は 1.21.1 側で API 依存を置いていないため、optional MOD profile には含めない。
+- Better Combat と Epic Fight は干渉が大きいため、通常確認では同時投入しない。
+- optional MOD の runtime 切替は Gradle の実行構成または `-PdevRuntimeMods=...` で行う。`build.gradle` の `runtimeOnly` / `localRuntime` コメントアウト解除運用は使わない。
 - 通常確認で `clean` は付けない。必要時のみ `./gradlew.bat clean build` を使う。
 - `runData` の出力先は `src/generated/resources` であり、`src/generated/resources/.cache` に記録された生成物だけが再生成・差分管理される前提で扱う。
 - `src/generated/resources/.cache` は Git 管理外のため、branch 切替・`cherry-pick`・手動コピーで持ち込んだ古い JSON は `runData` だけでは削除されない場合がある。
@@ -78,16 +113,24 @@ Get-ChildItem build\libs\*.jar
 4. コード、リソース、依存、datagen に影響する変更では `./gradlew.bat build` を成功させる。このビルドには明らかな文字化けと UTF-8 BOM の検査も含める。ドキュメントのみの変更では省略してよいが、最終報告に理由を残す。
 5. サーバー側の登録、データ読込、レシピ、生成、GameTest 対象構造に影響する変更では `./gradlew.bat runGameTestServer` を成功させる。
 6. `main` から `1.21.1-main` への forward-port では、実装内容に関係なく `./gradlew.bat runGameTestServer` と `./gradlew.bat build` を成功させる。
-7. client 専用 UI、renderer、screen、入力操作に影響する変更では必要に応じて `./gradlew.bat runClient` で確認する。
-8. コミットはレビューしやすく、forward-port しやすい粒度に分ける。無関係な整形や広域整理を混ぜない。
-9. `1.21.1-main` へ取り込む変更は必ずブランチ + PR で流し、直 push しない。
-10. PR では GitHub Actions の `PR CI / build-and-gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
-11. 通常は merge commit で取り込む。バージョン更新だけは rebase merge を使ってよい。squash merge は使わない。
+7. optional MOD 連携に影響する変更では、対象に応じて特殊 GameTest / client 構成を追加実行する。
+   - Create / Lodestone / Malum / Farmer's Delight: `./gradlew.bat runGameTestServerCompat`
+   - Easy Magic / エンチャントメニュー: `./gradlew.bat runGameTestServerEasyMagic`
+   - Better Combat / offhand / weapon_attributes: `./gradlew.bat runGameTestServerBetterCombat`
+   - Epic Fight / mixin / capabilities / item_skins: `./gradlew.bat runGameTestServerEpicFight`
+   - client 側の連携確認: 対応する `runClient...` 構成
+   - 組み合わせバランス確認: `./gradlew.bat runClientCompatEasyBetter`
+8. client 専用 UI、renderer、screen、入力操作に影響する変更では必要に応じて `./gradlew.bat runClient` で確認する。
+9. コミットはレビューしやすく、forward-port しやすい粒度に分ける。無関係な整形や広域整理を混ぜない。
+10. `1.21.1-main` へ取り込む変更は必ずブランチ + PR で流し、直 push しない。
+11. PR では GitHub Actions の `PR CI / build-and-gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
+12. 通常は merge commit で取り込む。バージョン更新だけは rebase merge を使ってよい。squash merge は使わない。
 
 ## 6. レビューチェックリスト
 - Java 21 環境で必要な検証が通っていること。コード/リソース変更では `./gradlew.bat build` を必須とする。
 - サーバー側の登録、データ読込、レシピ、生成に影響する変更では `./gradlew.bat runGameTestServer` が成功していること。
 - `main` から `1.21.1-main` への forward-port では、実装内容に関係なく `./gradlew.bat runGameTestServer` と `./gradlew.bat build` が成功していること。
+- optional MOD 連携に影響する変更では、該当する `runGameTestServerCompat` / `runGameTestServerEasyMagic` / `runGameTestServerBetterCombat` / `runGameTestServerEpicFight`、または対応する `runClient...` の実行結果が説明されていること。
 - `1.21.1-main` 向け PR では GitHub Actions の `PR CI / build-and-gametest` が成功していること。
 - Codex Cloud のスマートトリガーレビューで指摘が出ている場合、対応または明示的な見送り理由があること。
 - 追加・変更した要素の登録漏れ（Registry/EventBus）がないこと。

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 ```
 
 - `runGameTestServer` は専用 world `run/codex_gametest_clean` を毎回初期化してから起動します。通常の手動確認用 `run/world` は削除しません。
+- optional MOD 連携を含む GameTest は、通常 CI には入れず必要時に個別実行します。
+
+```powershell
+./gradlew.bat runGameTestServerCompat
+./gradlew.bat runGameTestServerEasyMagic
+./gradlew.bat runGameTestServerBetterCombat
+./gradlew.bat runGameTestServerEpicFight
+```
+
+- `runGameTestServerCompat` は Farmer's Delight / Create / Lodestone / Malum 連携を確認します。
+- `runGameTestServerEasyMagic` は Puzzles Lib / Easy Magic 連携を確認します。
+- `runGameTestServerBetterCombat` は Cloth Config / Better Combat 連携を確認します。
+- `runGameTestServerEpicFight` は Epic Fight 連携を確認します。
+- これらの特殊 GameTest では、対象 optional MOD が読み込まれていない場合に失敗します。
 - `runGameTestServer` では現在、次の項目を確認します。
 - Registry と動的登録の確認:
   item / block / block entity / entity / mob effect / enchantment / attribute / potion / recipe serializer / recipe type / creative tab / apprenticecodex の spell / School Affinity の動的 effect・potion・catalyst
@@ -76,9 +90,38 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 - 注意:
   これらはサーバー側の起動・読込・登録ミスの検知が主目的です。renderer や screen など client 専用の起動不良は別途 `runClient` で確認が必要です。
 
+### optional MOD 付き client 起動
+
+- IntelliJ IDEA で実行構成を同期する場合:
+
+```powershell
+.\scripts\use-java.ps1
+./gradlew.bat neoForgeIdeSync
+```
+
+- IDEA から起動して `Unsupported major.minor version 65.0` が出る場合は、IDEA が Java 17 の Project SDK / Gradle JVM / 古い実行構成を掴んでいます。Project SDK と Gradle JVM を JDK 21 にしてから `neoForgeIdeSync` を再実行し、必要なら古い Minecraft run configuration を削除して再生成してください。
+- Gradle 同期後、通常の `runClient` に加えて次の client 構成を使えます。
+  - `runClientCompat`
+  - `runClientEasyMagic`
+  - `runClientBetterCombat`
+  - `runClientEpicFight`
+  - `runClientCompatEasyBetter`
+- `runClientCompatEasyBetter` は compat + Easy Magic + Better Combat を入れた実環境寄りの手動バランス確認用です。Epic Fight は含めず、自動テスト対象にもしていません。
+- 一時的な組み合わせ確認では Gradle プロパティでも追加できます。
+
+```powershell
+./gradlew.bat runClient "-PdevRuntimeMods=create,malum"
+./gradlew.bat runClient "-PdevRuntimeMods=epic_fight"
+```
+
+- `devRuntimeMods` には `compat`, `easy_magic`, `better_combat`, `epic_fight`, `compat_easy_better` または個別名（`create`, `lodestone`, `malum` など）をカンマ区切りで指定できます。
+- Botania は 1.21.1 側で API 依存を置いていないため、optional MOD profile には含めていません。
+- Better Combat と Epic Fight は干渉が大きいため、同時投入は通常確認では避けます。
+
 ## PR 運用
 
 - `1.21.1-main` への取り込みは PR 経由で行い、`PR CI / build-and-gametest` の成功を必須とします。
+- optional MOD 付きの特殊 GameTest / client 起動は required CI に含めません。必要な変更ではローカルまたは Codex 実行結果を PR コメントや最終報告に残します。
 - Codex Cloud のスマートトリガーレビューをレビュー補助として使います。人間の判断と CI 通過を置き換えるものではありません。
 - GitHub Actions は `pull_request` でのみ実行し、`pull_request_target` は使いません。
 - CI では secrets を使いません。workflow 権限は read-only に固定します。

--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,77 @@ base {
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(21)
 
+idea {
+    project {
+        jdkName = '21'
+        languageLevel = JavaVersion.VERSION_21
+    }
+}
+
 def gameTestServerWorldName = 'codex_gametest_clean'
 def gameTestServerWorldDir = layout.projectDirectory.dir("run/${gameTestServerWorldName}")
+def requiredOptionalModsProperty = 'apprenticecodex.requiredOptionalMods'
+
+def optionalRuntimeModuleConfigurations = [
+        farmers_delight: 'farmersDelightRuntimeOnly',
+        create         : 'createRuntimeOnly',
+        puzzles_lib    : 'puzzlesLibRuntimeOnly',
+        easy_magic     : 'easyMagicRuntimeOnly',
+        cloth_config   : 'clothConfigRuntimeOnly',
+        better_combat  : 'betterCombatRuntimeOnly',
+        epic_fight     : 'epicFightRuntimeOnly',
+        lodestone      : 'lodestoneRuntimeOnly',
+        malum          : 'malumRuntimeOnly',
+]
+
+def optionalRuntimeProfileModules = [
+        compat            : ['farmers_delight', 'create', 'lodestone', 'malum'],
+        easy_magic        : ['puzzles_lib', 'easy_magic'],
+        better_combat     : ['cloth_config', 'better_combat'],
+        epic_fight        : ['epic_fight'],
+        compat_easy_better: ['farmers_delight', 'create', 'lodestone', 'malum', 'puzzles_lib', 'easy_magic', 'cloth_config', 'better_combat'],
+]
+
+def optionalRuntimeSelectorModules = optionalRuntimeProfileModules + [
+        farmersdelight: ['farmers_delight'],
+        farmer        : ['farmers_delight'],
+        puzzleslib    : ['puzzles_lib'],
+        easymagic     : ['puzzles_lib', 'easy_magic'],
+        bettercombat  : ['cloth_config', 'better_combat'],
+        epicfight     : ['epic_fight'],
+        create        : ['create'],
+        lodestone     : ['lodestone'],
+        malum         : ['lodestone', 'malum'],
+]
+
+def optionalRuntimeRequiredModIds = [
+        compat       : 'farmersdelight,create,lodestone,malum',
+        easy_magic   : 'puzzleslib,easymagic',
+        better_combat: 'cloth_config,bettercombat',
+        epic_fight   : 'epicfight',
+]
+
+def expandOptionalRuntimeModules = { Collection<String> selectors ->
+    selectors.collectMany { selector ->
+        def normalizedSelector = selector.trim().toLowerCase(Locale.ROOT).replace('-', '_')
+        def modules = optionalRuntimeSelectorModules[normalizedSelector]
+        if (modules == null) {
+            throw new GradleException("Unknown optional runtime MOD/profile '${selector}'. Available: ${optionalRuntimeSelectorModules.keySet().sort().join(', ')}")
+        }
+        modules
+    }.unique()
+}
+
+def extendRunJavaClasspath = { String runName, Collection<String> modules ->
+    def runTaskName = "run${runName.capitalize()}"
+    tasks.named(runTaskName).configure { task ->
+        def runtimeConfigurations = modules.collect { module ->
+            configurations.named(optionalRuntimeModuleConfigurations[module])
+        }
+        task.getClasspathProvider().from runtimeConfigurations
+        task.classpath runtimeConfigurations
+    }
+}
 
 neoForge {
     version = project.neo_version
@@ -88,6 +157,59 @@ neoForge {
         gameTestServer {
             type = "gameTestServer"
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            programArguments.addAll '--world', gameTestServerWorldName
+        }
+
+        clientCompat {
+            client()
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+        }
+
+        clientEasyMagic {
+            client()
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+        }
+
+        clientBetterCombat {
+            client()
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+        }
+
+        clientEpicFight {
+            client()
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+        }
+
+        clientCompatEasyBetter {
+            client()
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+        }
+
+        gameTestServerCompat {
+            type = "gameTestServer"
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty requiredOptionalModsProperty, optionalRuntimeRequiredModIds.compat
+            programArguments.addAll '--world', gameTestServerWorldName
+        }
+
+        gameTestServerEasyMagic {
+            type = "gameTestServer"
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty requiredOptionalModsProperty, optionalRuntimeRequiredModIds.easy_magic
+            programArguments.addAll '--world', gameTestServerWorldName
+        }
+
+        gameTestServerBetterCombat {
+            type = "gameTestServer"
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty requiredOptionalModsProperty, optionalRuntimeRequiredModIds.better_combat
+            programArguments.addAll '--world', gameTestServerWorldName
+        }
+
+        gameTestServerEpicFight {
+            type = "gameTestServer"
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty requiredOptionalModsProperty, optionalRuntimeRequiredModIds.epic_fight
             programArguments.addAll '--world', gameTestServerWorldName
         }
 
@@ -117,12 +239,35 @@ tasks.register('cleanGameTestServerWorld', Delete) {
     delete gameTestServerWorldDir
 }
 
-tasks.matching { it.name == 'runGameTestServer' }.configureEach {
+tasks.matching { it.name.startsWith('runGameTestServer') }.configureEach {
     dependsOn tasks.named('cleanGameTestServerWorld')
 }
 
 configurations {
     runtimeClasspath.extendsFrom localRuntime
+    optionalRuntimeModuleConfigurations.values().each { configurationName ->
+        create(configurationName) {
+            canBeConsumed = false
+            canBeResolved = true
+            transitive = true
+        }
+    }
+}
+
+extendRunJavaClasspath('clientCompat', expandOptionalRuntimeModules(['compat']))
+extendRunJavaClasspath('clientEasyMagic', expandOptionalRuntimeModules(['easy_magic']))
+extendRunJavaClasspath('clientBetterCombat', expandOptionalRuntimeModules(['better_combat']))
+extendRunJavaClasspath('clientEpicFight', expandOptionalRuntimeModules(['epic_fight']))
+extendRunJavaClasspath('clientCompatEasyBetter', expandOptionalRuntimeModules(['compat_easy_better']))
+extendRunJavaClasspath('gameTestServerCompat', expandOptionalRuntimeModules(['compat']))
+extendRunJavaClasspath('gameTestServerEasyMagic', expandOptionalRuntimeModules(['easy_magic']))
+extendRunJavaClasspath('gameTestServerBetterCombat', expandOptionalRuntimeModules(['better_combat']))
+extendRunJavaClasspath('gameTestServerEpicFight', expandOptionalRuntimeModules(['epic_fight']))
+
+def devRuntimeMods = providers.gradleProperty('devRuntimeMods').orNull
+if (devRuntimeMods != null && !devRuntimeMods.trim().isEmpty()) {
+    def devRuntimeModules = expandOptionalRuntimeModules(devRuntimeMods.split(',').collect { it.trim() }.findAll { !it.isEmpty() })
+    extendRunJavaClasspath('client', devRuntimeModules)
 }
 
 dependencies {
@@ -142,44 +287,43 @@ dependencies {
 
     // Create.
     // Create 連携のコンパイル用.
-    // ランタイム検証時のみ必要に応じてON.
+    // ランタイム検証では compat profile から読み込む.
     compileOnly "curse.maven:create-328085:7178775"
     compileOnly "com.tterrag.registrate:Registrate:${registrate_version}"
-    // runtimeOnly "curse.maven:create-328085:7178775"
+    add(optionalRuntimeModuleConfigurations.create, "curse.maven:create-328085:7178775")
 
     // EasyMagic.
-    // 必要に応じてON、デフォルトは入れない(前提にはしないため)
-    // localRuntime "maven.modrinth:puzzles-lib:v21.1.39-1.21.1-NeoForge"
-    // localRuntime "maven.modrinth:easy-magic:v21.1.4-1.21.1-NeoForge"
+    // easy_magic profile から読み込む。通常開発ではエンチャント挙動の変化を避ける.
+    add(optionalRuntimeModuleConfigurations.puzzles_lib, "maven.modrinth:puzzles-lib:v21.1.39-1.21.1-NeoForge")
+    add(optionalRuntimeModuleConfigurations.easy_magic, "maven.modrinth:easy-magic:v21.1.4-1.21.1-NeoForge")
 
     // Farmer's Delight.
-    // 必要に応じてON、デフォルトは入れない(前提にはしないため)
-    // HarvestMoon の互換回帰を GameTest で検証するため、開発環境では読み込む.
+    // HarvestMoon の互換回帰を既存の標準 GameTest で検証するため、開発環境では読み込む.
     runtimeOnly "maven.modrinth:farmers-delight:cYqC3svy"
 
     // Better Combat.
     // Better Combat の攻撃開始フックへ接続する互換コードのコンパイル用.
-    // ランタイムは必要に応じてON(1.20.1と異なり前提が増えている点に注意)
+    // better_combat profile では前提である Cloth Config も合わせて読み込む.
     compileOnly "maven.modrinth:better-combat:2NyTus6V"
-    // runtimeOnly "maven.modrinth:cloth-config:DqgODWcH"
-    // runtimeOnly "maven.modrinth:better-combat:2NyTus6V"
+    add(optionalRuntimeModuleConfigurations.cloth_config, "maven.modrinth:cloth-config:DqgODWcH")
+    add(optionalRuntimeModuleConfigurations.better_combat, "maven.modrinth:better-combat:2NyTus6V")
 
     // Epic Fight.
     // 武器関連対応、特殊武器アクション(e.g. 打撃詠唱杖の魔法発動)のコード接続用に参照も含める.
-    // 必要に応じてON、デフォルトは入れない(必須前提にはしないため)
+    // ランタイムは epic_fight profile から読み込む.
     compileOnly "maven.modrinth:epic-fight:${epicfight_version}"
-    // runtimeOnly "maven.modrinth:epic-fight:${epicfight_version}"
+    add(optionalRuntimeModuleConfigurations.epic_fight, "maven.modrinth:epic-fight:${epicfight_version}")
 
     // Lootr.
     // TreasureDivination が Lootr の個人開封済み判定へ接続するためのコンパイル用.
     compileOnly "noobanidus.mods.lootr:lootr-neoforge:${lootr_version}"
 
     // Lodestone / Malum.
-    // 必要に応じてランタイムはONにする.
+    // compat profile から読み込む。通常開発では追加要素による調査ノイズを避ける.
     compileOnly "curse.maven:lodestone-616457:7264731"
     compileOnly "curse.maven:malum-484064:7307339"
-    //runtimeOnly "curse.maven:lodestone-616457:7264731"
-    //runtimeOnly "curse.maven:malum-484064:7307339"
+    add(optionalRuntimeModuleConfigurations.lodestone, "curse.maven:lodestone-616457:7264731")
+    add(optionalRuntimeModuleConfigurations.malum, "curse.maven:malum-484064:7307339")
 
     // JEI.
     compileOnly "mezz.jei:jei-${minecraft_version}-neoforge:${jei_version}"

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexCoreGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexCoreGameTests.java
@@ -16,6 +16,11 @@ public final class ApprenticeCodexCoreGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void requiredOptionalModsAreLoaded(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.requiredOptionalModsAreLoaded(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void registriesAndDynamicContentAreRegistered(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.registriesAndDynamicContentAreRegistered(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -292,6 +292,7 @@ import net.neoforged.fml.ModList;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.lang.reflect.Method;
@@ -312,6 +313,7 @@ public final class ApprenticeCodexGameTestScenarios {
 
     private static final String CREATE_GAMETEST_HOOKS_CLASS =
             "jp.aquafactory.apprenticecodex.gametest.create.CreateGameTestHooks";
+    private static final String REQUIRED_OPTIONAL_MODS_PROPERTY = "apprenticecodex.requiredOptionalMods";
     private static final String VANILLA_NAMESPACE = "minecraft";
     private static final String FARMERS_DELIGHT_MOD_ID = "farmersdelight";
     private static final String LODESTONE_MOD_ID = "lodestone";
@@ -363,6 +365,26 @@ public final class ApprenticeCodexGameTestScenarios {
 
     private ApprenticeCodexGameTestScenarios() {
     }
+
+    static void requiredOptionalModsAreLoaded(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var requiredModsProperty = System.getProperty(REQUIRED_OPTIONAL_MODS_PROPERTY, "").trim();
+            if (requiredModsProperty.isEmpty()) {
+                return;
+            }
+
+            var missingModIds = Arrays.stream(requiredModsProperty.split(","))
+                    .map(String::trim)
+                    .filter(modId -> !modId.isEmpty())
+                    .filter(modId -> !ModList.get().isLoaded(modId))
+                    .toList();
+            helper.assertTrue(
+                    missingModIds.isEmpty(),
+                    "Required optional MODs are missing for this GameTest run: " + missingModIds
+            );
+        });
+    }
+
     static void registriesAndDynamicContentAreRegistered(GameTestHelper helper) {
         helper.succeedIf(() -> {
             assertBuiltinRegistryEntries(helper, "item", BuiltInRegistries.ITEM, ItemRegistry.ITEMS.getEntries());


### PR DESCRIPTION
## 概要
- PR #528 の optional MOD 実行構成を 1.21.1 / NeoForge ModDevGradle 向けに再実装
- compat / Easy Magic / Better Combat / Epic Fight 用の client と GameTest 実行構成を追加
- optional MOD のロード確認 GameTest と `devRuntimeMods` 指定を追加
- IntelliJ IDEA で JDK 17 の古い実行構成を掴んだ場合の注意を README / AGENTS に追記

## 検証
- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat runGameTestServerCompat`
- `./gradlew.bat runGameTestServerEasyMagic`
- `./gradlew.bat runGameTestServerBetterCombat`
- `./gradlew.bat runGameTestServerEpicFight`
- `./gradlew.bat runClientCompatEasyBetter --dry-run`
- `./gradlew.bat neoForgeIdeSync --dry-run`

## 補足
- `runClientCompatEasyBetter` は Gradle 経由では Java 21 で起動することを確認済み
- IDEA 側の古い実行構成が Java 17 を参照している場合は `Unsupported major.minor version 65.0` になるため、Project SDK / Gradle JVM を JDK 21 にそろえて再同期する想定