### PR TITLE
魔術染めのルーンタブレットのツールチップ膨大化問題対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/SpellStainedRunicTabletServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/SpellStainedRunicTabletServerConfig.java
@@ -6,11 +6,15 @@ import net.minecraftforge.common.ForgeConfigSpec;
 public final class SpellStainedRunicTabletServerConfig {
     private static final double MIN_BONUS_VALUE = -10000.0D;
     private static final double MAX_BONUS_VALUE = 10000.0D;
+    private static final double MIN_APPLIED_BONUS_THRESHOLD = 0.0D;
+    private static final double MAX_APPLIED_BONUS_THRESHOLD = 10000.0D;
     private static final int MIN_THRESHOLD_VALUE = -10000;
     private static final int MAX_THRESHOLD_VALUE = 10000;
 
     private final ConfiguredRarityBonuses maxMana;
     private final ConfiguredRarityBonuses schoolSpellPower;
+    private final ForgeConfigSpec.DoubleValue schoolSpellPowerMinimumAppliedPositiveBonus;
+    private final ForgeConfigSpec.DoubleValue schoolSpellPowerMinimumAppliedNegativePenalty;
     private final ConfiguredRarityBonuses generalSpellPower;
     private final ForgeConfigSpec.IntValue cooldownReductionMinimumSchoolCount;
     private final ForgeConfigSpec.DoubleValue cooldownReductionPerSchool;
@@ -24,6 +28,8 @@ public final class SpellStainedRunicTabletServerConfig {
     private SpellStainedRunicTabletServerConfig(
             ConfiguredRarityBonuses maxMana,
             ConfiguredRarityBonuses schoolSpellPower,
+            ForgeConfigSpec.DoubleValue schoolSpellPowerMinimumAppliedPositiveBonus,
+            ForgeConfigSpec.DoubleValue schoolSpellPowerMinimumAppliedNegativePenalty,
             ConfiguredRarityBonuses generalSpellPower,
             ForgeConfigSpec.IntValue cooldownReductionMinimumSchoolCount,
             ForgeConfigSpec.DoubleValue cooldownReductionPerSchool,
@@ -34,6 +40,8 @@ public final class SpellStainedRunicTabletServerConfig {
     ) {
         this.maxMana = maxMana;
         this.schoolSpellPower = schoolSpellPower;
+        this.schoolSpellPowerMinimumAppliedPositiveBonus = schoolSpellPowerMinimumAppliedPositiveBonus;
+        this.schoolSpellPowerMinimumAppliedNegativePenalty = schoolSpellPowerMinimumAppliedNegativePenalty;
         this.generalSpellPower = generalSpellPower;
         this.cooldownReductionMinimumSchoolCount = cooldownReductionMinimumSchoolCount;
         this.cooldownReductionPerSchool = cooldownReductionPerSchool;
@@ -61,6 +69,14 @@ public final class SpellStainedRunicTabletServerConfig {
                 0.02D,
                 0.05D
         ));
+        builder.push("schoolSpellPower");
+        var schoolSpellPowerMinimumAppliedPositiveBonus = builder
+                .comment("Minimum positive school spell power total required before Spell-stained Runic Tablet applies that school bonus. 0.05 means +5%.")
+                .defineInRange("minimumAppliedPositiveBonus", 0.05D, MIN_APPLIED_BONUS_THRESHOLD, MAX_APPLIED_BONUS_THRESHOLD);
+        var schoolSpellPowerMinimumAppliedNegativePenalty = builder
+                .comment("Minimum absolute negative school spell power total required before Spell-stained Runic Tablet applies that school penalty. 0.05 means -5%.")
+                .defineInRange("minimumAppliedNegativePenalty", 0.05D, MIN_APPLIED_BONUS_THRESHOLD, MAX_APPLIED_BONUS_THRESHOLD);
+        builder.pop();
         var generalSpellPower = defineRarityBonuses(builder, "generalSpellPower", new RarityBonuses(
                 0.0D,
                 0.0D,
@@ -98,6 +114,8 @@ public final class SpellStainedRunicTabletServerConfig {
         return new SpellStainedRunicTabletServerConfig(
                 maxMana,
                 schoolSpellPower,
+                schoolSpellPowerMinimumAppliedPositiveBonus,
+                schoolSpellPowerMinimumAppliedNegativePenalty,
                 generalSpellPower,
                 cooldownReductionMinimumSchoolCount,
                 cooldownReductionPerSchool,
@@ -116,6 +134,8 @@ public final class SpellStainedRunicTabletServerConfig {
         return new Values(
                 maxMana.values(),
                 schoolSpellPower.values(),
+                schoolSpellPowerMinimumAppliedPositiveBonus.get(),
+                schoolSpellPowerMinimumAppliedNegativePenalty.get(),
                 generalSpellPower.values(),
                 new ScalingBonus(
                         cooldownReductionMinimumSchoolCount.get(),
@@ -179,10 +199,16 @@ public final class SpellStainedRunicTabletServerConfig {
     public record Values(
             RarityBonuses maxMana,
             RarityBonuses schoolSpellPower,
+            double minimumAppliedPositiveBonus,
+            double minimumAppliedNegativePenalty,
             RarityBonuses generalSpellPower,
             ScalingBonus cooldownReduction,
             ScalingBonus castTimeReduction
     ) {
+        public Values {
+            minimumAppliedPositiveBonus = Math.max(0.0D, minimumAppliedPositiveBonus);
+            minimumAppliedNegativePenalty = Math.max(0.0D, minimumAppliedNegativePenalty);
+        }
     }
 
     public record RarityBonuses(

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexFlaskAndGuidebookGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexFlaskAndGuidebookGameTests.java
@@ -125,6 +125,11 @@ public final class ApprenticeCodexFlaskAndGuidebookGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void spellStainedRunicTabletFiltersSchoolPowerByConfiguredThresholds(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.spellStainedRunicTabletFiltersSchoolPowerByConfiguredThresholds(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void explorersCodexGuidebookTransferRecipeMovesFixedSpellsAndKeepsExplorersData(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.explorersCodexGuidebookTransferRecipeMovesFixedSpellsAndKeepsExplorersData(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -3833,6 +3833,8 @@ public final class ApprenticeCodexGameTestScenarios {
             var values = new SpellStainedRunicTabletServerConfig.Values(
                     sameRarityBonuses(-2.0D),
                     sameRarityBonuses(-0.07D),
+                    0.05D,
+                    0.05D,
                     sameRarityBonuses(-0.08D),
                     new SpellStainedRunicTabletServerConfig.ScalingBonus(1, -0.25D, 0.0D),
                     new SpellStainedRunicTabletServerConfig.ScalingBonus(1, -0.50D, 0.0D)
@@ -3896,6 +3898,55 @@ public final class ApprenticeCodexGameTestScenarios {
                 );
             }
         });
+    }
+
+    static void spellStainedRunicTabletFiltersSchoolPowerByConfiguredThresholds(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            assertSpellStainedRunicTabletThresholdScenario(helper, 0.04D, 0.05D, 0.05D, 0.0D,
+                    "Spell-stained Runic Tablet should ignore positive school spell power below threshold");
+            assertSpellStainedRunicTabletThresholdScenario(helper, 0.05D, 0.05D, 0.05D, 0.05D,
+                    "Spell-stained Runic Tablet should apply positive school spell power at threshold");
+            assertSpellStainedRunicTabletThresholdScenario(helper, -0.04D, 0.05D, 0.05D, 0.0D,
+                    "Spell-stained Runic Tablet should ignore negative school spell power below threshold");
+            assertSpellStainedRunicTabletThresholdScenario(helper, -0.05D, 0.05D, 0.05D, -0.05D,
+                    "Spell-stained Runic Tablet should apply negative school spell power at threshold");
+        });
+    }
+
+    private static void assertSpellStainedRunicTabletThresholdScenario(
+            GameTestHelper helper,
+            double configuredSchoolSpellPower,
+            double minimumAppliedPositiveBonus,
+            double minimumAppliedNegativePenalty,
+            double expectedSchoolSpellPower,
+            String message
+    ) {
+        var values = new SpellStainedRunicTabletServerConfig.Values(
+                sameRarityBonuses(0.0D),
+                sameRarityBonuses(configuredSchoolSpellPower),
+                minimumAppliedPositiveBonus,
+                minimumAppliedNegativePenalty,
+                sameRarityBonuses(0.0D),
+                new SpellStainedRunicTabletServerConfig.ScalingBonus(99, 0.0D, 0.0D),
+                new SpellStainedRunicTabletServerConfig.ScalingBonus(99, 0.0D, 0.0D)
+        );
+
+        try (var ignored = ApprenticeCodexServerConfig.useSpellStainedRunicTabletConfigOverrideForGameTest(values)) {
+            var item = (SpellStainedRunicTablet) ItemRegistry.SPELLSTAINED_RUNIC_TABLET.get();
+            var stack = createSpellStainedRunicTabletStack(
+                    helper,
+                    spellEntry(SpellRegistry.HIGANBANA.get(), SpellRarity.COMMON)
+            );
+            assertSpellStainedRunicTabletSchoolPower(
+                    helper,
+                    item,
+                    createSpellbookSlotContext(helper),
+                    stack,
+                    SpellRegistry.HIGANBANA.get(),
+                    expectedSchoolSpellPower,
+                    message
+            );
+        }
     }
 
     static void explorersCodexGuidebookTransferRecipeMovesFixedSpellsAndKeepsExplorersData(GameTestHelper helper) {
@@ -17024,6 +17075,26 @@ public final class ApprenticeCodexGameTestScenarios {
             AbstractSpell spell,
             double expectedAmount
     ) {
+        assertSpellStainedRunicTabletSchoolPower(
+                helper,
+                item,
+                slotContext,
+                stack,
+                spell,
+                expectedAmount,
+                "Spell-stained Runic Tablet school spell power mismatch for " + spell.getSpellResource()
+        );
+    }
+
+    private static void assertSpellStainedRunicTabletSchoolPower(
+            GameTestHelper helper,
+            SpellStainedRunicTablet item,
+            top.theillusivec4.curios.api.SlotContext slotContext,
+            ItemStack stack,
+            AbstractSpell spell,
+            double expectedAmount,
+            String message
+    ) {
         var attribute = MagicTools.resolveSchoolPowerAttribute(spell.getSchoolType());
         helper.assertTrue(attribute != null, "Could not resolve school spell power attribute for " + spell.getSpellResource());
         assertCurioModifierAmount(
@@ -17034,7 +17105,7 @@ public final class ApprenticeCodexGameTestScenarios {
                 attribute,
                 expectedAmount,
                 AttributeModifier.Operation.MULTIPLY_BASE,
-                "Spell-stained Runic Tablet school spell power mismatch for " + spell.getSpellResource()
+                message
         );
     }
 
@@ -17110,10 +17181,36 @@ public final class ApprenticeCodexGameTestScenarios {
         return new ExpectedSpellStainedRunicTabletAttributes(
                 maxMana,
                 generalSpellPower,
-                schoolSpellPower,
+                filterExpectedSpellStainedRunicTabletSchoolPower(schoolSpellPower, values),
                 values.cooldownReduction().resolve(schoolSpellCounts.size()),
                 values.castTimeReduction().resolve(topSchoolCount)
         );
+    }
+
+    private static Map<Attribute, Double> filterExpectedSpellStainedRunicTabletSchoolPower(
+            Map<Attribute, Double> schoolSpellPower,
+            SpellStainedRunicTabletServerConfig.Values values
+    ) {
+        var filtered = new LinkedHashMap<Attribute, Double>();
+        for (var entry : schoolSpellPower.entrySet()) {
+            if (shouldExpectSpellStainedRunicTabletSchoolPower(entry.getValue(), values)) {
+                filtered.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return filtered;
+    }
+
+    private static boolean shouldExpectSpellStainedRunicTabletSchoolPower(
+            double amount,
+            SpellStainedRunicTabletServerConfig.Values values
+    ) {
+        if (amount > 0.0D) {
+            return amount >= values.minimumAppliedPositiveBonus();
+        }
+        if (amount < 0.0D) {
+            return Math.abs(amount) >= values.minimumAppliedNegativePenalty();
+        }
+        return false;
     }
 
     private static top.theillusivec4.curios.api.SlotContext createSpellbookSlotContext(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
@@ -260,10 +260,37 @@ public class SpellStainedRunicTablet extends SpellBook implements IJeiInfoItem {
         return new SpellStats(
                 maxManaBonus,
                 globalSpellPowerBonus,
-                Map.copyOf(schoolSpellPowerBonuses),
+                filterAppliedSchoolSpellPowerBonuses(schoolSpellPowerBonuses, config),
                 schoolSpellCounts.size(),
                 maxSchoolSpellCount
         );
+    }
+
+    private Map<Attribute, Double> filterAppliedSchoolSpellPowerBonuses(
+            Map<Attribute, Double> schoolSpellPowerBonuses,
+            SpellStainedRunicTabletServerConfig.Values config
+    ) {
+        var appliedBonuses = new HashMap<Attribute, Double>();
+        for (var entry : schoolSpellPowerBonuses.entrySet()) {
+            var bonus = entry.getValue();
+            if (shouldApplySchoolSpellPowerBonus(bonus, config)) {
+                appliedBonuses.put(entry.getKey(), bonus);
+            }
+        }
+        return Map.copyOf(appliedBonuses);
+    }
+
+    private boolean shouldApplySchoolSpellPowerBonus(
+            double bonus,
+            SpellStainedRunicTabletServerConfig.Values config
+    ) {
+        if (bonus > 0.0D) {
+            return bonus >= config.minimumAppliedPositiveBonus();
+        }
+        if (bonus < 0.0D) {
+            return Math.abs(bonus) >= config.minimumAppliedNegativePenalty();
+        }
+        return false;
     }
 
     private void addModifier(

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -306,6 +306,7 @@
   "jei.apprenticecodex.spellstained_runic_tablet.desc_4": "- Spell power for the inscribed scrolls' schools increases based on rarity.",
   "jei.apprenticecodex.spellstained_runic_tablet.desc_5": "- Inscribing scrolls from many schools reduces cooldown.",
   "jei.apprenticecodex.spellstained_runic_tablet.desc_6": "- Inscribing many scrolls from the same school reduces cast time based on the highest count.",
+  "jei.apprenticecodex.spellstained_runic_tablet.desc_7": "By default, school spell power totals only apply when they reach +5% or -5%.",
   "jei.apprenticecodex.archivists_grimoire.desc_1": "A spellbook that accepts scrolls when used in hand, instead of being inscribed at an Inscription Table.",
   "jei.apprenticecodex.archivists_grimoire.desc_2": "Not every stored spell can be used at once; only up to 9 slots, the same as one inventory row, are available at a time.",
   "jei.apprenticecodex.archivists_grimoire.desc_3": "With the spell selection screen open, use the mouse wheel to switch which inventory row is active.",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -310,6 +310,7 @@
   "jei.apprenticecodex.spellstained_runic_tablet.desc_4": "- 刻み込んだスクロールの系統の魔法力がレアリティによって上昇。",
   "jei.apprenticecodex.spellstained_runic_tablet.desc_5": "- 多くの系統のスクロールを刻み込むとクールダウンが短縮。",
   "jei.apprenticecodex.spellstained_runic_tablet.desc_6": "- 同一の系統のスクロールを多数刻む込むと最大数に応じて詠唱時間が短縮。",
+  "jei.apprenticecodex.spellstained_runic_tablet.desc_7": "系統の魔法威力は、デフォルトでは同一系統の合計が+5%以上または-5%以下になった場合のみ性能として反映される。",
   "jei.apprenticecodex.archivists_grimoire.desc_1": "銘刻台で刻み込む代わりに手に持って使うことでスクロールを入れられる魔法書。",
   "jei.apprenticecodex.archivists_grimoire.desc_2": "全てが同時に使えるわけではなく、一度に使える魔法はインベントリの1行分と同じ9スロットまで。",
   "jei.apprenticecodex.archivists_grimoire.desc_3": "魔法選択画面を出した状態でマウスホイールを操作することで使用するインベントリの行を切り替えられる。",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -306,6 +306,7 @@
   "jei.apprenticecodex.spellstained_runic_tablet.desc_4": "- 铭刻卷轴所属派系的法术强度会根据稀有度提升。",
   "jei.apprenticecodex.spellstained_runic_tablet.desc_5": "- 铭刻较多派系的卷轴会缩短冷却时间。",
   "jei.apprenticecodex.spellstained_runic_tablet.desc_6": "- 铭刻多个同派系卷轴时，会根据最高数量缩短施法时间。",
+  "jei.apprenticecodex.spellstained_runic_tablet.desc_7": "默认情况下，同一派系的法术强度合计达到+5%或-5%时才会作为属性生效。",
   "jei.apprenticecodex.archivists_grimoire.desc_1": "手持该法术书即可添加卷轴，无需在铭文台铭刻。",
   "jei.apprenticecodex.archivists_grimoire.desc_2": "并非所有存储的法术都可同时使用，每次仅能使用最多9个槽位（相当于一行物品栏）。",
   "jei.apprenticecodex.archivists_grimoire.desc_3": "打开法术选择界面后，可通过鼠标滚轮切换激活的物品栏行。",


### PR DESCRIPTION
- 細かいschoolボーナスが重なると性能にさほど貢献しない能力でツールチップが溢れるためキャップをサーバー対応
- `runClient`および`runGameTestServer`は実行＆通過済み