### PR TITLE
カウンタースペルの全体的な対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/effect/ArcaneCharge.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/effect/ArcaneCharge.java
@@ -1,11 +1,11 @@
 package jp.aquafactory.apprenticecodex.effect;
 
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
-import net.minecraft.world.effect.MobEffect;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
-public class ArcaneCharge extends MobEffect {
+public class ArcaneCharge extends MagicMobEffect {
     public ArcaneCharge() {
         super(MobEffectCategory.BENEFICIAL, 0x7733ff);
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/effect/EchoSpell.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/effect/EchoSpell.java
@@ -1,9 +1,9 @@
 package jp.aquafactory.apprenticecodex.effect;
 
-import net.minecraft.world.effect.MobEffect;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 
-public class EchoSpell extends MobEffect {
+public class EchoSpell extends MagicMobEffect {
     public static final int DURATION_TICKS = 20 * 15;
 
     public EchoSpell() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/effect/MistFormEffect.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/effect/MistFormEffect.java
@@ -1,7 +1,7 @@
 package jp.aquafactory.apprenticecodex.effect;
 
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
-import net.minecraft.world.effect.MobEffect;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
@@ -9,7 +9,7 @@ import net.minecraftforge.common.ForgeMod;
 
 import java.util.UUID;
 
-public class MistFormEffect extends MobEffect {
+public class MistFormEffect extends MagicMobEffect {
     public static final double MOVEMENT_SPEED_BONUS = 0.20D;
     public static final double STEP_HEIGHT_ADDITION = 0.5D;
     public static final double SCHOOL_RESIST_WEAKNESS = -1.0D;

--- a/src/main/java/jp/aquafactory/apprenticecodex/effect/PaletteReception.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/effect/PaletteReception.java
@@ -1,9 +1,9 @@
 package jp.aquafactory.apprenticecodex.effect;
 
-import net.minecraft.world.effect.MobEffect;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 
-public class PaletteReception extends MobEffect {
+public class PaletteReception extends MagicMobEffect {
     public PaletteReception() {
         super(MobEffectCategory.BENEFICIAL, 0xEEDBFF);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/effect/SenseSensor.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/effect/SenseSensor.java
@@ -1,9 +1,9 @@
 package jp.aquafactory.apprenticecodex.effect;
 
-import net.minecraft.world.effect.MobEffect;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import net.minecraft.world.effect.MobEffectCategory;
 
-public class SenseSensor extends MobEffect {
+public class SenseSensor extends MagicMobEffect {
     public SenseSensor() {
         super(MobEffectCategory.BENEFICIAL, 0x00D1D1);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/effect/SpectralWingEffect.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/effect/SpectralWingEffect.java
@@ -1,9 +1,11 @@
 package jp.aquafactory.apprenticecodex.effect;
 
-import net.minecraft.world.effect.MobEffect;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
+import jp.aquafactory.apprenticecodex.spell.spectralwing.SpectralWingFlightEvent;
 import net.minecraft.world.effect.MobEffectCategory;
+import net.minecraft.world.entity.LivingEntity;
 
-public class SpectralWingEffect extends MobEffect {
+public class SpectralWingEffect extends MagicMobEffect {
     public SpectralWingEffect() {
         super(MobEffectCategory.BENEFICIAL, 0xD8F4FF);
     }
@@ -11,5 +13,10 @@ public class SpectralWingEffect extends MobEffect {
     @Override
     public boolean isDurationEffectTick(int duration, int amplifier) {
         return false;
+    }
+
+    @Override
+    public void onEffectRemoved(LivingEntity entity, int amplifier) {
+        SpectralWingFlightEvent.onSpectralWingEffectRemoved(entity);
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -143,6 +143,7 @@ import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconTargetList;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconTargetManager;
 import jp.aquafactory.apprenticecodex.spell.skyedge.SkyEdgeProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.tinylumberjack.TinyLumberjackJob;
+import jp.aquafactory.apprenticecodex.spell.uniteluna.UniteLunaMoonEntity;
 import jp.aquafactory.apprenticecodex.spell.worldflatter.WorldFlatterDrillEntity;
 import jp.aquafactory.apprenticecodex.item.armor.ApprenticeMageRobeItem;
 import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressItem;
@@ -14861,6 +14862,39 @@ public final class ApprenticeCodexGameTestScenarios {
                     "Repeated anti-magic should not restart Magic Spear harmless burst lifetime");
             assertHealthUnchanged(helper, target, targetHealth,
                     "Magic Spear harmless anti-magic burst should not damage nearby targets");
+        });
+    }
+
+    static void uniteLunaAntiMagicAmplifiesBurst(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = (ServerLevel) helper.getLevel();
+            var caster = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "unite_luna_antimagic_test");
+            var target = EntityType.SHEEP.create(level);
+            helper.assertTrue(target != null, "Failed to create Unite Luna anti-magic target");
+            target.setNoAi(true);
+            spawnCounterspellTestEntity(helper, target, new Vec3(10.0D, 2.0D, 2.5D));
+            var targetHealth = target.getHealth();
+
+            var moon = new UniteLunaMoonEntity(EntityRegistry.UNITE_LUNA_MOON.get(), level, caster);
+            moon.setDamage(2.0F);
+            spawnCounterspellTestEntity(helper, moon, new Vec3(2.5D, 2.0D, 2.5D));
+
+            helper.assertTrue(moon instanceof AntiMagicSusceptible,
+                    "Unite Luna moon should implement AntiMagicSusceptible");
+            ((AntiMagicSusceptible) moon).onAntiMagic(MagicData.getPlayerMagicData(caster));
+
+            helper.assertTrue(moon.getBurstKind() == UniteLunaMoonEntity.BURST_KIND_EXPLOSION,
+                    "Unite Luna anti-magic should force explosion burst");
+            helper.assertTrue(Math.abs(moon.getBurstCubeSize() - 22.0F) < 0.001F,
+                    "Unite Luna anti-magic burst cube size should be doubled max: " + moon.getBurstCubeSize());
+            var damageTaken = targetHealth - target.getHealth();
+            helper.assertTrue(Math.abs(damageTaken - 6.0F) < 0.1F,
+                    "Unite Luna anti-magic should triple damage inside doubled range: " + damageTaken);
+
+            var healthAfterFirstBurst = target.getHealth();
+            ((AntiMagicSusceptible) moon).onAntiMagic(MagicData.getPlayerMagicData(caster));
+            helper.assertTrue(Math.abs(target.getHealth() - healthAfterFirstBurst) < 0.001F,
+                    "Repeated Unite Luna anti-magic should not reapply burst damage");
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -16,6 +16,7 @@ import io.redspace.ironsspellbooks.api.spells.SpellRarity;
 import io.redspace.ironsspellbooks.api.util.Utils;
 import io.redspace.ironsspellbooks.capabilities.magic.MagicManager;
 import io.redspace.ironsspellbooks.capabilities.magic.RecastInstance;
+import io.redspace.ironsspellbooks.effect.MagicMobEffect;
 import io.redspace.ironsspellbooks.entity.spells.fire_breath.FireBreathProjectile;
 import io.redspace.ironsspellbooks.entity.spells.fireball.SmallMagicFireball;
 import io.redspace.ironsspellbooks.entity.spells.spectral_hammer.SpectralHammer;
@@ -202,6 +203,7 @@ import net.minecraft.world.entity.MoverType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.ai.attributes.Attribute;
@@ -14714,6 +14716,50 @@ public final class ApprenticeCodexGameTestScenarios {
             helper.assertBlockProperty(waterloggedStairPos, StairBlock.WATERLOGGED, true);
             helper.assertBlockPresent(Blocks.LAVA, lavaPos);
             helper.assertBlockPresent(Blocks.LAVA, changedToLavaPos);
+        });
+    }
+
+    static void counterspellCompatMagicMobEffectsAreMagicMobEffects(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            assertMagicMobEffect(helper, EffectRegistry.ARCANE_CHARGE.get(), "ArcaneCharge");
+            assertMagicMobEffect(helper, EffectRegistry.SENSE_SENSOR.get(), "SenseSensor");
+            assertMagicMobEffect(helper, EffectRegistry.ECHO_SPELL.get(), "EchoSpell");
+            assertMagicMobEffect(helper, EffectRegistry.MIST_FORM.get(), "MistFormEffect");
+            assertMagicMobEffect(helper, EffectRegistry.PALETTE_RECEPTION.get(), "PaletteReception");
+            assertMagicMobEffect(helper, EffectRegistry.SPECTRAL_WING.get(), "SpectralWingEffect");
+        });
+    }
+
+    private static void assertMagicMobEffect(GameTestHelper helper, MobEffect effect, String effectName) {
+        helper.assertTrue(effect instanceof MagicMobEffect,
+                effectName + " should be removable by Counterspell as MagicMobEffect");
+    }
+
+    static void spectralWingEffectRemovalClearsFlightState(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 8, 0), "spectral_wing_counterspell_test");
+            SpellRegistry.SPECTRAL_WING.get().onCast(helper.getLevel(), 1, player, CastSource.SPELLBOOK, MagicData.getPlayerMagicData(player));
+
+            var spellData = Capabilities.getSpellDataOrNull(player);
+            helper.assertTrue(spellData != null, "Spectral Wing test player should have Codex spell data");
+            var state = spellData.get(CodexSpellStateTypeRegister.SPECTRAL_WING_STATE);
+            helper.assertTrue(state.active && state.startedBySpell,
+                    "Spectral Wing cast should activate flight state before effect removal");
+            helper.assertTrue(player.hasEffect(EffectRegistry.SPECTRAL_WING.get()),
+                    "Spectral Wing cast should apply visual MagicMobEffect before removal");
+
+            player.removeEffect(EffectRegistry.SPECTRAL_WING.get());
+            jp.aquafactory.apprenticecodex.spell.spectralwing.SpectralWingFlightEvent.onPlayerTick(
+                    new TickEvent.PlayerTickEvent(TickEvent.Phase.START, player)
+            );
+
+            state = spellData.get(CodexSpellStateTypeRegister.SPECTRAL_WING_STATE);
+            helper.assertFalse(player.hasEffect(EffectRegistry.SPECTRAL_WING.get()),
+                    "Removing Spectral Wing effect should not be refreshed from stale state");
+            helper.assertFalse(state.active || state.startedBySpell || state.launchGraceTicks != 0 || state.waterGraceTicks != 0,
+                    "Removing Spectral Wing effect should clear flight state");
+            helper.assertFalse(player.isFallFlying(),
+                    "Removing Spectral Wing effect should stop fall flying");
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -14826,11 +14826,6 @@ public final class ApprenticeCodexGameTestScenarios {
             helper.assertFalse(demicreatorMagicData.getPlayerRecasts().hasRecastForSpell(demicreatorSpell),
                     "Demicreator Wings anti-magic should remove its recast");
 
-            var shieldOwner = createEquipmentTestPlayer(helper, new BlockPos(6, 2, 0), "mystic_shield_entity_antimagic_owner_test");
-            var shield = new MysticShieldShieldEntity(EntityRegistry.MYSTIC_SHIELD_SHIELD.get(), level, shieldOwner);
-            level.addFreshEntity(shield);
-            ((AntiMagicSusceptible) shield).onAntiMagic(counterMagicData);
-            helper.assertTrue(shield.isFading(), "Mystic Shield entity should start fading after anti-magic");
         });
     }
 
@@ -15011,11 +15006,24 @@ public final class ApprenticeCodexGameTestScenarios {
             );
             helper.assertTrue(frontAttack.isCanceled(), "Mystic Shield setup should store front damage before Counterspell");
 
+            var mysticShieldEntity = level.getEntitiesOfClass(
+                            MysticShieldShieldEntity.class,
+                            mysticCaster.getBoundingBox().inflate(4.0D)
+                    ).stream()
+                    .filter(entity -> entity.getOwner() == mysticCaster)
+                    .findFirst()
+                    .orElse(null);
+            helper.assertTrue(mysticShieldEntity != null, "Mystic Shield cast should spawn a shield entity before Counterspell");
+            helper.assertFalse(mysticShieldEntity instanceof AntiMagicSusceptible,
+                    "Mystic Shield shield entity should not be a direct Counterspell target");
+
             var counterCaster = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 5), "mystic_shield_counterspell_caster_test");
             var mysticCounterspell = new CounterSpellEvent(counterCaster, mysticCaster);
             MysticShieldDefenseEvent.onCounterSpell(mysticCounterspell);
             helper.assertFalse(mysticCounterspell.isCanceled(),
                     "Mystic Shield should not cancel the CounterSpellEvent itself");
+            helper.assertTrue(mysticShieldEntity.isFading(),
+                    "Mystic Shield should break its shield entity immediately when Counterspell hits the caster");
             completeMysticShieldCast(level, mysticCaster, 1, true);
             var reflected = level.getEntitiesOfClass(MysticShieldProjectileEntity.class, mysticCaster.getBoundingBox().inflate(4.0D));
             helper.assertTrue(reflected.isEmpty(),

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -17,6 +17,7 @@ import io.redspace.ironsspellbooks.api.util.Utils;
 import io.redspace.ironsspellbooks.capabilities.magic.MagicManager;
 import io.redspace.ironsspellbooks.capabilities.magic.RecastInstance;
 import io.redspace.ironsspellbooks.effect.MagicMobEffect;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import io.redspace.ironsspellbooks.entity.spells.fire_breath.FireBreathProjectile;
 import io.redspace.ironsspellbooks.entity.spells.fireball.SmallMagicFireball;
 import io.redspace.ironsspellbooks.entity.spells.spectral_hammer.SpectralHammer;
@@ -122,10 +123,14 @@ import jp.aquafactory.apprenticecodex.spell.archermultiple.ArcherMultipleBowEnti
 import jp.aquafactory.apprenticecodex.spell.assistwings.AssistWingsWingEntity;
 import jp.aquafactory.apprenticecodex.spell.automagnet.AutoMagnetFamiliarEntity;
 import jp.aquafactory.apprenticecodex.spell.earthforge.EarthForge;
+import jp.aquafactory.apprenticecodex.spell.extract.ExtractPotionProjectileEntity;
+import jp.aquafactory.apprenticecodex.spell.flyswatter.FlySwatterProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.healingbloom.HealingBloom;
 import jp.aquafactory.apprenticecodex.spell.healingbloom.HealingBloomEntity;
 import jp.aquafactory.apprenticecodex.spell.healingbloom.HealingBloomLightBlockEntity;
 import jp.aquafactory.apprenticecodex.spell.ICraftsmansDelightAffectedSpell;
+import jp.aquafactory.apprenticecodex.spell.illuminatestellar.IlluminateStellarStarEntity;
+import jp.aquafactory.apprenticecodex.spell.magicspear.MagicSpearMissileEntity;
 import jp.aquafactory.apprenticecodex.spell.manaslash.ManaSlashProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShield;
 import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShieldProjectileEntity;
@@ -136,6 +141,7 @@ import jp.aquafactory.apprenticecodex.spell.senseevil.SenseEvil;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconSearchService;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconTargetList;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconTargetManager;
+import jp.aquafactory.apprenticecodex.spell.skyedge.SkyEdgeProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.tinylumberjack.TinyLumberjackJob;
 import jp.aquafactory.apprenticecodex.spell.worldflatter.WorldFlatterDrillEntity;
 import jp.aquafactory.apprenticecodex.item.armor.ApprenticeMageRobeItem;
@@ -229,6 +235,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.alchemy.PotionUtils;
+import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.EnchantmentInstance;
@@ -14761,6 +14768,119 @@ public final class ApprenticeCodexGameTestScenarios {
             helper.assertFalse(player.isFallFlying(),
                     "Removing Spectral Wing effect should stop fall flying");
         });
+    }
+
+    static void counterspellCompatProjectilesFizzleHarmlessly(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = (ServerLevel) helper.getLevel();
+            var caster = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "counterspell_projectile_fizzle_test");
+            var target = EntityType.SHEEP.create(level);
+            helper.assertTrue(target != null, "Failed to create Counterspell projectile harmless target");
+            spawnCounterspellTestEntity(helper, target, new Vec3(2.5D, 2.0D, 2.5D));
+            var targetHealth = target.getHealth();
+
+            var compoundPhial = new CompoundPhialProjectileEntity(EntityRegistry.COMPOUND_PHIAL_PROJECTILE.get(), level, caster);
+            compoundPhial.setDamage(20.0F);
+            compoundPhial.setSplashRadius(4.0F);
+            compoundPhial.setPotionColorRandom(level);
+            spawnCounterspellTestEntity(helper, compoundPhial, new Vec3(2.5D, 2.0D, 2.5D));
+            assertAntiMagicDiscard(helper, caster, compoundPhial, "Compound Phial");
+
+            var extract = new ExtractPotionProjectileEntity(EntityRegistry.EXTRACT_POTION_PROJECTILE.get(), level, caster);
+            extract.setItem(PotionUtils.setPotion(new ItemStack(Items.SPLASH_POTION), Potions.POISON));
+            spawnCounterspellTestEntity(helper, extract, new Vec3(2.5D, 2.0D, 2.5D));
+            assertAntiMagicDiscard(helper, caster, extract, "Extract potion");
+
+            var flySwatter = new FlySwatterProjectileEntity(EntityRegistry.FLY_SWATTER_PROJECTILE.get(), level, caster);
+            flySwatter.setDamage(20.0F);
+            flySwatter.setRadius(4.0F);
+            spawnCounterspellTestEntity(helper, flySwatter, new Vec3(2.5D, 2.0D, 2.5D));
+            assertAntiMagicDiscard(helper, caster, flySwatter, "Fly Swatter");
+
+            var stellar = new IlluminateStellarStarEntity(EntityRegistry.ILLUMINATE_STELLAR_STAR.get(), level, caster);
+            stellar.setDamage(20.0F);
+            stellar.setDriftProfile(new Vec3(1.0D, 0.0D, 0.0D));
+            stellar.setFallbackTarget(target);
+            spawnCounterspellTestEntity(helper, stellar, new Vec3(2.5D, 2.0D, 2.5D));
+            assertAntiMagicDiscard(helper, caster, stellar, "Illuminate Stellar");
+
+            var manaSlash = new ManaSlashProjectileEntity(EntityRegistry.MANA_SLASH_PROJECTILE.get(), level, caster);
+            manaSlash.setDamage(20.0F);
+            manaSlash.shoot(new Vec3(1.0D, 0.0D, 0.0D));
+            spawnCounterspellTestEntity(helper, manaSlash, new Vec3(2.5D, 2.0D, 2.5D));
+            assertAntiMagicDiscard(helper, caster, manaSlash, "Mana Slash");
+
+            var mysticShield = new MysticShieldProjectileEntity(EntityRegistry.MYSTIC_SHIELD_PROJECTILE.get(), level, caster);
+            mysticShield.setDamage(20.0F);
+            mysticShield.shoot(new Vec3(1.0D, 0.0D, 0.0D));
+            spawnCounterspellTestEntity(helper, mysticShield, new Vec3(2.5D, 2.0D, 2.5D));
+            assertAntiMagicDiscard(helper, caster, mysticShield, "Mystic Shield projectile");
+
+            var skyEdge = new SkyEdgeProjectileEntity(EntityRegistry.SKY_EDGE_PROJECTILE.get(), level, caster);
+            skyEdge.setDamage(20.0F);
+            skyEdge.setProjectileVelocity(new Vec3(1.0D, 0.0D, 0.0D), 1.0D);
+            spawnCounterspellTestEntity(helper, skyEdge, new Vec3(2.5D, 2.0D, 2.5D));
+            assertAntiMagicDiscard(helper, caster, skyEdge, "Sky Edge");
+
+            assertHealthUnchanged(helper, target, targetHealth,
+                    "Counterspell projectile fizzle should not damage nearby targets");
+            helper.assertFalse(target.hasEffect(MobEffects.POISON),
+                    "Counterspell projectile fizzle should not apply potion effects");
+        });
+    }
+
+    static void magicSpearAntiMagicBurstDoesNotRestart(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = (ServerLevel) helper.getLevel();
+            var caster = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "magic_spear_antimagic_repeat_test");
+            var target = EntityType.SHEEP.create(level);
+            helper.assertTrue(target != null, "Failed to create Magic Spear anti-magic target");
+            spawnCounterspellTestEntity(helper, target, new Vec3(2.5D, 2.0D, 2.5D));
+            var targetHealth = target.getHealth();
+
+            var spear = new MagicSpearMissileEntity(EntityRegistry.MAGIC_SPEAR_MISSILE.get(), level, caster);
+            spear.setup(20.0F, new Vec3(1.0D, 0.0D, 0.0D), new Vec3(0.0D, 0.0D, 1.0D), target);
+            spawnCounterspellTestEntity(helper, spear, new Vec3(2.5D, 2.0D, 2.5D));
+
+            var magicData = MagicData.getPlayerMagicData(caster);
+            ((AntiMagicSusceptible) spear).onAntiMagic(magicData);
+            helper.assertTrue(spear.isBursting(), "Magic Spear should enter harmless burst state after anti-magic");
+
+            for (var i = 0; i < 7 && !spear.isRemoved(); ++i) {
+                spear.tick();
+            }
+
+            ((AntiMagicSusceptible) spear).onAntiMagic(magicData);
+            helper.assertTrue(spear.isBursting(), "Repeated anti-magic should not leave harmless burst state");
+
+            for (var i = 0; i < 7 && !spear.isRemoved(); ++i) {
+                spear.tick();
+            }
+
+            helper.assertTrue(spear.isRemoved(),
+                    "Repeated anti-magic should not restart Magic Spear harmless burst lifetime");
+            assertHealthUnchanged(helper, target, targetHealth,
+                    "Magic Spear harmless anti-magic burst should not damage nearby targets");
+        });
+    }
+
+    private static void assertAntiMagicDiscard(GameTestHelper helper, FakePlayer caster, net.minecraft.world.entity.Entity entity, String entityName) {
+        helper.assertTrue(entity instanceof AntiMagicSusceptible,
+                entityName + " should implement AntiMagicSusceptible");
+        ((AntiMagicSusceptible) entity).onAntiMagic(MagicData.getPlayerMagicData(caster));
+        helper.assertTrue(entity.isRemoved(), entityName + " should be discarded by anti-magic");
+    }
+
+    private static void assertHealthUnchanged(GameTestHelper helper, net.minecraft.world.entity.LivingEntity target, float expectedHealth, String message) {
+        helper.assertTrue(Math.abs(target.getHealth() - expectedHealth) < 0.001F,
+                message + ": expected=" + expectedHealth + ", actual=" + target.getHealth());
+    }
+
+    private static void spawnCounterspellTestEntity(GameTestHelper helper, net.minecraft.world.entity.Entity entity, Vec3 localPos) {
+        var absolutePos = helper.absoluteVec(localPos);
+        entity.moveTo(absolutePos.x, absolutePos.y, absolutePos.z, 0.0F, 0.0F);
+        entity.setDeltaMovement(Vec3.ZERO);
+        helper.getLevel().addFreshEntity(entity);
     }
 
     static void mistFormAppliesEffectAndFixedAttributes(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -1,6 +1,7 @@
 package jp.aquafactory.apprenticecodex.gametest;
 
 import com.mojang.authlib.GameProfile;
+import io.redspace.ironsspellbooks.api.events.CounterSpellEvent;
 import io.redspace.ironsspellbooks.api.registry.SchoolRegistry;
 import io.redspace.ironsspellbooks.api.events.SpellCooldownAddedEvent;
 import io.redspace.ironsspellbooks.api.events.SpellOnCastEvent;
@@ -52,6 +53,7 @@ import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.config.item.SpellStainedRunicTabletServerConfig;
 import jp.aquafactory.apprenticecodex.datagen.DamageTypeTagGenerator;
 import jp.aquafactory.apprenticecodex.effect.CastingMoveSpeedAdjustment;
+import jp.aquafactory.apprenticecodex.effect.PhalanxStance;
 import jp.aquafactory.apprenticecodex.event.ErrandMageVillagerTradesEvent;
 import jp.aquafactory.apprenticecodex.event.errandmage.ErrandMageTradeManager;
 import jp.aquafactory.apprenticecodex.event.ScrollcasterGauntletGrindstoneEvent;
@@ -122,6 +124,7 @@ import jp.aquafactory.apprenticecodex.spell.demicreatorwings.DemicreatorWingsMan
 import jp.aquafactory.apprenticecodex.spell.archermultiple.ArcherMultipleBowEntity;
 import jp.aquafactory.apprenticecodex.spell.assistwings.AssistWingsWingEntity;
 import jp.aquafactory.apprenticecodex.spell.automagnet.AutoMagnetFamiliarEntity;
+import jp.aquafactory.apprenticecodex.spell.automagnet.AutoMagnetFamiliarManager;
 import jp.aquafactory.apprenticecodex.spell.earthforge.EarthForge;
 import jp.aquafactory.apprenticecodex.spell.extract.ExtractPotionProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.flyswatter.FlySwatterProjectileEntity;
@@ -133,9 +136,12 @@ import jp.aquafactory.apprenticecodex.spell.illuminatestellar.IlluminateStellarS
 import jp.aquafactory.apprenticecodex.spell.magicspear.MagicSpearMissileEntity;
 import jp.aquafactory.apprenticecodex.spell.manaslash.ManaSlashProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShield;
+import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShieldDefenseEvent;
 import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShieldProjectileEntity;
+import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShieldShieldEntity;
 import jp.aquafactory.apprenticecodex.spell.personalshelf.PersonalShelf;
 import jp.aquafactory.apprenticecodex.spell.personalshelf.PersonalShelfChestBlockEntity;
+import jp.aquafactory.apprenticecodex.spell.phalanxcharge.PhalanxCounterSpellEvent;
 import jp.aquafactory.apprenticecodex.spell.precisionjack.PrecisionJackKnifeEntity;
 import jp.aquafactory.apprenticecodex.spell.senseevil.SenseEvil;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconSearchService;
@@ -14771,6 +14777,97 @@ public final class ApprenticeCodexGameTestScenarios {
         });
     }
 
