### PR TITLE
PR #541 BetterCombat使用時における術式装填ガントレットのオフハンド限定救済を1.21.1へ移植

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatOffhandSpellSelectionRescueCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatOffhandSpellSelectionRescueCompat.java
@@ -10,12 +10,17 @@ public final class BetterCombatOffhandSpellSelectionRescueCompat {
     }
 
     public static void appendSelectionIfNeeded(SpellSelectionManager.SpellSelectionEvent event) {
-        var player = event.getEntity();
-        if (!BetterCombatOffhandAttributeRescueCompat.isRescueActive(player)) {
+        if (!event.getManager().getSpellsForSlot(SpellSelectionManager.OFFHAND).isEmpty()) {
             return;
         }
 
-        if (!event.getManager().getSpellsForSlot(SpellSelectionManager.OFFHAND).isEmpty()) {
+        appendOffhandMagicItemSelectionIfNeeded(event);
+        appendScrollcasterGauntletSelectionIfNeeded(event);
+    }
+
+    private static void appendOffhandMagicItemSelectionIfNeeded(SpellSelectionManager.SpellSelectionEvent event) {
+        var player = event.getEntity();
+        if (!BetterCombatOffhandAttributeRescueCompat.isRescueActive(player)) {
             return;
         }
 
@@ -35,6 +40,25 @@ public final class BetterCombatOffhandSpellSelectionRescueCompat {
             return;
         }
 
+        event.addSelectionOption(spellData, SpellSelectionManager.OFFHAND, 0);
+    }
+
+    private static void appendScrollcasterGauntletSelectionIfNeeded(SpellSelectionManager.SpellSelectionEvent event) {
+        if (!event.getManager().getSpellsForSlot(SpellSelectionManager.OFFHAND).isEmpty()) {
+            return;
+        }
+
+        var player = event.getEntity();
+        if (!BetterCombatScrollcasterGauntletCompat.isRescueActive(player)) {
+            return;
+        }
+
+        var spellData = BetterCombatScrollcasterGauntletCompat.getSelectedOffhandSpell(player);
+        if (spellData == SpellData.EMPTY) {
+            return;
+        }
+
+        // Scrollcaster Gauntlet は選択中スクロールだけを魔法ホルダーとして wheel に戻す。
         event.addSelectionOption(spellData, SpellSelectionManager.OFFHAND, 0);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatScrollcasterGauntletCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatScrollcasterGauntletCompat.java
@@ -1,0 +1,53 @@
+package jp.aquafactory.apprenticecodex.compat.bettercombat;
+
+import io.redspace.ironsspellbooks.api.spells.SpellData;
+import jp.aquafactory.apprenticecodex.item.ScrollcasterGauntlet;
+import net.bettercombat.logic.WeaponRegistry;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+public final class BetterCombatScrollcasterGauntletCompat {
+    private BetterCombatScrollcasterGauntletCompat() {
+    }
+
+    public static boolean isRescueActive(Player player) {
+        if (player == null || !player.isAlive()) {
+            return false;
+        }
+
+        if (!isTwoHandedMainHandWeapon(player.getMainHandItem())) {
+            return false;
+        }
+
+        return getPhysicalOffhandStack(player).getItem() instanceof ScrollcasterGauntlet;
+    }
+
+    public static ItemStack getResolvedHeldStack(Player player, InteractionHand hand) {
+        if (hand == InteractionHand.OFF_HAND && isRescueActive(player)) {
+            return getPhysicalOffhandStack(player);
+        }
+        return player.getItemInHand(hand);
+    }
+
+    public static ItemStack getPhysicalOffhandStack(Player player) {
+        return BetterCombatOffhandAttributeRescueCompat.getPhysicalOffhandStack(player);
+    }
+
+    public static SpellData getSelectedOffhandSpell(Player player) {
+        var offhandStack = getPhysicalOffhandStack(player);
+        if (!(offhandStack.getItem() instanceof ScrollcasterGauntlet)) {
+            return SpellData.EMPTY;
+        }
+        return ScrollcasterGauntlet.getSelectedSpellData(offhandStack);
+    }
+
+    private static boolean isTwoHandedMainHandWeapon(ItemStack mainHandStack) {
+        if (mainHandStack.isEmpty()) {
+            return false;
+        }
+
+        var weaponAttributes = WeaponRegistry.getAttributes(mainHandStack);
+        return weaponAttributes != null && weaponAttributes.isTwoHanded();
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexClientConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexClientConfig.java
@@ -16,6 +16,10 @@ public final class ApprenticeCodexClientConfig {
             SCROLLCASTER_GAUNTLET_OFFHAND_VISUAL_DISABLED_MAINHAND_CATEGORIES;
     private static final ModConfigSpec.ConfigValue<List<? extends String>>
             SCROLLCASTER_GAUNTLET_OFFHAND_VISUAL_DISABLED_MAINHAND_ITEMS;
+    private static final ModConfigSpec.BooleanValue ENABLE_BETTER_COMBAT_SCROLLCASTER_GAUNTLET_FIRST_PERSON_OFFHAND_VISUAL;
+    private static final ModConfigSpec.BooleanValue ENABLE_BETTER_COMBAT_SCROLLCASTER_GAUNTLET_THIRD_PERSON_OFFHAND_VISUAL;
+    private static final ModConfigSpec.ConfigValue<List<? extends String>>
+            BETTER_COMBAT_SCROLLCASTER_GAUNTLET_THIRD_PERSON_OFFHAND_VISUAL_DENIED_MAINHAND_ITEMS;
     private static final ModConfigSpec.BooleanValue DISABLE_ESSENCE_SMOKER_PARTICLE_TEXTURE_ANALYSIS;
 
     static {
@@ -58,6 +62,29 @@ public final class ApprenticeCodexClientConfig {
                                 "apprenticecodex:multipurpose_staffrifle"
                         ),
                         value -> value instanceof String text && ResourceLocation.tryParse(text) != null);
+        ENABLE_BETTER_COMBAT_SCROLLCASTER_GAUNTLET_FIRST_PERSON_OFFHAND_VISUAL = builder
+                .comment(
+                        "Render the offhand Scrollcaster Gauntlet in first person while casting through Better Combat's two-handed offhand hiding.",
+                        "This controls only the normal first-person hand renderer used for casting, not Better Combat attack animations.",
+                        "This affects only the client-side visual workaround and does not change combat behavior."
+                )
+                .define("enableBetterCombatScrollcasterGauntletFirstPersonOffhandVisual", true);
+        ENABLE_BETTER_COMBAT_SCROLLCASTER_GAUNTLET_THIRD_PERSON_OFFHAND_VISUAL = builder
+                .comment(
+                        "Render the offhand Scrollcaster Gauntlet in third person while Better Combat hides offhand equipment for two-handed weapons.",
+                        "Better Combat first-person attack animations can use the third-person player model, so this may also affect first-person attack animations.",
+                        "This affects only the client-side visual workaround and does not change combat behavior."
+                )
+                .define("enableBetterCombatScrollcasterGauntletThirdPersonOffhandVisual", true);
+        BETTER_COMBAT_SCROLLCASTER_GAUNTLET_THIRD_PERSON_OFFHAND_VISUAL_DENIED_MAINHAND_ITEMS = builder
+                .comment(
+                        "Main-hand item IDs that suppress Better Combat's third-person Scrollcaster Gauntlet offhand visual workaround.",
+                        "This denylist also applies when Better Combat renders first-person attack animations through the third-person player model.",
+                        "Use this only for specific weapons whose model visually conflicts with the gauntlet."
+                )
+                .defineList("betterCombatScrollcasterGauntletThirdPersonOffhandVisualDeniedMainhandItems",
+                        List.of(),
+                        value -> value instanceof String text && ResourceLocation.tryParse(text) != null);
         builder.pop();
 
         builder.push("Blocks");
@@ -99,6 +126,22 @@ public final class ApprenticeCodexClientConfig {
     public static boolean isScrollcasterGauntletOffhandVisualDisabledForMainhandItem(String itemId) {
         var normalizedItemId = normalizeResourceLocation(itemId);
         return SCROLLCASTER_GAUNTLET_OFFHAND_VISUAL_DISABLED_MAINHAND_ITEMS.get().stream()
+                .map(String::valueOf)
+                .map(ApprenticeCodexClientConfig::normalizeResourceLocation)
+                .anyMatch(normalizedItemId::equals);
+    }
+
+    public static boolean enableBetterCombatScrollcasterGauntletFirstPersonOffhandVisual() {
+        return ENABLE_BETTER_COMBAT_SCROLLCASTER_GAUNTLET_FIRST_PERSON_OFFHAND_VISUAL.get();
+    }
+
+    public static boolean enableBetterCombatScrollcasterGauntletThirdPersonOffhandVisual() {
+        return ENABLE_BETTER_COMBAT_SCROLLCASTER_GAUNTLET_THIRD_PERSON_OFFHAND_VISUAL.get();
+    }
+
+    public static boolean isBetterCombatScrollcasterGauntletThirdPersonOffhandVisualDeniedForMainhandItem(String itemId) {
+        var normalizedItemId = normalizeResourceLocation(itemId);
+        return BETTER_COMBAT_SCROLLCASTER_GAUNTLET_THIRD_PERSON_OFFHAND_VISUAL_DENIED_MAINHAND_ITEMS.get().stream()
                 .map(String::valueOf)
                 .map(ApprenticeCodexClientConfig::normalizeResourceLocation)
                 .anyMatch(normalizedItemId::equals);

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/BetterCombatOffhandSpellSelectionRefreshEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/BetterCombatOffhandSpellSelectionRefreshEvent.java
@@ -4,6 +4,7 @@ import io.redspace.ironsspellbooks.player.ClientMagicData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatClientCompat;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat;
+import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
@@ -42,7 +43,8 @@ public final class BetterCombatOffhandSpellSelectionRefreshEvent {
             return;
         }
 
-        var rescueActive = BetterCombatOffhandAttributeRescueCompat.isRescueActive(player);
+        var rescueActive = BetterCombatOffhandAttributeRescueCompat.isRescueActive(player)
+                || BetterCombatScrollcasterGauntletCompat.isRescueActive(player);
         if (!rescueActive && !wasRescueActive) {
             lastOffhandSnapshot = null;
             return;
@@ -51,7 +53,7 @@ public final class BetterCombatOffhandSpellSelectionRefreshEvent {
         // Better Combat 1.20.1 は両手武器中の getOffhandItem() を空へ差し替えるため、
         // spell wheel の再構築判定だけは物理 offhand スロットを直接監視する。
         var currentOffhandSnapshot = rescueActive
-                ? OffhandSnapshot.capture(BetterCombatOffhandAttributeRescueCompat.getPhysicalOffhandStack(player))
+                ? OffhandSnapshot.capture(BetterCombatScrollcasterGauntletCompat.getPhysicalOffhandStack(player))
                 : null;
         if (rescueActive != wasRescueActive || !Objects.equals(lastOffhandSnapshot, currentOffhandSnapshot)) {
             ClientMagicData.updateSpellSelectionManager();

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ScrollcasterGauntletSelectionClientController.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ScrollcasterGauntletSelectionClientController.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.event.client;
 
 import io.redspace.ironsspellbooks.player.ClientMagicData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat;
 import jp.aquafactory.apprenticecodex.item.ScrollcasterGauntlet;
 import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.ClientConfirmScrollcasterGauntletIndexPacket;
@@ -12,6 +13,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
@@ -23,6 +25,7 @@ import java.util.List;
 
 @EventBusSubscriber(modid = ApprenticeCodex.MODID, value = Dist.CLIENT)
 public final class ScrollcasterGauntletSelectionClientController {
+    private static final String BETTER_COMBAT_MOD_ID = "bettercombat";
     private static final ResourceLocation TEXTURE =
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "textures/gui/scrollcaster_gauntlet.png");
     private static final int TEXTURE_SIZE = 64;
@@ -140,7 +143,7 @@ public final class ScrollcasterGauntletSelectionClientController {
     }
 
     private static void openSelection(net.minecraft.world.entity.player.Player player, InteractionHand hand) {
-        var stack = player.getItemInHand(hand);
+        var stack = resolveHeldGauntletStack(player, hand);
         var views = ScrollcasterGauntlet.getSelectionViews(stack, player.level().registryAccess());
         if (views.isEmpty()) {
             return;
@@ -156,7 +159,7 @@ public final class ScrollcasterGauntletSelectionClientController {
 
         var selectedScrollIndex = activeState.selectedView().scrollIndex();
         var refreshedViews = ScrollcasterGauntlet.getSelectionViews(
-                player.getItemInHand(activeState.hand()),
+                resolveHeldGauntletStack(player, activeState.hand()),
                 player.level().registryAccess()
         );
         if (refreshedViews.isEmpty()) {
@@ -203,6 +206,10 @@ public final class ScrollcasterGauntletSelectionClientController {
         if (player.getMainHandItem().getItem() instanceof ScrollcasterGauntlet) {
             return InteractionHand.MAIN_HAND;
         }
+        if (ModList.get().isLoaded(BETTER_COMBAT_MOD_ID)
+                && BetterCombatScrollcasterGauntletCompat.isRescueActive(player)) {
+            return InteractionHand.OFF_HAND;
+        }
         if (player.getOffhandItem().getItem() instanceof ScrollcasterGauntlet) {
             return InteractionHand.OFF_HAND;
         }
@@ -210,7 +217,17 @@ public final class ScrollcasterGauntletSelectionClientController {
     }
 
     private static boolean isValidHeldGauntlet(net.minecraft.world.entity.player.Player player, InteractionHand hand) {
-        return player.getItemInHand(hand).getItem() instanceof ScrollcasterGauntlet;
+        return resolveHeldGauntletStack(player, hand).getItem() instanceof ScrollcasterGauntlet;
+    }
+
+    private static net.minecraft.world.item.ItemStack resolveHeldGauntletStack(
+            net.minecraft.world.entity.player.Player player,
+            InteractionHand hand
+    ) {
+        if (ModList.get().isLoaded(BETTER_COMBAT_MOD_ID)) {
+            return BetterCombatScrollcasterGauntletCompat.getResolvedHeldStack(player, hand);
+        }
+        return player.getItemInHand(hand);
     }
 
     private static int findInitialViewIndex(List<ScrollcasterGauntlet.ScrollSelectionView> views) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -409,6 +409,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void betterCombatScrollcasterGauntletRescueUsesPhysicalOffhandInventoryStack(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.betterCombatScrollcasterGauntletRescueUsesPhysicalOffhandInventoryStack(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void dynamicCastingMobilityEffectRebalancesAgainstExternalCastingMoveSpeed(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.dynamicCastingMobilityEffectRebalancesAgainstExternalCastingMoveSpeed(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -6902,6 +6902,70 @@ public final class ApprenticeCodexGameTestScenarios {
             );
         });
     }
+    static void betterCombatScrollcasterGauntletRescueUsesPhysicalOffhandInventoryStack(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            if (!ModList.get().isLoaded("bettercombat")) {
+                return;
+            }
+
+            var spellbreaker = BuiltInRegistries.ITEM.getOptional(
+                    ResourceLocation.fromNamespaceAndPath("irons_spellbooks", "spellbreaker")
+            ).orElse(null);
+            helper.assertTrue(spellbreaker != null && spellbreaker != Items.AIR,
+                    "Missing irons_spellbooks:spellbreaker for Better Combat Scrollcaster test");
+
+            var expectedSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+            var gauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
+            ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(expectedSpell));
+            ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
+
+            var player = createBetterCombatHiddenOffhandPlayer(
+                    helper,
+                    new ItemStack(spellbreaker),
+                    gauntlet,
+                    "better_combat_hidden_scrollcaster_spell_test"
+            );
+            helper.assertTrue(player.getOffhandItem().isEmpty(),
+                    "Better Combat should hide getOffhandItem() for spellbreaker Scrollcaster test but returned "
+                            + player.getOffhandItem());
+            helper.assertFalse(
+                    jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat
+                            .isRescueActive(player),
+                    "Scrollcaster Gauntlet should not join the Better Combat attribute rescue path"
+            );
+            helper.assertTrue(
+                    jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat
+                            .isRescueActive(player),
+                    "Scrollcaster Gauntlet should join only the Better Combat magic-holder rescue path"
+            );
+
+            var resolvedStack =
+                    jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat
+                            .getResolvedHeldStack(player, InteractionHand.OFF_HAND);
+            helper.assertTrue(resolvedStack.is(ItemRegistry.SCROLLCASTER_GAUNTLET.get()),
+                    "Scrollcaster resolver should return the physical offhand gauntlet but got " + resolvedStack);
+
+            var selectionManager = new io.redspace.ironsspellbooks.api.magic.SpellSelectionManager(player);
+            var offhandSelections = selectionManager.getSpellsForSlot(
+                    io.redspace.ironsspellbooks.api.magic.SpellSelectionManager.OFFHAND
+            );
+            helper.assertTrue(offhandSelections.size() == 1,
+                    "Better Combat Scrollcaster rescue should add exactly one selected offhand spell but got "
+                            + offhandSelections.size() + " selections=" + offhandSelections);
+
+            var rescuedSpell = selectionManager.getSpellForSlot(
+                    io.redspace.ironsspellbooks.api.magic.SpellSelectionManager.OFFHAND,
+                    0
+            );
+            helper.assertTrue(
+                    rescuedSpell != SpellData.EMPTY
+                            && rescuedSpell.getSpell().equals(expectedSpell)
+                            && rescuedSpell.getLevel() == 1,
+                    "Better Combat Scrollcaster rescue should restore selected spell "
+                            + expectedSpell.getSpellResource() + " but got " + rescuedSpell
+            );
+        });
+    }
     static void enchantedCircletKeepsExpectedEnchantmentSurfaces(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var stack = createInitializedPresetStack(ItemRegistry.ENCHANTED_CIRCLET.get());

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/BetterCombatItemInHandLayerMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/BetterCombatItemInHandLayerMixin.java
@@ -1,0 +1,88 @@
+package jp.aquafactory.apprenticecodex.mixin;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexClientConfig;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.entity.layers.ItemInHandLayer;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.entity.HumanoidArm;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ItemInHandLayer.class)
+public abstract class BetterCombatItemInHandLayerMixin {
+    @Shadow
+    protected abstract void renderArmWithItem(
+            LivingEntity livingEntity,
+            ItemStack itemStack,
+            ItemDisplayContext displayContext,
+            HumanoidArm arm,
+            PoseStack poseStack,
+            MultiBufferSource buffer,
+            int packedLight
+    );
+
+    @Inject(
+            method = "render(Lcom/mojang/blaze3d/vertex/PoseStack;"
+                    + "Lnet/minecraft/client/renderer/MultiBufferSource;"
+                    + "ILnet/minecraft/world/entity/LivingEntity;FFFFFF)V",
+            at = @At("TAIL")
+    )
+    private void apprenticecodex$renderBetterCombatScrollcasterOffhand(
+            PoseStack poseStack,
+            MultiBufferSource buffer,
+            int packedLight,
+            LivingEntity livingEntity,
+            float limbSwing,
+            float limbSwingAmount,
+            float partialTicks,
+            float ageInTicks,
+            float netHeadYaw,
+            float headPitch,
+            CallbackInfo callback
+    ) {
+        if (!(livingEntity instanceof Player player)) {
+            return;
+        }
+        if (!ApprenticeCodexClientConfig.enableBetterCombatScrollcasterGauntletThirdPersonOffhandVisual()) {
+            return;
+        }
+        if (!player.getOffhandItem().isEmpty() || !BetterCombatScrollcasterGauntletCompat.isRescueActive(player)) {
+            return;
+        }
+        if (apprentice_codex$isDeniedMainhandItem(player.getMainHandItem())) {
+            return;
+        }
+
+        var offhandStack = BetterCombatScrollcasterGauntletCompat.getPhysicalOffhandStack(player);
+        if (offhandStack.isEmpty()) {
+            return;
+        }
+
+        var offhandArm = player.getMainArm().getOpposite();
+        var displayContext = offhandArm == HumanoidArm.RIGHT
+                ? ItemDisplayContext.THIRD_PERSON_RIGHT_HAND
+                : ItemDisplayContext.THIRD_PERSON_LEFT_HAND;
+
+        poseStack.pushPose();
+        renderArmWithItem(player, offhandStack, displayContext, offhandArm, poseStack, buffer, packedLight);
+        poseStack.popPose();
+    }
+
+    @Unique
+    private static boolean apprentice_codex$isDeniedMainhandItem(ItemStack mainHandStack) {
+        var itemId = BuiltInRegistries.ITEM.getKey(mainHandStack.getItem());
+        return itemId != null
+                && ApprenticeCodexClientConfig
+                .isBetterCombatScrollcasterGauntletThirdPersonOffhandVisualDeniedForMainhandItem(itemId.toString());
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/BetterCombatItemInHandRendererMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/BetterCombatItemInHandRendererMixin.java
@@ -1,0 +1,95 @@
+package jp.aquafactory.apprenticecodex.mixin;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
+import io.redspace.ironsspellbooks.player.ClientMagicData;
+import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexClientConfig;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.ItemInHandRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.util.Mth;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ItemInHandRenderer.class)
+public abstract class BetterCombatItemInHandRendererMixin {
+    @Shadow
+    private ItemStack offHandItem;
+
+    @Shadow
+    private float offHandHeight;
+
+    @Shadow
+    private float oOffHandHeight;
+
+    @Invoker("renderArmWithItem")
+    protected abstract void apprenticecodex$renderArmWithItem(
+            AbstractClientPlayer player,
+            float partialTicks,
+            float pitch,
+            InteractionHand hand,
+            float swingProgress,
+            ItemStack stack,
+            float equippedProgress,
+            PoseStack poseStack,
+            MultiBufferSource buffer,
+            int combinedLight
+    );
+
+    @Inject(
+            method = "renderHandsWithItems",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;endBatch()V"
+            )
+    )
+    private void apprenticecodex$renderBetterCombatScrollcasterOffhandWhileCasting(
+            float partialTicks,
+            PoseStack poseStack,
+            MultiBufferSource.BufferSource buffer,
+            LocalPlayer player,
+            int combinedLight,
+            CallbackInfo callback
+    ) {
+        if (!ApprenticeCodexClientConfig.enableBetterCombatScrollcasterGauntletFirstPersonOffhandVisual()) {
+            return;
+        }
+        if (!offHandItem.isEmpty() || !BetterCombatScrollcasterGauntletCompat.isRescueActive(player)) {
+            return;
+        }
+        var syncedSpellData = ClientMagicData.getSyncedSpellData(player);
+        if (!syncedSpellData.isCasting()
+                || !SpellSelectionManager.OFFHAND.equals(syncedSpellData.getCastingEquipmentSlot())) {
+            return;
+        }
+
+        var offhandStack = BetterCombatScrollcasterGauntletCompat.getPhysicalOffhandStack(player);
+        if (offhandStack.isEmpty()) {
+            return;
+        }
+
+        var swingProgress = player.swingingArm == InteractionHand.OFF_HAND ? player.getAttackAnim(partialTicks) : 0.0F;
+        var pitch = Mth.lerp(partialTicks, player.xRotO, player.getXRot());
+        var equippedProgress = 1.0F - Mth.lerp(partialTicks, oOffHandHeight, offHandHeight);
+        apprenticecodex$renderArmWithItem(
+                player,
+                partialTicks,
+                pitch,
+                InteractionHand.OFF_HAND,
+                swingProgress,
+                offhandStack,
+                equippedProgress,
+                poseStack,
+                buffer,
+                combinedLight
+        );
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/ClientSpellCastHelperMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/ClientSpellCastHelperMixin.java
@@ -10,6 +10,7 @@ import io.redspace.ironsspellbooks.render.animation.AnimationHelper;
 import jp.aquafactory.apprenticecodex.event.client.ClientPlacementPreviewManager;
 import jp.aquafactory.apprenticecodex.event.client.ClientMultipurposeStaffrifleCastContext;
 import jp.aquafactory.apprenticecodex.event.client.ClientSwingcastStaffCastContext;
+import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat;
 import jp.aquafactory.apprenticecodex.item.CastAnimationOverrideItem;
 import jp.aquafactory.apprenticecodex.item.FocusStaffbow;
 import jp.aquafactory.apprenticecodex.item.MultipurposeStaffrifle;
@@ -30,11 +31,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import net.neoforged.fml.ModList;
 
 import java.util.UUID;
 
 @Mixin(value = ClientSpellCastHelper.class, remap = false)
 public abstract class ClientSpellCastHelperMixin {
+    @Unique
+    private static final String apprentice_codex$BETTER_COMBAT_MOD_ID = "bettercombat";
 
     // 特殊アイテム発動時だけ開始アニメーションを差し替え、音や入力抑制など他の前処理は元の spell 実装へ委ねる.
     @Inject(
@@ -207,7 +211,7 @@ public abstract class ClientSpellCastHelperMixin {
             return player.getMainHandItem();
         }
         if (SpellSelectionManager.OFFHAND.equals(castingSlot)) {
-            return player.getOffhandItem();
+            return apprentice_codex$resolveOffhandStack(player);
         }
         return ItemStack.EMPTY;
     }
@@ -254,7 +258,7 @@ public abstract class ClientSpellCastHelperMixin {
             return mainHand;
         }
 
-        var offHand = player.getOffhandItem();
+        var offHand = apprentice_codex$resolveOffhandStack(player);
         if (offHand != castingStack && apprentice_codex$hasCastStartAnimationOverride(player, offHand, spell)) {
             return offHand;
         }
@@ -291,12 +295,21 @@ public abstract class ClientSpellCastHelperMixin {
             return mainHand;
         }
 
-        var offHand = player.getOffhandItem();
+        var offHand = apprentice_codex$resolveOffhandStack(player);
         if (offHand != castingStack && apprentice_codex$hasCastAnimationOverride(player, offHand, spell)) {
             return offHand;
         }
 
         return ItemStack.EMPTY;
+    }
+
+    @Unique
+    private static ItemStack apprentice_codex$resolveOffhandStack(Player player) {
+        if (ModList.get().isLoaded(apprentice_codex$BETTER_COMBAT_MOD_ID)
+                && BetterCombatScrollcasterGauntletCompat.isRescueActive(player)) {
+            return BetterCombatScrollcasterGauntletCompat.getPhysicalOffhandStack(player);
+        }
+        return player.getOffhandItem();
     }
 
     @Unique

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientConfirmScrollcasterGauntletIndexPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientConfirmScrollcasterGauntletIndexPacket.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.network.packet;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcasterGauntletCompat;
 import jp.aquafactory.apprenticecodex.item.ScrollcasterGauntlet;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -12,12 +13,16 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 public record ClientConfirmScrollcasterGauntletIndexPacket(
         InteractionHand hand,
         int selectedIndex
 ) implements CustomPacketPayload {
+    private static final String BETTER_COMBAT_MOD_ID = "bettercombat";
     public static final Type<ClientConfirmScrollcasterGauntletIndexPacket> TYPE =
             new Type<>(ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "client_confirm_scrollcaster_gauntlet_index"));
     public static final StreamCodec<RegistryFriendlyByteBuf, ClientConfirmScrollcasterGauntletIndexPacket> STREAM_CODEC =
@@ -51,7 +56,7 @@ public record ClientConfirmScrollcasterGauntletIndexPacket(
                 return;
             }
 
-            var stack = sender.getItemInHand(packet.hand());
+            var stack = resolveHeldGauntletStack(sender, packet.hand());
             if (!(stack.getItem() instanceof ScrollcasterGauntlet)
                     || !ScrollcasterGauntlet.isSelectableScrollIndex(stack, packet.selectedIndex())) {
                 return;
@@ -70,5 +75,12 @@ public record ClientConfirmScrollcasterGauntletIndexPacket(
                 );
             }
         });
+    }
+
+    private static ItemStack resolveHeldGauntletStack(Player player, InteractionHand hand) {
+        if (ModList.get().isLoaded(BETTER_COMBAT_MOD_ID)) {
+            return BetterCombatScrollcasterGauntletCompat.getResolvedHeldStack(player, hand);
+        }
+        return player.getItemInHand(hand);
     }
 }

--- a/src/main/resources/mixins.apprenticecodex.json
+++ b/src/main/resources/mixins.apprenticecodex.json
@@ -46,6 +46,8 @@
   ],
   "client": [
     "ArcaneAnvilJeiRecipeMixin",
+    "BetterCombatItemInHandLayerMixin",
+    "BetterCombatItemInHandRendererMixin",
     "ClientPlayerEventsAutocastAmuletTooltipMixin",
     "ClientPlayerEventsFocusStaffbowMixin",
     "ClientPlayerRecastsMixin",


### PR DESCRIPTION
## 概要
- PR #541 の変更を `1.21.1-main` へ forward-port しました。
- Better Combat の両手武器で offhand が空扱いになる状況でも、術式装填ガントレットの spell wheel / 選択 UI / 表示救済だけを復活させます。
- 右クリック機能、エンチャント、Attribute 救済は元 PR の方針通り追加していません。

## 移植調整
- NeoForge 1.21.1 側の payload API、client event、registry access に合わせてコンフリクトを解消しました。
- 追加 mixin は既存の Better Combat 用 mixin plugin 判定に乗せています。

## 検証
- `./gradlew.bat runGameTestServer` 成功（477 tests passed）
- `./gradlew.bat runGameTestServerBetterCombat` 成功（477 tests passed）
- `./gradlew.bat build` 成功（`checkTextEncodingHygiene` 含む）
- `runClientBetterCombat` はローカル動作確認済み