### PR TITLE
PR #527を1.21.1-mainへforward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatDualWieldingPolicyCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatDualWieldingPolicyCompat.java
@@ -1,0 +1,24 @@
+package jp.aquafactory.apprenticecodex.compat.bettercombat;
+
+import jp.aquafactory.apprenticecodex.item.BetterCombatOffhandDualWieldingPolicyItem;
+import net.minecraft.world.entity.player.Player;
+
+public final class BetterCombatDualWieldingPolicyCompat {
+    private BetterCombatDualWieldingPolicyCompat() {
+    }
+
+    public static boolean shouldSuppressDualWielding(Player player) {
+        if (player == null) {
+            return false;
+        }
+
+        var mainHandStack = player.getMainHandItem();
+        var offhandStack = player.getOffhandItem();
+        if (mainHandStack.isEmpty() || offhandStack.isEmpty()) {
+            return false;
+        }
+
+        return offhandStack.getItem() instanceof BetterCombatOffhandDualWieldingPolicyItem policyItem
+                && policyItem.suppressesBetterCombatOffhandDualWielding(offhandStack, mainHandStack);
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -389,6 +389,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void betterCombatOffhandOnlyGauntletDoesNotForceDualWielding(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.betterCombatOffhandOnlyGauntletDoesNotForceDualWielding(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void betterCombatOffhandRescueIncludesEnchantAndImbueDerivedModifiers(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.betterCombatOffhandRescueIncludesEnchantAndImbueDerivedModifiers(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -6266,6 +6266,46 @@ public final class ApprenticeCodexGameTestScenarios {
                             + spellPowerBonus + " modifiers=" + describeModifiers(amplifierModifiers));
         });
     }
+
+    static void betterCombatOffhandOnlyGauntletDoesNotForceDualWielding(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            if (!ModList.get().isLoaded("bettercombat")) {
+                return;
+            }
+
+            var swordStack = new ItemStack(Items.DIAMOND_SWORD);
+            var gauntletStack = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
+            helper.assertTrue(net.bettercombat.logic.WeaponRegistry.getAttributes(swordStack) != null,
+                    "Better Combat diamond sword attributes should be present for offhand Gauntlet test");
+            helper.assertTrue(net.bettercombat.logic.WeaponRegistry.getAttributes(gauntletStack) != null,
+                    "Better Combat Scrollcaster Gauntlet attributes should be present for offhand Gauntlet test");
+
+            var swordMainPlayer = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "better_combat_offhand_gauntlet_no_dual_test");
+            swordMainPlayer.setItemInHand(InteractionHand.MAIN_HAND, swordStack);
+            swordMainPlayer.setItemInHand(InteractionHand.OFF_HAND, gauntletStack.copy());
+
+            helper.assertFalse(net.bettercombat.logic.PlayerAttackHelper.isDualWielding(swordMainPlayer),
+                    "Offhand-only Scrollcaster Gauntlet should not make a normal mainhand weapon dual wield");
+            var secondSwordAttack = net.bettercombat.logic.PlayerAttackHelper.getCurrentAttack(swordMainPlayer, 1);
+            helper.assertTrue(secondSwordAttack != null && !secondSwordAttack.isOffHand(),
+                    "Offhand-only Scrollcaster Gauntlet should keep Better Combat attacks on mainhand but got "
+                            + secondSwordAttack);
+
+            var dualGauntletPlayer = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "better_combat_dual_gauntlet_stays_dual_test");
+            dualGauntletPlayer.setItemInHand(InteractionHand.MAIN_HAND, gauntletStack.copy());
+            dualGauntletPlayer.setItemInHand(InteractionHand.OFF_HAND, gauntletStack.copy());
+
+            helper.assertTrue(net.bettercombat.logic.PlayerAttackHelper.isDualWielding(dualGauntletPlayer),
+                    "Two Scrollcaster Gauntlets should keep the previous Better Combat dual wield behavior");
+            var secondGauntletAttack = net.bettercombat.logic.PlayerAttackHelper.getCurrentAttack(dualGauntletPlayer, 1);
+            helper.assertTrue(secondGauntletAttack != null && secondGauntletAttack.isOffHand(),
+                    "Dual Scrollcaster Gauntlets should still select offhand on the second attack but got "
+                            + secondGauntletAttack);
+        });
+    }
+
     static void chargedTwinBladeStaffUpgradeMergesMainhandMeleeDamage(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var item = (ChargedTwinBladeStaff) ItemRegistry.CHARGED_TWIN_BLADE_STAFF.get();

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/BetterCombatOffhandDualWieldingPolicyItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/BetterCombatOffhandDualWieldingPolicyItem.java
@@ -1,0 +1,25 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import net.minecraft.world.item.ItemStack;
+
+public interface BetterCombatOffhandDualWieldingPolicyItem {
+    default boolean suppressesBetterCombatOffhandDualWielding(
+            ItemStack offhandStack,
+            ItemStack mainHandStack
+    ) {
+        return !allowsBetterCombatDualWieldingWithMainHand(offhandStack, mainHandStack);
+    }
+
+    default boolean allowsBetterCombatDualWieldingWithMainHand(
+            ItemStack offhandStack,
+            ItemStack mainHandStack
+    ) {
+        return mainHandStack.getItem() instanceof BetterCombatOffhandDualWieldingPolicyItem mainHandPolicyItem
+                && betterCombatOffhandDualWieldingPolicyGroup(offhandStack)
+                == mainHandPolicyItem.betterCombatOffhandDualWieldingPolicyGroup(mainHandStack);
+    }
+
+    default Class<?> betterCombatOffhandDualWieldingPolicyGroup(ItemStack stack) {
+        return getClass();
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
@@ -74,7 +74,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 public final class ScrollcasterGauntlet extends Item implements GeoItem, IPresetSpellContainer, UniqueItem,
-        WeaponImbueCooldownPolicyItem, ItemTransformPreservingCastAnimationItem, IJeiInfoItem {
+        WeaponImbueCooldownPolicyItem, ItemTransformPreservingCastAnimationItem,
+        BetterCombatOffhandDualWieldingPolicyItem, IJeiInfoItem {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.scrollcaster_gauntlet.desc_";
 
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/ApprenticeCodexMixinPlugin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/ApprenticeCodexMixinPlugin.java
@@ -13,10 +13,12 @@ public final class ApprenticeCodexMixinPlugin implements IMixinConfigPlugin {
     private static final String APOTHEOSIS_MOD_ID = "apotheosis";
     private static final String JEI_MOD_ID = "jei";
     private static final String EPIC_FIGHT_MOD_ID = "epicfight";
+    private static final String BETTER_COMBAT_MOD_ID = "bettercombat";
     private static final String EASY_MAGIC_MIXIN = "jp.aquafactory.apprenticecodex.mixin.EasyMagicModEnchantmentMenuMixin";
     private static final String ARCANE_ANVIL_JEI_RECIPE_MIXIN =
             "jp.aquafactory.apprenticecodex.mixin.ArcaneAnvilJeiRecipeMixin";
     private static final String EPIC_FIGHT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.EpicFight";
+    private static final String BETTER_COMBAT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.BetterCombat";
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -47,6 +49,10 @@ public final class ApprenticeCodexMixinPlugin implements IMixinConfigPlugin {
             return loadingModList != null && loadingModList.getModFileById(EPIC_FIGHT_MOD_ID) != null;
         }
 
+        if (mixinClassName.startsWith(BETTER_COMBAT_MIXIN_PREFIX)) {
+            var loadingModList = FMLLoader.getLoadingModList();
+            return loadingModList != null && loadingModList.getModFileById(BETTER_COMBAT_MOD_ID) != null;
+        }
         return true;
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/BetterCombatPlayerAttackHelperMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/BetterCombatPlayerAttackHelperMixin.java
@@ -1,0 +1,24 @@
+package jp.aquafactory.apprenticecodex.mixin;
+
+import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatDualWieldingPolicyCompat;
+import net.bettercombat.logic.PlayerAttackHelper;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(PlayerAttackHelper.class)
+public abstract class BetterCombatPlayerAttackHelperMixin {
+    @Inject(method = "isDualWielding", at = @At("HEAD"), cancellable = true, remap = false)
+    private static void apprenticecodex$suppressPolicyOffhandDualWielding(
+            Player player,
+            CallbackInfoReturnable<Boolean> callback
+    ) {
+        if (BetterCombatDualWieldingPolicyCompat.shouldSuppressDualWielding(player)) {
+            // weapon_attributes はメインハンド運用向けに残しつつ、offhand 補助具運用だけは
+            // Better Combat の交互攻撃へ参加させない。1.21.1 側では攻撃手選択の実装差分を再確認する。
+            callback.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/resources/mixins.apprenticecodex.json
+++ b/src/main/resources/mixins.apprenticecodex.json
@@ -9,6 +9,7 @@
     "AbstractSpellMixin",
     "AbstractFurnaceBlockEntityMixin",
     "ArcaneAnvilMenuMixin",
+    "BetterCombatPlayerAttackHelperMixin",
     "BowItemSpellcasterQuiverMixin",
     "CombatTrackerAccessor",
     "EasyMagicModEnchantmentMenuMixin",


### PR DESCRIPTION
## 概要
- PR #527 の Better Combat 向け術式装填ガントレット offhand dual wield 抑止対応を 1.21.1-main へ forward-port
- 移植元: 98f55fa082d6bf3568ca6ce2eb63fc9f4254d94b
- Better Combat 導入時のみ PlayerAttackHelper mixin が適用されるよう optional gating を追加
- offhand ガントレット単体では Better Combat の dual wield 攻撃に参加せず、両手ガントレットでは従来動作を維持する GameTest を追加

## 検証
- [x] .\\scripts\\use-java.ps1; ./gradlew.bat runGameTestServer
- [x] .\\scripts\\use-java.ps1; ./gradlew.bat build
- [x] .\\scripts\\use-java.ps1; ./gradlew.bat runGameTestServerBetterCombat
- [x] ./gradlew.bat runClientBetterCombat（手元確認済み）

## 補足
- generated resources への差分なし。runData は未実行。