+    static void counterspellCompatMagicConstructsDeactivateSafely(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var counterCaster = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "counterspell_construct_caster_test");
+            var counterMagicData = MagicData.getPlayerMagicData(counterCaster);
+
+            var assistOwner = createEquipmentTestPlayer(helper, new BlockPos(0, 4, 0), "assist_wings_antimagic_owner_test");
+            var assistWing = new AssistWingsWingEntity(EntityRegistry.ASSIST_WINGS_WING.get(), level, assistOwner);
+            level.addFreshEntity(assistWing);
+            setAssistWingsState(assistOwner, 1, assistWing.getId());
+            assistOwner.addEffect(new MobEffectInstance(MobEffects.SLOW_FALLING, 20, 0, true, false, false));
+            ((AntiMagicSusceptible) assistWing).onAntiMagic(counterMagicData);
+            var assistState = Capabilities.getSpellDataOrNull(assistOwner).get(CodexSpellStateTypeRegister.ASSIST_WINGS_STATE);
+            helper.assertTrue(assistWing.isRemoved(), "Assist Wings wing should be discarded by anti-magic");
+            helper.assertTrue(assistState.localEntityId == -1 && assistState.doneJump == 1,
+                    "Assist Wings anti-magic should clear only the managed wing id");
+            helper.assertFalse(assistOwner.hasEffect(MobEffects.SLOW_FALLING),
+                    "Assist Wings anti-magic should remove its own short slow-falling effect");
+
+            var magnetOwner = createEquipmentTestPlayer(helper, new BlockPos(2, 2, 0), "auto_magnet_antimagic_owner_test");
+            AutoMagnetFamiliarManager.activate(magnetOwner, 6.0D, 0.0D);
+            var familiar = level.getEntitiesOfClass(AutoMagnetFamiliarEntity.class, magnetOwner.getBoundingBox().inflate(4.0D))
+                    .stream()
+                    .filter(entity -> entity.getOwner() == magnetOwner)
+                    .findFirst()
+                    .orElse(null);
+            helper.assertTrue(familiar != null, "AutoMagnet anti-magic test should spawn a familiar");
+            ((AntiMagicSusceptible) familiar).onAntiMagic(counterMagicData);
+            var magnetState = Capabilities.getSpellDataOrNull(magnetOwner).get(CodexSpellStateTypeRegister.AUTO_MAGNET_STATE);
+            helper.assertTrue(familiar.isRemoved(), "AutoMagnet familiar should be discarded by anti-magic");
+            helper.assertFalse(magnetState.active || magnetState.getFamiliarUuid() != null,
+                    "AutoMagnet anti-magic should clear active state and familiar UUID");
+
+            var demicreatorOwner = createEquipmentTestPlayer(helper, new BlockPos(4, 2, 0), "demicreator_wings_antimagic_owner_test");
+            var demicreatorSpell = (DemicreatorWings) SpellRegistry.DEMICREATOR_WINGS.get();
+            var demicreatorMagicData = MagicData.getPlayerMagicData(demicreatorOwner);
+            DemicreatorWingsManager.activate(demicreatorOwner, 1, CastSource.SPELLBOOK, demicreatorMagicData, demicreatorSpell);
+            DemicreatorWingsManager.ensureFlightGranted(demicreatorOwner);
+            var core = DemicreatorWingsManager.getManagedCore(demicreatorOwner);
+            helper.assertTrue(core instanceof AntiMagicSusceptible, "Demicreator Wings core should be anti-magic susceptible");
+            ((AntiMagicSusceptible) core).onAntiMagic(counterMagicData);
+            var demicreatorState = Capabilities.getSpellDataOrNull(demicreatorOwner).get(CodexSpellStateTypeRegister.DEMICREATOR_WINGS_STATE);
+            helper.assertFalse(demicreatorState.active || demicreatorState.coreEntityId >= 0 || demicreatorState.wingEntityId >= 0 || demicreatorState.grantedFlight,
+                    "Demicreator Wings anti-magic should reset managed state");
+            helper.assertFalse(demicreatorOwner.getAbilities().mayfly || demicreatorOwner.getAbilities().flying,
+                    "Demicreator Wings anti-magic should strip granted flight");
+            helper.assertFalse(demicreatorMagicData.getPlayerRecasts().hasRecastForSpell(demicreatorSpell),
+                    "Demicreator Wings anti-magic should remove its recast");
+
+            var shieldOwner = createEquipmentTestPlayer(helper, new BlockPos(6, 2, 0), "mystic_shield_entity_antimagic_owner_test");
+            var shield = new MysticShieldShieldEntity(EntityRegistry.MYSTIC_SHIELD_SHIELD.get(), level, shieldOwner);
+            level.addFreshEntity(shield);
+            ((AntiMagicSusceptible) shield).onAntiMagic(counterMagicData);
+            helper.assertTrue(shield.isFading(), "Mystic Shield entity should start fading after anti-magic");
+        });
+    }
+
+    static void healingBloomAntiMagicUsesDeathCleanup(GameTestHelper helper) {
+        var level = helper.getLevel();
+        var owner = createHealingBloomPlayer(helper, new BlockPos(0, 2, 0), "healing_bloom_antimagic_owner_test");
+        var anchorPos = new BlockPos(0, 2, 0);
+        var absoluteAnchorPos = helper.absolutePos(anchorPos);
+        helper.setBlock(anchorPos.below(), Blocks.STONE);
+        castHealingBloom(helper, owner, 1, anchorPos, false);
+        var bloom = getSingleLivingHealingBloom(helper, owner);
+        setHealingBloomFruitCount(bloom, 2);
+        bloom.setOwner(owner);
+        level.setBlockAndUpdate(absoluteAnchorPos.above(), BlockRegistry.HEALING_BLOOM_LIGHT.get().defaultBlockState());
+
+        var counterCaster = createEquipmentTestPlayer(helper, new BlockPos(2, 2, 0), "healing_bloom_antimagic_caster_test");
+        ((AntiMagicSusceptible) bloom).onAntiMagic(MagicData.getPlayerMagicData(counterCaster));
+
+        helper.runAtTickTime(3, () -> {
+            var spellData = Capabilities.getSpellDataOrNull(owner);
+            helper.assertTrue(spellData != null, "Healing Bloom anti-magic test should resolve owner spell data");
+            helper.assertTrue(getOwnedHealingBlooms(helper, owner).isEmpty(),
+                    "Healing Bloom anti-magic should leave no living managed bloom");
+            helper.assertTrue(spellData.get(CodexSpellStateTypeRegister.HEALING_BLOOM_STATE).getBloomUuid() == null,
+                    "Healing Bloom anti-magic should clear managed bloom UUID");
+            helper.assertTrue(!level.getBlockState(absoluteAnchorPos.above()).is(BlockRegistry.HEALING_BLOOM_LIGHT.get()),
+                    "Healing Bloom anti-magic should remove its light block");
+            var droppedBerries = level.getEntitiesOfClass(ItemEntity.class, new AABB(absoluteAnchorPos).inflate(1.5D)).stream()
+                    .filter(itemEntity -> itemEntity.getItem().is(ItemRegistry.COMFORT_BERRIES.get()))
+                    .mapToInt(itemEntity -> itemEntity.getItem().getCount())
+                    .sum();
+            helper.assertTrue(droppedBerries == 2,
+                    "Healing Bloom anti-magic should use normal death drops for stored fruit");
+            helper.succeed();
+        });
+    }
+
     static void counterspellCompatProjectilesFizzleHarmlessly(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var level = (ServerLevel) helper.getLevel();
@@ -14895,6 +14992,73 @@ public final class ApprenticeCodexGameTestScenarios {
             ((AntiMagicSusceptible) moon).onAntiMagic(MagicData.getPlayerMagicData(caster));
             helper.assertTrue(Math.abs(target.getHealth() - healthAfterFirstBurst) < 0.001F,
                     "Repeated Unite Luna anti-magic should not reapply burst damage");
+        });
+    }
+
+    static void counterspellCompatSpecialPlayerTargetBehaviors(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+
+            var mysticCaster = createTrackedEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mystic_shield_counterspell_target_test");
+            mysticCaster.setYRot(0.0f);
+            mysticCaster.setXRot(0.0f);
+            var attacker = helper.spawn(EntityType.ZOMBIE, new BlockPos(0, 2, 3));
+            beginMysticShieldCast(level, mysticCaster, 1);
+            var frontAttack = postLivingAttackEventForGameTest(
+                    mysticCaster,
+                    CombatTools.getDamageSource(level, attacker, DamageTypes.SHOCK),
+                    8.0f
+            );
+            helper.assertTrue(frontAttack.isCanceled(), "Mystic Shield setup should store front damage before Counterspell");
+
+            var counterCaster = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 5), "mystic_shield_counterspell_caster_test");
+            var mysticCounterspell = new CounterSpellEvent(counterCaster, mysticCaster);
+            MysticShieldDefenseEvent.onCounterSpell(mysticCounterspell);
+            helper.assertFalse(mysticCounterspell.isCanceled(),
+                    "Mystic Shield should not cancel the CounterSpellEvent itself");
+            completeMysticShieldCast(level, mysticCaster, 1, true);
+            var reflected = level.getEntitiesOfClass(MysticShieldProjectileEntity.class, mysticCaster.getBoundingBox().inflate(4.0D));
+            helper.assertTrue(reflected.isEmpty(),
+                    "Mystic Shield interrupted by Counterspell should clear stored damage without firing a reflection");
+
+            var phalanxTarget = createEquipmentTestPlayer(helper, new BlockPos(4, 2, 0), "phalanx_counterspell_target_test");
+            phalanxTarget.setYRot(0.0f);
+            phalanxTarget.setXRot(0.0f);
+            phalanxTarget.addEffect(new MobEffectInstance(
+                    EffectRegistry.PHALANX_STANCE.get(),
+                    20,
+                    PhalanxStance.MOVE_SPEED_ENABLED_AMPLIFIER,
+                    false,
+                    false,
+                    true
+            ));
+            var phalanxFrontCaster = createEquipmentTestPlayer(helper, new BlockPos(4, 2, 3), "phalanx_counterspell_front_test");
+            var frontCounterspell = new CounterSpellEvent(phalanxFrontCaster, phalanxTarget);
+            PhalanxCounterSpellEvent.onCounterSpell(frontCounterspell);
+            helper.assertTrue(frontCounterspell.isCanceled(),
+                    "Enhanced Phalanx stance should cancel Counterspell from the front");
+
+            var phalanxBackCaster = createEquipmentTestPlayer(helper, new BlockPos(4, 2, -3), "phalanx_counterspell_back_test");
+            var backCounterspell = new CounterSpellEvent(phalanxBackCaster, phalanxTarget);
+            PhalanxCounterSpellEvent.onCounterSpell(backCounterspell);
+            helper.assertFalse(backCounterspell.isCanceled(),
+                    "Enhanced Phalanx stance should not cancel Counterspell from behind");
+
+            var normalPhalanxTarget = createEquipmentTestPlayer(helper, new BlockPos(8, 2, 0), "phalanx_counterspell_normal_target_test");
+            normalPhalanxTarget.setYRot(0.0f);
+            normalPhalanxTarget.addEffect(new MobEffectInstance(
+                    EffectRegistry.PHALANX_STANCE.get(),
+                    20,
+                    PhalanxStance.FIXED_AMPLIFIER,
+                    false,
+                    false,
+                    true
+            ));
+            var normalFrontCaster = createEquipmentTestPlayer(helper, new BlockPos(8, 2, 3), "phalanx_counterspell_normal_front_test");
+            var normalCounterspell = new CounterSpellEvent(normalFrontCaster, normalPhalanxTarget);
+            PhalanxCounterSpellEvent.onCounterSpell(normalCounterspell);
+            helper.assertFalse(normalCounterspell.isCanceled(),
+                    "Unenhanced Phalanx stance should not cancel Counterspell");
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -15059,6 +15059,42 @@ public final class ApprenticeCodexGameTestScenarios {
             PhalanxCounterSpellEvent.onCounterSpell(normalCounterspell);
             helper.assertFalse(normalCounterspell.isCanceled(),
                     "Unenhanced Phalanx stance should not cancel Counterspell");
+
+            var phalanxMysticTarget = createTrackedEquipmentTestPlayer(helper, new BlockPos(12, 2, 0), "mystic_shield_phalanx_cancel_target_test");
+            phalanxMysticTarget.setYRot(0.0f);
+            phalanxMysticTarget.setXRot(0.0f);
+            phalanxMysticTarget.addEffect(new MobEffectInstance(
+                    EffectRegistry.PHALANX_STANCE.get(),
+                    20,
+                    PhalanxStance.MOVE_SPEED_ENABLED_AMPLIFIER,
+                    false,
+                    false,
+                    true
+            ));
+            beginMysticShieldCast(level, phalanxMysticTarget, 1);
+            var phalanxMysticAttacker = helper.spawn(EntityType.ZOMBIE, new BlockPos(12, 2, 3));
+            var phalanxMysticFrontAttack = postLivingAttackEventForGameTest(
+                    phalanxMysticTarget,
+                    CombatTools.getDamageSource(level, phalanxMysticAttacker, DamageTypes.SHOCK),
+                    8.0f
+            );
+            helper.assertTrue(phalanxMysticFrontAttack.isCanceled(),
+                    "Mystic Shield setup should store front damage before a Phalanx-canceled Counterspell");
+
+            var phalanxMysticCounterCaster = createEquipmentTestPlayer(helper, new BlockPos(12, 2, 5), "mystic_shield_phalanx_cancel_caster_test");
+            var phalanxCanceledCounterspell = new CounterSpellEvent(phalanxMysticCounterCaster, phalanxMysticTarget);
+            PhalanxCounterSpellEvent.onCounterSpell(phalanxCanceledCounterspell);
+            helper.assertTrue(phalanxCanceledCounterspell.isCanceled(),
+                    "Enhanced Phalanx stance should cancel Counterspell before Mystic Shield observes it");
+            MysticShieldDefenseEvent.onCounterSpell(phalanxCanceledCounterspell);
+            completeMysticShieldCast(level, phalanxMysticTarget, 1, false);
+            var reflectedAfterCanceledCounterspell = level.getEntitiesOfClass(
+                    MysticShieldProjectileEntity.class,
+                    phalanxMysticTarget.getBoundingBox().inflate(4.0D)
+            );
+            helper.assertTrue(reflectedAfterCanceledCounterspell.size() == 1,
+                    "Mystic Shield should keep stored reflection when Counterspell is canceled but got "
+                            + reflectedAfterCanceledCounterspell.size());
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -389,6 +389,16 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
         ApprenticeCodexGameTestScenarios.spectralWingEffectRemovalClearsFlightState(helper);
     }
 
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH)
+    public static void counterspellCompatMagicConstructsDeactivateSafely(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.counterspellCompatMagicConstructsDeactivateSafely(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH, timeoutTicks = 40)
+    public static void healingBloomAntiMagicUsesDeathCleanup(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.healingBloomAntiMagicUsesDeathCleanup(helper);
+    }
+
     @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH, timeoutTicks = 40)
     public static void counterspellCompatProjectilesFizzleHarmlessly(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.counterspellCompatProjectilesFizzleHarmlessly(helper);
@@ -402,6 +412,11 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH, timeoutTicks = 40)
     public static void uniteLunaAntiMagicAmplifiesBurst(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.uniteLunaAntiMagicAmplifiesBurst(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH)
+    public static void counterspellCompatSpecialPlayerTargetBehaviors(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.counterspellCompatSpecialPlayerTargetBehaviors(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = MIST_FORM_ISOLATED_BATCH)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -29,6 +29,7 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     private static final String ECHO_CAST_MULTICAST_LIMIT_BATCH = "apprenticecodex.echo_cast_multicast_limit";
     private static final String MYSTIC_SHIELD_ISOLATED_BATCH = "apprenticecodex.mystic_shield_isolated";
     private static final String MIST_FORM_ISOLATED_BATCH = "apprenticecodex.mist_form_isolated";
+    private static final String COUNTERSPELL_COMPAT_ISOLATED_BATCH = "apprenticecodex.counterspell_compat_isolated";
 
     private ApprenticeCodexSpellBehaviorGameTests() {
     }
@@ -376,6 +377,16 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     @GameTest(template = TEMPLATE, batch = MYSTIC_SHIELD_ISOLATED_BATCH)
     public static void mysticShieldReceivesProtectionSpellSupporterBenefits(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.mysticShieldReceivesProtectionSpellSupporterBenefits(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH)
+    public static void counterspellCompatMagicMobEffectsAreMagicMobEffects(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.counterspellCompatMagicMobEffectsAreMagicMobEffects(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH)
+    public static void spectralWingEffectRemovalClearsFlightState(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.spectralWingEffectRemovalClearsFlightState(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = MIST_FORM_ISOLATED_BATCH)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -399,6 +399,11 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
         ApprenticeCodexGameTestScenarios.magicSpearAntiMagicBurstDoesNotRestart(helper);
     }
 
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH, timeoutTicks = 40)
+    public static void uniteLunaAntiMagicAmplifiesBurst(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.uniteLunaAntiMagicAmplifiesBurst(helper);
+    }
+
     @GameTest(template = TEMPLATE, batch = MIST_FORM_ISOLATED_BATCH)
     public static void mistFormAppliesEffectAndFixedAttributes(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.mistFormAppliesEffectAndFixedAttributes(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -389,6 +389,16 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
         ApprenticeCodexGameTestScenarios.spectralWingEffectRemovalClearsFlightState(helper);
     }
 
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH, timeoutTicks = 40)
+    public static void counterspellCompatProjectilesFizzleHarmlessly(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.counterspellCompatProjectilesFizzleHarmlessly(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = COUNTERSPELL_COMPAT_ISOLATED_BATCH, timeoutTicks = 40)
+    public static void magicSpearAntiMagicBurstDoesNotRestart(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.magicSpearAntiMagicBurstDoesNotRestart(helper);
+    }
+
     @GameTest(template = TEMPLATE, batch = MIST_FORM_ISOLATED_BATCH)
     public static void mistFormAppliesEffectAndFixedAttributes(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.mistFormAppliesEffectAndFixedAttributes(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/assistwings/AssistWingsWingEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/assistwings/AssistWingsWingEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.assistwings;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.entity.SummonWeaponEntity;
@@ -15,7 +17,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
 
-public class AssistWingsWingEntity extends SummonWeaponEntity {
+public class AssistWingsWingEntity extends SummonWeaponEntity implements AntiMagicSusceptible {
 
     private int KeepTick = 10;
 
@@ -108,5 +110,38 @@ public class AssistWingsWingEntity extends SummonWeaponEntity {
 
     public Vec3 getBackPosition(LivingEntity owner){
         return RotationTools.calculateBehindPosition(owner, 0.25, 0, -0.4);
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        if (getOwner() instanceof Player owner) {
+            clearManagedState(owner);
+            removeOwnSlowFalling(owner);
+        }
+        discard();
+    }
+
+    private void clearManagedState(Player owner) {
+        Capabilities.withSpellData(owner, data -> data.edit(CodexSpellStateTypeRegister.ASSIST_WINGS_STATE, state -> {
+            if (state.localEntityId == getId()) {
+                state.localEntityId = -1;
+            }
+        }));
+    }
+
+    private static void removeOwnSlowFalling(Player owner) {
+        var effect = owner.getEffect(MobEffects.SLOW_FALLING);
+        if (effect != null
+                && effect.getAmplifier() == 0
+                && effect.getDuration() <= 20
+                && effect.isAmbient()
+                && !effect.isVisible()
+                && !effect.showIcon()) {
+            owner.removeEffect(MobEffects.SLOW_FALLING);
+        }
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/automagnet/AutoMagnetFamiliarEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/automagnet/AutoMagnetFamiliarEntity.java
@@ -1,12 +1,14 @@
 package jp.aquafactory.apprenticecodex.spell.automagnet;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.compat.botania.BotaniaSolegnoliaCompatBridge;
 import jp.aquafactory.apprenticecodex.entity.PersistentSummonWeaponEntity;
 import jp.aquafactory.apprenticecodex.mixin.ItemEntityAccessor;
 import jp.aquafactory.apprenticecodex.utility.AudioTools;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.damagesource.DamageSource;
@@ -31,7 +33,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 
 import java.util.UUID;
 
-public class AutoMagnetFamiliarEntity extends PersistentSummonWeaponEntity implements GeoEntity {
+public class AutoMagnetFamiliarEntity extends PersistentSummonWeaponEntity implements GeoEntity, AntiMagicSusceptible {
     private static final double ORBIT_RADIUS = 1.4;
     private static final double ORBIT_HEIGHT = 1.2;
     private static final double ORBIT_SPEED = Math.PI / 45.0;
@@ -180,6 +182,20 @@ public class AutoMagnetFamiliarEntity extends PersistentSummonWeaponEntity imple
     @Override
     public AnimatableInstanceCache getAnimatableInstanceCache() {
         return cache;
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        if (getOwner() instanceof ServerPlayer owner) {
+            AutoMagnetFamiliarManager.deactivate(owner);
+            return;
+        }
+
+        discard();
     }
 
     public double getPickupRange() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/compoundphial/CompoundPhialProjectileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/compoundphial/CompoundPhialProjectileEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.compoundphial;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import jp.aquafactory.apprenticecodex.utility.CombatTools;
@@ -24,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
 
-public class CompoundPhialProjectileEntity extends ThrowableProjectile {
+public class CompoundPhialProjectileEntity extends ThrowableProjectile implements AntiMagicSusceptible {
     private static final float FULL_DAMAGE_RADIUS_SCALE = 0.5f;
     private static final float MIN_SPLASH_DAMAGE_SCALE = 0.6f;
 
@@ -142,6 +144,15 @@ public class CompoundPhialProjectileEntity extends ThrowableProjectile {
     protected void onHitBlock(@NotNull BlockHitResult hit) {
         onImpact(level());
         super.onHitBlock(hit);
+        discard();
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
         discard();
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/demicreatorwings/DemicreatorWingsCoreEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/demicreatorwings/DemicreatorWingsCoreEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.demicreatorwings;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
@@ -23,7 +25,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class DemicreatorWingsCoreEntity extends Entity implements TraceableEntity {
+public class DemicreatorWingsCoreEntity extends Entity implements TraceableEntity, AntiMagicSusceptible {
     private static final int NO_OWNER_ENTITY_ID = -1;
     private static final EntityDataAccessor<Integer> ALLOWED_RADIUS =
             SynchedEntityData.defineId(DemicreatorWingsCoreEntity.class, EntityDataSerializers.INT);
@@ -148,6 +150,20 @@ public class DemicreatorWingsCoreEntity extends Entity implements TraceableEntit
     @Override
     public @NotNull PushReaction getPistonPushReaction() {
         return PushReaction.IGNORE;
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        if (getOwner() instanceof ServerPlayer owner) {
+            DemicreatorWingsManager.deactivate(owner, true);
+            return;
+        }
+
+        discard();
     }
 
     private void tickServer(ServerLevel level) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/extract/ExtractPotionProjectileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/extract/ExtractPotionProjectileEntity.java
@@ -1,11 +1,13 @@
 package jp.aquafactory.apprenticecodex.spell.extract;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.ThrownPotion;
 import net.minecraft.world.level.Level;
 
-public class ExtractPotionProjectileEntity extends ThrownPotion {
+public class ExtractPotionProjectileEntity extends ThrownPotion implements AntiMagicSusceptible {
     public ExtractPotionProjectileEntity(EntityType<? extends ExtractPotionProjectileEntity> entityType, Level level) {
         super(entityType, level);
     }
@@ -13,5 +15,14 @@ public class ExtractPotionProjectileEntity extends ThrownPotion {
     public ExtractPotionProjectileEntity(EntityType<? extends ExtractPotionProjectileEntity> entityType, Level level, LivingEntity owner) {
         this(entityType, level);
         setOwner(owner);
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        discard();
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/flyswatter/FlySwatterProjectileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/flyswatter/FlySwatterProjectileEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.flyswatter;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import jp.aquafactory.apprenticecodex.utility.CombatTools;
@@ -31,7 +33,7 @@ import net.minecraft.world.phys.*;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 
-public class FlySwatterProjectileEntity extends Projectile {
+public class FlySwatterProjectileEntity extends Projectile implements AntiMagicSusceptible {
     private static final EntityDataAccessor<Integer> STANDBY_TICK =
             SynchedEntityData.defineId(FlySwatterProjectileEntity.class, EntityDataSerializers.INT);
 
@@ -169,6 +171,15 @@ public class FlySwatterProjectileEntity extends Projectile {
         }
     }
 
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        fizzleByAntiMagic();
+    }
+
     private void onImpact(Level level, Entity directHitTarget){
         var position = position();
 
@@ -239,6 +250,19 @@ public class FlySwatterProjectileEntity extends Projectile {
                 e.push(dir.x * EXPLOSION_KNOCKBACK * scale, EXPLOSION_KNOCKBACK_UP * scale, dir.z * EXPLOSION_KNOCKBACK * scale);
             }
         }
+    }
+
+    private void fizzleByAntiMagic() {
+        var position = position();
+        if (level() instanceof ServerLevel server) {
+            server.sendParticles(ParticleTypes.POOF, position.x, position.y, position.z,
+                    18, 0.25, 0.18, 0.25, 0.08);
+            server.sendParticles(ParticleTypes.LARGE_SMOKE, position.x, position.y, position.z,
+                    8, 0.2, 0.12, 0.2, 0.01);
+            server.playSound(null, BlockPos.containing(position), SoundEvents.FIRE_EXTINGUISH,
+                    SoundSource.PLAYERS, 0.7f, 0.9f + level().random.nextFloat() * 0.2f);
+        }
+        discard();
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/healingbloom/HealingBloomEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/healingbloom/HealingBloomEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.healingbloom;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import io.redspace.ironsspellbooks.registries.SoundRegistry;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
@@ -57,7 +59,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 
 import java.util.UUID;
 
-public class HealingBloomEntity extends PathfinderMob implements GeoEntity {
+public class HealingBloomEntity extends PathfinderMob implements GeoEntity, AntiMagicSusceptible {
     public static final float WIDTH = 0.85f;
     public static final float HEIGHT = 1.8f;
     private static final int ACTIVATION_DELAY_TICK = 40;
@@ -369,6 +371,22 @@ public class HealingBloomEntity extends PathfinderMob implements GeoEntity {
     public void dieFromReplacement() {
         if (level() instanceof ServerLevel serverLevel) {
             dieFromAnchorLoss(serverLevel);
+        }
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved() || isDeadOrDying()) {
+            return;
+        }
+
+        if (level() instanceof ServerLevel serverLevel) {
+            var owner = getOwner();
+            if (owner instanceof ServerPlayer serverPlayer) {
+                HealingBloomManager.onBloomRemoved(serverPlayer, this);
+            }
+            setHealth(0.0f);
+            die(serverLevel.damageSources().genericKill());
         }
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/illuminatestellar/IlluminateStellarStarEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/illuminatestellar/IlluminateStellarStarEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.illuminatestellar;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.ParticleRegistry;
@@ -34,9 +36,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 
-// 多すぎるのでこの弾は大本で潰す.
-@SuppressWarnings("resource")
-public class IlluminateStellarStarEntity extends Projectile {
+public class IlluminateStellarStarEntity extends Projectile implements AntiMagicSusceptible {
     private static final int PHASE_DRIFT = 0;
     private static final int PHASE_WAIT = 1;
     private static final int PHASE_LAUNCH = 2;
@@ -270,6 +270,15 @@ public class IlluminateStellarStarEntity extends Projectile {
         if (!level().isClientSide) {
             triggerImpactAndDiscard();
         }
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        triggerImpactAndDiscard();
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/magicspear/MagicSpearMissileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/magicspear/MagicSpearMissileEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.magicspear;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.ParticleRegistry;
@@ -45,7 +47,7 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 import java.util.HashSet;
 import java.util.UUID;
 
-public class MagicSpearMissileEntity extends Projectile implements GeoEntity {
+public class MagicSpearMissileEntity extends Projectile implements GeoEntity, AntiMagicSusceptible {
     private static final RawAnimation IDLE = RawAnimation.begin().thenLoop("idle");
 
     private static final int PHASE_RELEASE = 0;
@@ -154,6 +156,16 @@ public class MagicSpearMissileEntity extends Projectile implements GeoEntity {
         if (!level().isClientSide && getPhase() != PHASE_BURST) {
             explode(hit.getLocation());
         }
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved() || getPhase() == PHASE_BURST) {
+            return;
+        }
+
+        // burst 表示は同一エンティティで残るため、二発目以降の Counterspell では再初期化しない。
+        burstWithoutDamage(position());
     }
 
     @Override
@@ -318,6 +330,18 @@ public class MagicSpearMissileEntity extends Projectile implements GeoEntity {
             server.sendParticles(ParticleTypes.EXPLOSION, center.x, center.y, center.z, 1, 0.0, 0.0, 0.0, 0.0);
             server.playSound(null, BlockPos.containing(center), SoundEvents.GENERIC_EXPLODE,
                     SoundSource.PLAYERS, 0.95f, 1.15f + level().random.nextFloat() * 0.12f);
+        }
+    }
+
+    private void burstWithoutDamage(Vec3 center) {
+        setPhase(PHASE_BURST);
+        phaseTicks = 0;
+        setDeltaMovement(Vec3.ZERO);
+        setPos(center.x, center.y, center.z);
+        if (level() instanceof ServerLevel server) {
+            server.sendParticles(ParticleTypes.EXPLOSION, center.x, center.y, center.z, 1, 0.0, 0.0, 0.0, 0.0);
+            server.playSound(null, BlockPos.containing(center), SoundEvents.FIRE_EXTINGUISH,
+                    SoundSource.PLAYERS, 0.85f, 1.1f + level().random.nextFloat() * 0.12f);
         }
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlashProjectileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlashProjectileEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.manaslash;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
@@ -33,7 +35,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashSet;
 import java.util.Set;
 
-public class ManaSlashProjectileEntity extends Projectile {
+public class ManaSlashProjectileEntity extends Projectile implements AntiMagicSusceptible {
     private static final EntityDataAccessor<Float> DATA_RADIUS =
             SynchedEntityData.defineId(ManaSlashProjectileEntity.class, EntityDataSerializers.FLOAT);
 
@@ -130,6 +132,15 @@ public class ManaSlashProjectileEntity extends Projectile {
         if (!level().isClientSide) {
             discard();
         }
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        discard();
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldDefenseEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldDefenseEvent.java
@@ -1,5 +1,6 @@
 package jp.aquafactory.apprenticecodex.spell.mysticshield;
 
+import io.redspace.ironsspellbooks.api.events.CounterSpellEvent;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
@@ -31,6 +32,7 @@ public final class MysticShieldDefenseEvent {
     private static final String ACCUMULATED_DAMAGE_TAG = "ApprenticeCodexMysticShieldAccumulatedDamage";
     private static final String SOURCE_COOLDOWNS_TAG = "ApprenticeCodexMysticShieldSourceCooldowns";
     private static final String SHIELD_ENTITY_ID_TAG = "ApprenticeCodexMysticShieldEntityId";
+    private static final String COUNTERSPELL_INTERRUPTED_TAG = "ApprenticeCodexMysticShieldCounterspellInterrupted";
 
     private MysticShieldDefenseEvent() {
     }
@@ -38,7 +40,6 @@ public final class MysticShieldDefenseEvent {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onLivingAttack(LivingAttackEvent event) {
         var target = event.getEntity();
-        //noinspection resource
         if (target.level().isClientSide) {
             return;
         }
@@ -60,6 +61,19 @@ public final class MysticShieldDefenseEvent {
         spawnBlockEffect(target, source);
         discardDirectProjectile(source);
         AudioTools.playSoundFromEntity(target.level(), target, SoundRegistry.MYSTIC_SHIELD_BLOCK.get(), SoundSource.PLAYERS, 0.75f, 1.0f, 0.05f);
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onCounterSpell(CounterSpellEvent event) {
+        if (!(event.target instanceof LivingEntity target)) {
+            return;
+        }
+
+        if (getActiveMysticShield(target) == null) {
+            return;
+        }
+
+        target.getPersistentData().putBoolean(COUNTERSPELL_INTERRUPTED_TAG, true);
     }
 
     public static void resetStoredDamage(LivingEntity entity) {
@@ -85,8 +99,13 @@ public final class MysticShieldDefenseEvent {
 
     public static void releaseStoredDamage(Level level, int spellLevel, LivingEntity caster, boolean cancelled) {
         fadeStoredShieldEntity(level, caster);
+        var interruptedByCounterspell = consumeCounterspellInterrupted(caster);
         var accumulatedDamage = getStoredDamage(caster);
         resetStoredDamage(caster);
+
+        if (interruptedByCounterspell) {
+            return;
+        }
 
         if (level.isClientSide || accumulatedDamage <= 0.0f) {
             return;
@@ -115,6 +134,13 @@ public final class MysticShieldDefenseEvent {
 
     static float getStoredDamage(LivingEntity entity) {
         return entity.getPersistentData().getFloat(ACCUMULATED_DAMAGE_TAG);
+    }
+
+    private static boolean consumeCounterspellInterrupted(LivingEntity entity) {
+        var tag = entity.getPersistentData();
+        var interrupted = tag.getBoolean(COUNTERSPELL_INTERRUPTED_TAG);
+        tag.remove(COUNTERSPELL_INTERRUPTED_TAG);
+        return interrupted;
     }
 
     private static void fadeStoredShieldEntity(Level level, LivingEntity caster) {
@@ -154,7 +180,6 @@ public final class MysticShieldDefenseEvent {
             return true;
         }
 
-        //noinspection resource
         var now = defender.level().getGameTime();
         var cooldowns = defender.getPersistentData().getCompound(SOURCE_COOLDOWNS_TAG);
         var lastTick = cooldowns.getLong(sourceKey);

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldDefenseEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldDefenseEvent.java
@@ -73,11 +73,7 @@ public final class MysticShieldDefenseEvent {
             return;
         }
 
-        if (getActiveMysticShield(target) == null) {
-            return;
-        }
-
-        target.getPersistentData().putBoolean(COUNTERSPELL_INTERRUPTED_TAG, true);
+        interruptByCounterspell(target);
     }
 
     public static void resetStoredDamage(LivingEntity entity) {
@@ -138,6 +134,18 @@ public final class MysticShieldDefenseEvent {
 
     static float getStoredDamage(LivingEntity entity) {
         return entity.getPersistentData().getFloat(ACCUMULATED_DAMAGE_TAG);
+    }
+
+    private static boolean interruptByCounterspell(LivingEntity entity) {
+        if (getActiveMysticShield(entity) == null) {
+            return false;
+        }
+
+        entity.getPersistentData().putBoolean(COUNTERSPELL_INTERRUPTED_TAG, true);
+        // Iron's 側の詠唱キャンセル完了を待たず、その場で防御判定と反射用ダメージを消す。
+        resetStoredDamage(entity);
+        fadeStoredShieldEntity(entity.level(), entity);
+        return true;
     }
 
     private static boolean consumeCounterspellInterrupted(LivingEntity entity) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldDefenseEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldDefenseEvent.java
@@ -63,8 +63,12 @@ public final class MysticShieldDefenseEvent {
         AudioTools.playSoundFromEntity(target.level(), target, SoundRegistry.MYSTIC_SHIELD_BLOCK.get(), SoundSource.PLAYERS, 0.75f, 1.0f, 0.05f);
     }
 
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    @SubscribeEvent(priority = EventPriority.LOWEST)
     public static void onCounterSpell(CounterSpellEvent event) {
+        if (event.isCanceled()) {
+            return;
+        }
+
         if (!(event.target instanceof LivingEntity target)) {
             return;
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldProjectileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldProjectileEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.mysticshield;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.ParticleRegistry;
@@ -24,7 +26,7 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 
-public class MysticShieldProjectileEntity extends Projectile {
+public class MysticShieldProjectileEntity extends Projectile implements AntiMagicSusceptible {
     private static final int LIFE_TICKS = 60;
     private static final double SPEED = 1.55;
     private static final double TRAIL_INTERPOLATION_STEP = 0.24;
@@ -119,6 +121,15 @@ public class MysticShieldProjectileEntity extends Projectile {
         if (!level().isClientSide) {
             discard();
         }
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        discard();
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldShieldEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldShieldEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.mysticshield;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.ParticleRegistry;
 import net.minecraft.nbt.CompoundTag;
@@ -22,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class MysticShieldShieldEntity extends Entity implements TraceableEntity {
+public class MysticShieldShieldEntity extends Entity implements TraceableEntity, AntiMagicSusceptible {
     static final int FADE_TICKS = 4;
 
     private static final EntityDataAccessor<Boolean> DATA_FADING =
@@ -171,6 +173,15 @@ public class MysticShieldShieldEntity extends Entity implements TraceableEntity 
 
     public boolean isFading() {
         return entityData.get(DATA_FADING);
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        startFade();
     }
 
     private void spawnBreakParticles() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldShieldEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mysticshield/MysticShieldShieldEntity.java
@@ -1,7 +1,5 @@
 package jp.aquafactory.apprenticecodex.spell.mysticshield;
 
-import io.redspace.ironsspellbooks.api.magic.MagicData;
-import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.ParticleRegistry;
 import net.minecraft.nbt.CompoundTag;
@@ -24,7 +22,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public class MysticShieldShieldEntity extends Entity implements TraceableEntity, AntiMagicSusceptible {
+// Counterspell は AntiMagicSusceptible を raycast の有効対象にするため、盾ではなく術者本体で受ける。
+public class MysticShieldShieldEntity extends Entity implements TraceableEntity {
     static final int FADE_TICKS = 4;
 
     private static final EntityDataAccessor<Boolean> DATA_FADING =
@@ -173,15 +172,6 @@ public class MysticShieldShieldEntity extends Entity implements TraceableEntity,
 
     public boolean isFading() {
         return entityData.get(DATA_FADING);
-    }
-
-    @Override
-    public void onAntiMagic(MagicData playerMagicData) {
-        if (level().isClientSide || isRemoved()) {
-            return;
-        }
-
-        startFade();
     }
 
     private void spawnBreakParticles() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxCounterSpellEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxCounterSpellEvent.java
@@ -1,0 +1,59 @@
+package jp.aquafactory.apprenticecodex.spell.phalanxcharge;
+
+import io.redspace.ironsspellbooks.api.events.CounterSpellEvent;
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.effect.PhalanxStance;
+import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID)
+public final class PhalanxCounterSpellEvent {
+    private static final double FRONT_DOT_THRESHOLD = 0.25;
+
+    private PhalanxCounterSpellEvent() {
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onCounterSpell(CounterSpellEvent event) {
+        if (!(event.target instanceof ServerPlayer target)) {
+            return;
+        }
+
+        var stance = target.getEffect(EffectRegistry.PHALANX_STANCE.get());
+        if (stance == null || stance.getAmplifier() < PhalanxStance.MOVE_SPEED_ENABLED_AMPLIFIER) {
+            return;
+        }
+
+        if (!isFromFront(target, event.caster)) {
+            return;
+        }
+
+        event.setCanceled(true);
+        PhalanxGuardSuccessFlashEvent.triggerGuardSuccess(target);
+    }
+
+    private static boolean isFromFront(ServerPlayer target, Entity caster) {
+        if (caster == null || caster == target) {
+            return false;
+        }
+
+        var forward = horizontal(target.getLookAngle());
+        var incoming = horizontal(caster.getBoundingBox().getCenter().subtract(target.getBoundingBox().getCenter()));
+        return isUsableDirection(forward)
+                && isUsableDirection(incoming)
+                && forward.normalize().dot(incoming.normalize()) >= FRONT_DOT_THRESHOLD;
+    }
+
+    private static Vec3 horizontal(Vec3 vector) {
+        return new Vec3(vector.x, 0.0, vector.z);
+    }
+
+    private static boolean isUsableDirection(Vec3 vector) {
+        return vector.lengthSqr() > 1.0e-6;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxGuardSuccessFlashEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxGuardSuccessFlashEvent.java
@@ -3,7 +3,6 @@ package jp.aquafactory.apprenticecodex.spell.phalanxcharge;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
-import jp.aquafactory.apprenticecodex.spell.phalanxcharge.PhalanxWeaponryEntity;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.entity.living.ShieldBlockEvent;
@@ -50,6 +49,15 @@ public final class PhalanxGuardSuccessFlashEvent {
             return;
         }
 
+        triggerGuardSuccess(player);
+    }
+
+    public static void triggerGuardSuccess(Player player) {
+        var level = player.level();
+        if (level.isClientSide) {
+            return;
+        }
+
         var box = player.getBoundingBox().inflate(SEARCH_RANGE);
         var entities = level.getEntitiesOfClass(
                 PhalanxWeaponryEntity.class,
@@ -64,7 +72,7 @@ public final class PhalanxGuardSuccessFlashEvent {
             return;
         }
 
-        LAST_GUARD_FLASH_TICK.put(player, currentTick);
+        LAST_GUARD_FLASH_TICK.put(player, player.tickCount);
 
         level.playSound(
                 null,

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/skyedge/SkyEdgeProjectileEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/skyedge/SkyEdgeProjectileEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.skyedge;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
@@ -25,7 +27,7 @@ import net.minecraft.world.phys.*;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.NotNull;
 
-public class SkyEdgeProjectileEntity extends Projectile
+public class SkyEdgeProjectileEntity extends Projectile implements AntiMagicSusceptible
 {
     private static final int LIFE_TICKS = 20 * 5;
     private static final RandomSource RNG = RandomSource.create();
@@ -135,6 +137,16 @@ public class SkyEdgeProjectileEntity extends Projectile
             onImpact(level, 0.1, false);
             discard();
         }
+    }
+
+    @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved()) {
+            return;
+        }
+
+        onImpact(level(), 0.1, false);
+        discard();
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/spectralwing/SpectralWingFlightEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/spectralwing/SpectralWingFlightEvent.java
@@ -6,6 +6,7 @@ import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellData;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.SpectralWingState;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -16,6 +17,14 @@ public final class SpectralWingFlightEvent {
     private static final int WATER_DEACTIVATE_GRACE_TICKS = 4;
 
     private SpectralWingFlightEvent() {
+    }
+
+    public static void onSpectralWingEffectRemoved(LivingEntity entity) {
+        if (!(entity instanceof Player player) || player.level().isClientSide) {
+            return;
+        }
+
+        clearWingState(player);
     }
 
     @SubscribeEvent
@@ -97,9 +106,7 @@ public final class SpectralWingFlightEvent {
     }
 
     private static void deactivate(Player player, CodexSpellData spellData, SpectralWingState state) {
-        if (player.isFallFlying()) {
-            player.stopFallFlying();
-        }
+        stopFallFlying(player);
 
         player.removeEffect(EffectRegistry.SPECTRAL_WING.get());
         if (!state.active && !state.startedBySpell && state.launchGraceTicks == 0) {
@@ -112,6 +119,20 @@ public final class SpectralWingFlightEvent {
     private static void clearLingeringVisual(Player player) {
         if (player.hasEffect(EffectRegistry.SPECTRAL_WING.get())) {
             player.removeEffect(EffectRegistry.SPECTRAL_WING.get());
+        }
+    }
+
+    private static void clearWingState(Player player) {
+        stopFallFlying(player);
+        var spellData = Capabilities.getSpellDataOrNull(player);
+        if (spellData != null) {
+            spellData.edit(CodexSpellStateTypeRegister.SPECTRAL_WING_STATE, SpectralWingState::reset);
+        }
+    }
+
+    private static void stopFallFlying(Player player) {
+        if (player.isFallFlying()) {
+            player.stopFallFlying();
         }
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/uniteluna/UniteLunaMoonEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/uniteluna/UniteLunaMoonEntity.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.uniteluna;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.entity.mobs.AntiMagicSusceptible;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.ParticleRegistry;
@@ -35,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
 
-public class UniteLunaMoonEntity extends Projectile {
+public class UniteLunaMoonEntity extends Projectile implements AntiMagicSusceptible {
     public static final float CUBE_SIZE = 1.5f;
 
     private static final int PHASE_DECELERATE = 0;
@@ -69,6 +71,9 @@ public class UniteLunaMoonEntity extends Projectile {
     private static final double MIN_DIRECTION_LENGTH_SQR = 1.0e-6;
     private static final float MIN_BURST_CUBE_SIZE = 7.0f;
     private static final float MAX_BURST_CUBE_SIZE = 11.0f;
+    private static final float COUNTERSPELL_BURST_CUBE_SIZE = MAX_BURST_CUBE_SIZE * 2.0f;
+    private static final float COUNTERSPELL_DAMAGE_MULTIPLIER = 3.0f;
+    private static final int COUNTERSPELL_BURST_PARTICLE_MULTIPLIER = 2;
 
     private static final float SPARK_RED = 0.9f;
     private static final float SPARK_GREEN = 0.97f;
@@ -174,6 +179,16 @@ public class UniteLunaMoonEntity extends Projectile {
     }
 
     @Override
+    public void onAntiMagic(MagicData playerMagicData) {
+        if (level().isClientSide || isRemoved() || getPhase() == PHASE_BURST) {
+            return;
+        }
+
+        // Counterspell を受けても無害化せず、吸収した魔力で爆発を過熱させる。
+        explodeByAntiMagic(position());
+    }
+
+    @Override
     protected void addAdditionalSaveData(@NotNull CompoundTag tag) {
         super.addAdditionalSaveData(tag);
         tag.putFloat("Damage", damage);
@@ -205,7 +220,7 @@ public class UniteLunaMoonEntity extends Projectile {
             entityData.set(DATA_SPIN_DIRECTION, spinDirection);
         }
         if (tag.contains("BurstCubeSize")) {
-            burstCubeSize = Mth.clamp(tag.getFloat("BurstCubeSize"), MIN_BURST_CUBE_SIZE, MAX_BURST_CUBE_SIZE);
+            burstCubeSize = Mth.clamp(tag.getFloat("BurstCubeSize"), MIN_BURST_CUBE_SIZE, COUNTERSPELL_BURST_CUBE_SIZE);
             entityData.set(DATA_BURST_CUBE_SIZE, burstCubeSize);
         }
         if (tag.contains("MovementDirectionX") && tag.contains("MovementDirectionY") && tag.contains("MovementDirectionZ")) {
@@ -356,23 +371,33 @@ public class UniteLunaMoonEntity extends Projectile {
     }
 
     private void explode(Vec3 center) {
-        startBurst(BURST_KIND_EXPLOSION, center);
-        applyBurstDamage(center);
+        startBurst(BURST_KIND_EXPLOSION, center, pickNormalBurstCubeSize());
+        applyBurstDamage(center, 1.0f);
         AudioTools.playSoundFromEntity(level(), this, SoundRegistry.STELLAR_EXPLODE.get(), SoundSource.PLAYERS, 1.5f, 0.92f, 0.04f);
     }
 
     private void startBurst(int burstKind, Vec3 center) {
+        startBurst(burstKind, center, burstKind == BURST_KIND_EXPLOSION ? pickNormalBurstCubeSize() : MIN_BURST_CUBE_SIZE);
+    }
+
+    private void explodeByAntiMagic(Vec3 center) {
+        startBurst(BURST_KIND_EXPLOSION, center, COUNTERSPELL_BURST_CUBE_SIZE);
+        applyBurstDamage(center, COUNTERSPELL_DAMAGE_MULTIPLIER);
+        AudioTools.playSoundFromEntity(level(), this, SoundRegistry.STELLAR_EXPLODE.get(), SoundSource.PLAYERS, 1.8f, 0.78f, 0.04f);
+    }
+
+    private void startBurst(int burstKind, Vec3 center, float newBurstCubeSize) {
         setPhase(PHASE_BURST);
         setBurstKind(burstKind);
         phaseTicks = 0;
-        if (burstKind == BURST_KIND_EXPLOSION) {
-            burstCubeSize = Mth.lerp(level().random.nextFloat(), MIN_BURST_CUBE_SIZE, MAX_BURST_CUBE_SIZE);
-        } else {
-            burstCubeSize = MIN_BURST_CUBE_SIZE;
-        }
+        burstCubeSize = Mth.clamp(newBurstCubeSize, MIN_BURST_CUBE_SIZE, COUNTERSPELL_BURST_CUBE_SIZE);
         entityData.set(DATA_BURST_CUBE_SIZE, burstCubeSize);
         setDeltaMovement(Vec3.ZERO);
         setPos(center.x, center.y, center.z);
+    }
+
+    private float pickNormalBurstCubeSize() {
+        return Mth.lerp(level().random.nextFloat(), MIN_BURST_CUBE_SIZE, MAX_BURST_CUBE_SIZE);
     }
 
     private boolean moveWithImpactCheck(double speed) {
@@ -422,7 +447,7 @@ public class UniteLunaMoonEntity extends Projectile {
         return blockHit.getType() == HitResult.Type.BLOCK ? blockHit : null;
     }
 
-    private void applyBurstDamage(Vec3 center) {
+    private void applyBurstDamage(Vec3 center, float damageMultiplier) {
         var owner = getOwner();
         var source = CombatTools.getDamageSource(level(), this, owner, DamageTypes.UNITE_LUNA);
         var burstHalfExtent = burstCubeSize * 0.5f;
@@ -437,7 +462,7 @@ public class UniteLunaMoonEntity extends Projectile {
             if (target == owner || !damagedIds.add(target.getId())) {
                 continue;
             }
-            CombatTools.applyDamage(target, damage, source, SpellRegistry.UNITE_LUNA.get().getSchoolType(), CombatTools.KnockbackTypes.NO_KNOCKBACK);
+            CombatTools.applyDamage(target, damage * damageMultiplier, source, SpellRegistry.UNITE_LUNA.get().getSchoolType(), CombatTools.KnockbackTypes.NO_KNOCKBACK);
         }
     }
 
@@ -557,7 +582,11 @@ public class UniteLunaMoonEntity extends Projectile {
 
     private void spawnBurstParticles() {
         var random = level().random;
-        for (var i = 0; i < BURST_PARTICLE_COUNT_PER_TICK; ++i) {
+        var particleCount = BURST_PARTICLE_COUNT_PER_TICK;
+        if (getBurstCubeSize() > MAX_BURST_CUBE_SIZE) {
+            particleCount *= COUNTERSPELL_BURST_PARTICLE_MULTIPLIER;
+        }
+        for (var i = 0; i < particleCount; ++i) {
             var offset = createBurstShellOffset(random);
             var velocity = normalizeOrFallback(offset, movementDirection).scale(0.03 + random.nextDouble() * 0.14).add(
                     (random.nextDouble() - 0.5) * 0.015,

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -600,7 +600,7 @@
   "spell.apprenticecodex.spectral_wing.guide": "Launches you into the air with mana wings and immediately transitions into a glide. Recast while flying to surge hard in the direction you are looking. The wings vanish when you land or touch water.",
   "spell.apprenticecodex.auto_turret.guide": "Summons Automatically attacks nearby enemies with a crossbow. Disappears when out of ammo or durability runs out.",
   "spell.apprenticecodex.illuminate_stellar.guide": "A latent spell unique to the Illuminate Stellar Staff. By waving it, spreads twinkling stars and flies towards entities with malevolent intent.",
-  "spell.apprenticecodex.unite_luna.guide": "A latent spell unique to the Unite Luna Staff. By waving it, creates a crescent moon and obliterates disturbing entities.",
+  "spell.apprenticecodex.unite_luna.guide": "A latent spell unique to the Unite Luna Staff. By waving it, creates a crescent moon and obliterates disturbing entities. If someone tries to negate its magic, it turns that force into greater power.",
   "spell.apprenticecodex.demicreator_wings.guide": "Place a demi-creator core at your current position and gain creative flight only while you remain inside its area. Recast it, let the timer expire, or leave the area to dismiss the wings.",
   "spell.apprenticecodex.companion_trunk.guide": "Summon an arcane chest to follow you. It can hold about as many items as a normal chest, can be recalled to your side even while loaded if it is far enough away, and tries to stash its contents into a chest when it vanishes.",
   "spell.apprenticecodex.treasure_divination.guide": "Focus your mana to learn how far away the nearest valuable-looking thing is. It may not actually be valuable, and what it can detect is limited.",

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -270,7 +270,7 @@
   "jei.apprenticecodex.craftsmans_delight.desc_11": "- Touch Dig: Range is doubled.",
   "jei.apprenticecodex.protection_spell_supporter.desc_1": "Modifies the spells below and reduces their mana cost while they are active.",
   "jei.apprenticecodex.protection_spell_supporter.desc_2": "- Force Field: Can block attacks that a shield cannot.",
-  "jei.apprenticecodex.protection_spell_supporter.desc_3": "- Phalanx Charge: Increases movement speed while guarding with the shield.",
+  "jei.apprenticecodex.protection_spell_supporter.desc_3": "- Phalanx Charge: Increases movement speed while guarding with the shield, and can neutralize Counterspell from the front.",
   "jei.apprenticecodex.protection_spell_supporter.desc_4": "- Mystic Shield: Increases damage of reflected projectiles.",
   "jei.apprenticecodex.offhand_magic_items.desc_1": "Spellcasting aids meant to be used in your offhand.",
   "jei.apprenticecodex.offhand_magic_items.desc_2": "When your main hand holds a weapon or tool without a special use action, you can use these from your offhand-like a staff-to cast spells.",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -274,7 +274,7 @@
   "jei.apprenticecodex.craftsmans_delight.desc_11": "- タッチディグ：射程が2倍に伸びる。",
   "jei.apprenticecodex.protection_spell_supporter.desc_1": "下記の魔法の性能を変化させ、使用中のマナ消費量も減少させる。",
   "jei.apprenticecodex.protection_spell_supporter.desc_2": "- フォースフィールド：盾で防げない攻撃も防げるようになる。",
-  "jei.apprenticecodex.protection_spell_supporter.desc_3": "- ファランクスチャージ：盾を構えた時の移動速度が上昇する。",
+  "jei.apprenticecodex.protection_spell_supporter.desc_3": "- ファランクスチャージ：盾を構えた時の移動速度が上昇し、前方からのカウンタースペルを無力化できる。",
   "jei.apprenticecodex.protection_spell_supporter.desc_4": "- ミスティックシールド：反射弾のダメージが上昇する。",
   "jei.apprenticecodex.offhand_magic_items.desc_1": "利き手ではない方につけて使う魔法詠唱補助具。",
   "jei.apprenticecodex.offhand_magic_items.desc_2": "利き手に特殊な機能を持たない武器や道具などを持っている時に、杖と同じようにオフハンド側で使用することで魔法を詠唱できる。",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -608,7 +608,7 @@
   "spell.apprenticecodex.spectral_wing.guide": "魔力の翼で空中へ打ち上がり、そのまま滑空する。飛行中に再使用すると視線方向へ激しく加速する。地上か水面へ降りると翼は消える。",
   "spell.apprenticecodex.auto_turret.guide": "自動で近くの敵を攻撃するクロスボウを召喚する。弾を撃ち切るか耐久力が無くなると消滅する。",
   "spell.apprenticecodex.illuminate_stellar.guide": "星照らしの杖固有の潜在魔法。振るうことで瞬く星を散らし、害意を持つ存在へと飛翔する。",
-  "spell.apprenticecodex.unite_luna.guide": "月結びの杖固有の潜在魔法。振るうことで朧う月を作り出し、阻む存在を消し飛ばす",
+  "spell.apprenticecodex.unite_luna.guide": "月結びの杖固有の潜在魔法。振るうことで朧う月を作り出し、阻む存在を消し飛ばす。魔力を打ち消そうとすると、その力を利用して威力を増大させる。",
   "spell.apprenticecodex.demicreator_wings.guide": "現在位置へ半創造の核を置き、その範囲内だけクリエイティブ飛行できるようになる。再使用するか、時間切れになるか、範囲外へ出ると翼は失われる。",
   "spell.apprenticecodex.companion_trunk.guide": "魔導仕掛けのチェストを召喚し追従させる。通常のチェストと同程度のアイテムを保持でき、中身入りでも離れていれば手元へ呼び戻せる。消滅時は可能なら周囲にチェストとして中身を退避する。",
   "spell.apprenticecodex.treasure_divination.guide": "マナを集中させることで最寄りの価値の高そうなものまでの距離を知る。必ずしも価値が高いとは限らず、探知できるものも限定される。",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -270,7 +270,7 @@
   "jei.apprenticecodex.craftsmans_delight.desc_11": "- 触控挖掘：范围翻倍",
   "jei.apprenticecodex.protection_spell_supporter.desc_1": "修改以下法术，并在法术生效期间降低其魔力消耗：",
   "jei.apprenticecodex.protection_spell_supporter.desc_2": "- 力场：可抵挡盾牌无法防御的攻击",
-  "jei.apprenticecodex.protection_spell_supporter.desc_3": "- 方阵冲锋：持盾格挡时提升移动速度",
+  "jei.apprenticecodex.protection_spell_supporter.desc_3": "- 方阵冲锋：持盾格挡时提升移动速度，并可无效化来自前方的反制法术",
   "jei.apprenticecodex.protection_spell_supporter.desc_4": "- 秘术护盾：提升反射弹的伤害。",
   "jei.apprenticecodex.offhand_magic_items.desc_1": "用于副手的施法辅助物品。",
   "jei.apprenticecodex.offhand_magic_items.desc_2": "主手持无特殊使用动作的武器/工具时，可像法杖一样从副手使用这些物品施法。",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -600,7 +600,7 @@
   "spell.apprenticecodex.spectral_wing.guide": "借助魔力翅膀升空，并立即进入滑翔状态。飞行时再次施法，会朝你注视的方向猛冲。落地或接触水后翅膀消失。",
   "spell.apprenticecodex.auto_turret.guide": "召唤自动炮塔，使用弩攻击附近敌人。弹药耗尽或耐久用尽后消失。",
   "spell.apprenticecodex.illuminate_stellar.guide": "辉耀星法杖专属被动法术。挥舞法杖，散播闪烁星光，飞向怀有恶意的实体。",
-  "spell.apprenticecodex.unite_luna.guide": "融月法杖专属被动法术。挥舞法杖，生成新月之力，消灭侵扰的实体。",
+  "spell.apprenticecodex.unite_luna.guide": "融月法杖专属被动法术。挥舞法杖，生成新月之力，消灭侵扰的实体。若有人试图抵消其魔力，它会利用那股力量进一步增强威力。",
   "spell.apprenticecodex.demicreator_wings.guide": "在当前位置放置一个造物者核心，仅在核心范围内获得创造模式飞行。再次施法、计时结束或离开范围会收回翅膀。",
   "spell.apprenticecodex.companion_trunk.guide": "召唤一个奥术宝箱跟随你。容量与普通箱子相当，距离过远时可召回身边，消失时会尝试将内容物存入箱子。",
   "spell.apprenticecodex.treasure_divination.guide": "集中魔力，感知最近的贵重物品距离。探测到的物品不一定真正贵重，且可探测目标有限。",


### PR DESCRIPTION
- 基本的にはバフは無力化、弾は無力化
- 召喚武器系はLONGかCONTINUOUSなので本体に向かってカウンタースペルを撃ち込んで無力化想定
- 下記は特別な理由があり未対応
    - CompanionTrunk : アイテムが関係するのはユーザー間トラブルを招くため対応保留
    - SearchBeacon : 捧げたアイテムが関係するのはユーザー間トラブルを招くため対応保留