### PR TITLE
PR #535を1.21.1へforward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -11568,7 +11568,7 @@ public final class ApprenticeCodexGameTestScenarios {
             magicData.setAdditionalCastData(null);
         });
 
-        helper.runAtTickTime(4, () -> {
+        helper.succeedWhen(() -> {
             MulticastEchoStaffCastHelper.onPlayerTick(new PlayerTickEvent.Post(player));
             var magicData = MagicData.getPlayerMagicData(player);
             var cooldown = magicData.getPlayerCooldowns().getSpellCooldowns().get(spell.getSpellId());
@@ -11582,7 +11582,6 @@ public final class ApprenticeCodexGameTestScenarios {
                             + " / expected " + expectedCooldown);
             helper.assertTrue(magicData.getAdditionalCastData() == null,
                     "Delayed multicast pre-cast data should be restored after the repeated cast");
-            helper.succeed();
         });
     }
 
@@ -13594,14 +13593,17 @@ public final class ApprenticeCodexGameTestScenarios {
         var spell = SpellRegistry.ARCHER_MULTIPLE.get();
         var magicData = MagicData.getPlayerMagicData(player);
 
-        helper.runAtTickTime(1, () -> {
-            castArcherMultiple(helper, player, 1);
-            helper.assertTrue(getOwnedArcherMultipleBows(helper, player).size() == 4,
-                    "Archer Multiple should summon all bows before the removal test starts");
-        });
-        helper.runAtTickTime(3, () -> getOwnedArcherMultipleBows(helper, player).forEach(bow -> bow.remove(net.minecraft.world.entity.Entity.RemovalReason.DISCARDED)));
+        var removalStarted = new java.util.concurrent.atomic.AtomicBoolean(false);
 
+        helper.runAtTickTime(1, () -> castArcherMultiple(helper, player, 1));
         helper.succeedWhen(() -> {
+            if (!removalStarted.get()) {
+                var bows = getOwnedArcherMultipleBows(helper, player);
+                helper.assertTrue(bows.size() == 4,
+                        "Archer Multiple should summon all bows before the removal test starts");
+                bows.forEach(bow -> bow.remove(net.minecraft.world.entity.Entity.RemovalReason.DISCARDED));
+                removalStarted.set(true);
+            }
             helper.assertFalse(magicData.getPlayerRecasts().hasRecastForSpell(spell),
                     "Archer Multiple recast should end once every summoned bow has disappeared");
             helper.assertTrue(getOwnedArcherMultipleBows(helper, player).isEmpty(),


### PR DESCRIPTION
## 概要
- #535 の変更を `1.21.1-main` へ forward-port
- 取り込み元: `1adad370877215e6dceaf08ec71db151ff91637a`
- GameTest の flaky 対策のみ

## 変更内容
- `multicastEchoStaffLongCastUsesStartEchoContextAfterEffectRemoved` を固定 tick の瞬間確認から `succeedWhen` に変更
- `archerMultipleAllBowRemovalEndsRecastAndStartsCooldown` で、召喚完了後に一度だけ bow を削除して状態成立を待つよう変更

## 検証
- `./gradlew.bat runGameTestServer` 成功（460 required tests passed）
- `./gradlew.bat runGameTestServer` 成功（460 required tests passed、2回目）
- `./gradlew.bat build` 成功

`runData` は GameTest Java 1 ファイルのみの変更で generated resources に影響しないため未実行です。