### PR TITLE
[codex] PR #556を1.21.1へforward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.config;
 
 import jp.aquafactory.apprenticecodex.config.item.SpellStainedRunicTabletServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArchivistsGrimoireServerConfig;
+import jp.aquafactory.apprenticecodex.config.item.SpellgunServerConfig;
 import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbowChargeSettings;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.state.BlockState;
@@ -403,6 +404,38 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.circuitHeatStaffCooldownBypassMaxRemainingTicks();
     }
 
+    public static int ironSpellgunMaxInstantImbueCooldownTicks() {
+        return ITEMS_CONFIG.ironSpellgunMaxInstantImbueCooldownTicks();
+    }
+
+    public static int ironSpellgunOverriddenSpellCooldownTicks() {
+        return ITEMS_CONFIG.ironSpellgunOverriddenSpellCooldownTicks();
+    }
+
+    public static int copperSpellgunMaxInstantImbueCooldownTicks() {
+        return ITEMS_CONFIG.copperSpellgunMaxInstantImbueCooldownTicks();
+    }
+
+    public static int copperSpellgunOverriddenSpellCooldownTicks() {
+        return ITEMS_CONFIG.copperSpellgunOverriddenSpellCooldownTicks();
+    }
+
+    public static int goldSpellgunMaxInstantImbueCooldownTicks() {
+        return ITEMS_CONFIG.goldSpellgunMaxInstantImbueCooldownTicks();
+    }
+
+    public static int goldSpellgunOverriddenSpellCooldownTicks() {
+        return ITEMS_CONFIG.goldSpellgunOverriddenSpellCooldownTicks();
+    }
+
+    public static int diamondSpellgunMaxInstantImbueCooldownTicks() {
+        return ITEMS_CONFIG.diamondSpellgunMaxInstantImbueCooldownTicks();
+    }
+
+    public static int diamondSpellgunOverriddenSpellCooldownTicks() {
+        return ITEMS_CONFIG.diamondSpellgunOverriddenSpellCooldownTicks();
+    }
+
     public static boolean isCircuitHeatStaffSpellDenied(ResourceLocation spellId) {
         return ITEMS_CONFIG.isCircuitHeatStaffSpellDenied(spellId);
     }
@@ -695,6 +728,12 @@ public final class ApprenticeCodexServerConfig {
         var previousSpellDenylist = ITEMS_CONFIG.multipurposeStaffrifleSpellDenylist();
         ITEMS_CONFIG.setMultipurposeStaffrifleSpellDenylistForGameTest(spellDenylist);
         return () -> ITEMS_CONFIG.setMultipurposeStaffrifleSpellDenylistForGameTest(previousSpellDenylist);
+    }
+
+    public static GameTestConfigOverride useSpellgunConfigOverrideForGameTest(SpellgunServerConfig.Values values) {
+        var previousValues = ITEMS_CONFIG.spellgunConfig();
+        ITEMS_CONFIG.setSpellgunConfigForGameTest(values);
+        return () -> ITEMS_CONFIG.setSpellgunConfigForGameTest(previousValues);
     }
 
     public static GameTestConfigOverride useManaShieldCharmConfigOverrideForGameTest(

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -19,6 +19,7 @@ import jp.aquafactory.apprenticecodex.config.item.ArchivistsGrimoireServerConfig
 import jp.aquafactory.apprenticecodex.config.item.SatelliteFollowcastAmuletServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ScarletThirstServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ScrollcasterGauntletServerConfig;
+import jp.aquafactory.apprenticecodex.config.item.SpellgunServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.SpellStainedRunicTabletServerConfig;
 import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbowChargeSettings;
 import net.minecraft.resources.ResourceLocation;
@@ -38,6 +39,7 @@ final class ItemsServerConfig {
     private final ManaForceBladeServerConfig manaForceBladeConfig;
     private final ManaShieldCharmServerConfig manaShieldCharmConfig;
     private final CircuitHeatStaffServerConfig circuitHeatStaffConfig;
+    private final SpellgunServerConfig spellgunConfig;
     private final MulticastEchoStaffServerConfig multicastEchoStaffConfig;
     private final MultipurposeStaffrifleServerConfig multipurposeStaffrifleConfig;
     private final FocusStaffbowServerConfig focusStaffbowConfig;
@@ -60,6 +62,7 @@ final class ItemsServerConfig {
             ManaForceBladeServerConfig manaForceBladeConfig,
             ManaShieldCharmServerConfig manaShieldCharmConfig,
             CircuitHeatStaffServerConfig circuitHeatStaffConfig,
+            SpellgunServerConfig spellgunConfig,
             MulticastEchoStaffServerConfig multicastEchoStaffConfig,
             MultipurposeStaffrifleServerConfig multipurposeStaffrifleConfig,
             FocusStaffbowServerConfig focusStaffbowConfig,
@@ -81,6 +84,7 @@ final class ItemsServerConfig {
         this.manaForceBladeConfig = manaForceBladeConfig;
         this.manaShieldCharmConfig = manaShieldCharmConfig;
         this.circuitHeatStaffConfig = circuitHeatStaffConfig;
+        this.spellgunConfig = spellgunConfig;
         this.multicastEchoStaffConfig = multicastEchoStaffConfig;
         this.multipurposeStaffrifleConfig = multipurposeStaffrifleConfig;
         this.focusStaffbowConfig = focusStaffbowConfig;
@@ -105,6 +109,7 @@ final class ItemsServerConfig {
         var manaForceBladeConfig = ManaForceBladeServerConfig.define(builder);
         var manaShieldCharmConfig = ManaShieldCharmServerConfig.define(builder);
         var circuitHeatStaffConfig = CircuitHeatStaffServerConfig.define(builder);
+        var spellgunConfig = SpellgunServerConfig.define(builder);
         var multicastEchoStaffConfig = MulticastEchoStaffServerConfig.define(builder);
         var multipurposeStaffrifleConfig = MultipurposeStaffrifleServerConfig.define(builder);
         var focusStaffbowConfig = FocusStaffbowServerConfig.define(builder);
@@ -128,6 +133,7 @@ final class ItemsServerConfig {
                 manaForceBladeConfig,
                 manaShieldCharmConfig,
                 circuitHeatStaffConfig,
+                spellgunConfig,
                 multicastEchoStaffConfig,
                 multipurposeStaffrifleConfig,
                 focusStaffbowConfig,
@@ -282,6 +288,38 @@ final class ItemsServerConfig {
 
     int circuitHeatStaffCooldownBypassMaxRemainingTicks() {
         return circuitHeatStaffConfig.cooldownBypassMaxRemainingTicks();
+    }
+
+    int ironSpellgunMaxInstantImbueCooldownTicks() {
+        return spellgunConfig.ironMaxInstantImbueCooldownTicks();
+    }
+
+    int ironSpellgunOverriddenSpellCooldownTicks() {
+        return spellgunConfig.ironOverriddenSpellCooldownTicks();
+    }
+
+    int copperSpellgunMaxInstantImbueCooldownTicks() {
+        return spellgunConfig.copperMaxInstantImbueCooldownTicks();
+    }
+
+    int copperSpellgunOverriddenSpellCooldownTicks() {
+        return spellgunConfig.copperOverriddenSpellCooldownTicks();
+    }
+
+    int goldSpellgunMaxInstantImbueCooldownTicks() {
+        return spellgunConfig.goldMaxInstantImbueCooldownTicks();
+    }
+
+    int goldSpellgunOverriddenSpellCooldownTicks() {
+        return spellgunConfig.goldOverriddenSpellCooldownTicks();
+    }
+
+    int diamondSpellgunMaxInstantImbueCooldownTicks() {
+        return spellgunConfig.diamondMaxInstantImbueCooldownTicks();
+    }
+
+    int diamondSpellgunOverriddenSpellCooldownTicks() {
+        return spellgunConfig.diamondOverriddenSpellCooldownTicks();
     }
 
     boolean isCircuitHeatStaffSpellDenied(ResourceLocation spellId) {
@@ -550,6 +588,14 @@ final class ItemsServerConfig {
 
     List<String> multipurposeStaffrifleSpellDenylist() {
         return multipurposeStaffrifleConfig.spellDenylist();
+    }
+
+    SpellgunServerConfig.Values spellgunConfig() {
+        return spellgunConfig.values();
+    }
+
+    void setSpellgunConfigForGameTest(SpellgunServerConfig.Values values) {
+        spellgunConfig.setForGameTest(values);
     }
 
     void setMultipurposeStaffrifleSpellDenylistForGameTest(List<String> spellDenylist) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/SpellgunServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/SpellgunServerConfig.java
@@ -1,0 +1,156 @@
+package jp.aquafactory.apprenticecodex.config.item;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class SpellgunServerConfig {
+    private static final int MAX_CONFIGURED_TICKS = 72000;
+
+    private final TierConfig iron;
+    private final TierConfig copper;
+    private final TierConfig gold;
+    private final TierConfig diamond;
+    private Values override;
+
+    private SpellgunServerConfig(TierConfig iron, TierConfig copper, TierConfig gold, TierConfig diamond) {
+        this.iron = iron;
+        this.copper = copper;
+        this.gold = gold;
+        this.diamond = diamond;
+    }
+
+    public static SpellgunServerConfig define(ModConfigSpec.Builder builder) {
+        builder.push("Spellgun");
+        var iron = defineTier(builder, "Iron", 20 * 5, 10);
+        var copper = defineTier(builder, "Copper", 20 * 10, 20);
+        var gold = defineTier(builder, "Gold", 20 * 20, 40);
+        var diamond = defineTier(builder, "Diamond", 20 * 30, 80);
+        builder.pop();
+
+        return new SpellgunServerConfig(iron, copper, gold, diamond);
+    }
+
+    public int ironMaxInstantImbueCooldownTicks() {
+        return values().ironMaxInstantImbueCooldownTicks();
+    }
+
+    public int ironOverriddenSpellCooldownTicks() {
+        return values().ironOverriddenSpellCooldownTicks();
+    }
+
+    public int copperMaxInstantImbueCooldownTicks() {
+        return values().copperMaxInstantImbueCooldownTicks();
+    }
+
+    public int copperOverriddenSpellCooldownTicks() {
+        return values().copperOverriddenSpellCooldownTicks();
+    }
+
+    public int goldMaxInstantImbueCooldownTicks() {
+        return values().goldMaxInstantImbueCooldownTicks();
+    }
+
+    public int goldOverriddenSpellCooldownTicks() {
+        return values().goldOverriddenSpellCooldownTicks();
+    }
+
+    public int diamondMaxInstantImbueCooldownTicks() {
+        return values().diamondMaxInstantImbueCooldownTicks();
+    }
+
+    public int diamondOverriddenSpellCooldownTicks() {
+        return values().diamondOverriddenSpellCooldownTicks();
+    }
+
+    public Values values() {
+        if (override != null) {
+            return override;
+        }
+        return new Values(
+                iron.maxInstantImbueCooldownTicks(),
+                iron.overriddenSpellCooldownTicks(),
+                copper.maxInstantImbueCooldownTicks(),
+                copper.overriddenSpellCooldownTicks(),
+                gold.maxInstantImbueCooldownTicks(),
+                gold.overriddenSpellCooldownTicks(),
+                diamond.maxInstantImbueCooldownTicks(),
+                diamond.overriddenSpellCooldownTicks()
+        );
+    }
+
+    public void setForGameTest(Values values) {
+        override = values;
+    }
+
+    private static TierConfig defineTier(
+            ModConfigSpec.Builder builder,
+            String tierName,
+            int defaultMaxInstantImbueCooldownTicks,
+            int defaultOverriddenSpellCooldownTicks
+    ) {
+        builder.push(tierName);
+        var maxInstantImbueCooldownTicks = builder
+                .comment("Maximum spell cooldown ticks allowed for this Spellgun's imbue restriction. 0 disables this limit.")
+                .defineInRange("maxInstantImbueCooldownTicks", defaultMaxInstantImbueCooldownTicks, 0, MAX_CONFIGURED_TICKS);
+        var overriddenSpellCooldownTicks = builder
+                .comment("Cooldown ticks applied after this Spellgun casts. 0 forces a 0-tick cooldown instead of using the original spell cooldown.")
+                .defineInRange("overriddenSpellCooldownTicks", defaultOverriddenSpellCooldownTicks, 0, MAX_CONFIGURED_TICKS);
+        builder.pop();
+
+        return new TierConfig(
+                maxInstantImbueCooldownTicks,
+                defaultMaxInstantImbueCooldownTicks,
+                overriddenSpellCooldownTicks,
+                defaultOverriddenSpellCooldownTicks
+        );
+    }
+
+    public record Values(
+            int ironMaxInstantImbueCooldownTicks,
+            int ironOverriddenSpellCooldownTicks,
+            int copperMaxInstantImbueCooldownTicks,
+            int copperOverriddenSpellCooldownTicks,
+            int goldMaxInstantImbueCooldownTicks,
+            int goldOverriddenSpellCooldownTicks,
+            int diamondMaxInstantImbueCooldownTicks,
+            int diamondOverriddenSpellCooldownTicks
+    ) {
+        public Values {
+            ironMaxInstantImbueCooldownTicks = clampTicks(ironMaxInstantImbueCooldownTicks);
+            ironOverriddenSpellCooldownTicks = clampTicks(ironOverriddenSpellCooldownTicks);
+            copperMaxInstantImbueCooldownTicks = clampTicks(copperMaxInstantImbueCooldownTicks);
+            copperOverriddenSpellCooldownTicks = clampTicks(copperOverriddenSpellCooldownTicks);
+            goldMaxInstantImbueCooldownTicks = clampTicks(goldMaxInstantImbueCooldownTicks);
+            goldOverriddenSpellCooldownTicks = clampTicks(goldOverriddenSpellCooldownTicks);
+            diamondMaxInstantImbueCooldownTicks = clampTicks(diamondMaxInstantImbueCooldownTicks);
+            diamondOverriddenSpellCooldownTicks = clampTicks(diamondOverriddenSpellCooldownTicks);
+        }
+    }
+
+    private record TierConfig(
+            ModConfigSpec.IntValue maxInstantImbueCooldownTicksValue,
+            int defaultMaxInstantImbueCooldownTicks,
+            ModConfigSpec.IntValue overriddenSpellCooldownTicksValue,
+            int defaultOverriddenSpellCooldownTicks
+    ) {
+        int maxInstantImbueCooldownTicks() {
+            return configuredTicks(maxInstantImbueCooldownTicksValue, defaultMaxInstantImbueCooldownTicks);
+        }
+
+        int overriddenSpellCooldownTicks() {
+            return configuredTicks(overriddenSpellCooldownTicksValue, defaultOverriddenSpellCooldownTicks);
+        }
+    }
+
+    private static int configuredTicks(ModConfigSpec.IntValue value, int defaultValue) {
+        try {
+            return value.get();
+        } catch (IllegalStateException ignored) {
+            // Datapack 読み込み中の ItemStack 正規化では server config がまだロードされていない.
+            return defaultValue;
+        }
+    }
+
+    private static int clampTicks(int ticks) {
+        return Math.max(0, Math.min(MAX_CONFIGURED_TICKS, ticks));
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -26,6 +26,7 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
             "apprenticecodex.focus_staffbow_denylist_config";
     private static final String FOCUS_STAFFBOW_ALLOWLIST_CONFIG_BATCH =
             "apprenticecodex.focus_staffbow_allowlist_config";
+    private static final String SPELLGUN_CONFIG_BATCH = "apprenticecodex.spellgun_config";
     private static final String ELEMENTAL_BOW_OVERHEAT_BATCH = "apprenticecodex.elemental_bow_overheat";
     private static final String ELEMENTAL_BOW_DRAW_CONFIG_BATCH =
             "apprenticecodex.elemental_bow_draw_config";
@@ -86,6 +87,21 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     @GameTest(template = TEMPLATE)
     public static void spellcasterGunRecastImbueRestrictionsMatchTier(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.spellcasterGunRecastImbueRestrictionsMatchTier(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellgunServerConfigDefaultsMatchCurrentHardcodedValues(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.spellgunServerConfigDefaultsMatchCurrentHardcodedValues(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = SPELLGUN_CONFIG_BATCH)
+    public static void spellgunZeroImbueCooldownLimitDisablesOnlyCooldownLimit(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.spellgunZeroImbueCooldownLimitDisablesOnlyCooldownLimit(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = SPELLGUN_CONFIG_BATCH)
+    public static void spellgunZeroCastCooldownConfigForcesZeroCooldown(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.spellgunZeroCastCooldownConfigForcesZeroCooldown(helper);
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -47,6 +47,7 @@ import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateT
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArchivistsGrimoireServerConfig;
+import jp.aquafactory.apprenticecodex.config.item.SpellgunServerConfig;
 import jp.aquafactory.apprenticecodex.enchantment.WisdomExperienceDropEvent;
 import jp.aquafactory.apprenticecodex.entity.spelldispenser.SpellDispenserAnchorEntity;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
@@ -4770,6 +4771,81 @@ public final class ApprenticeCodexGameTestScenarios {
                     "Diamond Spellcaster Gun should allow long recast spell imbuing");
             helper.assertFalse(diamond.canImbueSpell(continuousSpell, 1),
                     "Diamond Spellcaster Gun should continue rejecting continuous spells");
+        });
+    }
+    static void spellgunServerConfigDefaultsMatchCurrentHardcodedValues(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            helper.assertTrue(ApprenticeCodexServerConfig.ironSpellgunMaxInstantImbueCooldownTicks() == 20 * 5,
+                    "Iron Spellcaster Gun imbue cooldown limit default changed");
+            helper.assertTrue(ApprenticeCodexServerConfig.ironSpellgunOverriddenSpellCooldownTicks() == 10,
+                    "Iron Spellcaster Gun cast cooldown default changed");
+            helper.assertTrue(ApprenticeCodexServerConfig.copperSpellgunMaxInstantImbueCooldownTicks() == 20 * 10,
+                    "Copper Spellcaster Gun imbue cooldown limit default changed");
+            helper.assertTrue(ApprenticeCodexServerConfig.copperSpellgunOverriddenSpellCooldownTicks() == 20,
+                    "Copper Spellcaster Gun cast cooldown default changed");
+            helper.assertTrue(ApprenticeCodexServerConfig.goldSpellgunMaxInstantImbueCooldownTicks() == 20 * 20,
+                    "Gold Spellcaster Gun imbue cooldown limit default changed");
+            helper.assertTrue(ApprenticeCodexServerConfig.goldSpellgunOverriddenSpellCooldownTicks() == 40,
+                    "Gold Spellcaster Gun cast cooldown default changed");
+            helper.assertTrue(ApprenticeCodexServerConfig.diamondSpellgunMaxInstantImbueCooldownTicks() == 20 * 30,
+                    "Diamond Spellcaster Gun imbue cooldown limit default changed");
+            helper.assertTrue(ApprenticeCodexServerConfig.diamondSpellgunOverriddenSpellCooldownTicks() == 80,
+                    "Diamond Spellcaster Gun cast cooldown default changed");
+
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "spellgun_default_config_test");
+            var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+            assertSpellgunCooldownOverride(helper, player, new ItemStack(ItemRegistry.IRON_SPELLCASTER_GUN.get()), spell, 200, 10,
+                    "Iron Spellcaster Gun should keep its default cast cooldown");
+            assertSpellgunCooldownOverride(helper, player, new ItemStack(ItemRegistry.COPPER_SPELLCASTER_GUN.get()), spell, 200, 20,
+                    "Copper Spellcaster Gun should keep its default cast cooldown");
+            assertSpellgunCooldownOverride(helper, player, new ItemStack(ItemRegistry.GOLD_SPELLCASTER_GUN.get()), spell, 200, 40,
+                    "Gold Spellcaster Gun should keep its default cast cooldown");
+            assertSpellgunCooldownOverride(helper, player, new ItemStack(ItemRegistry.DIAMOND_SPELLCASTER_GUN.get()), spell, 200, 80,
+                    "Diamond Spellcaster Gun should keep its default cast cooldown");
+        });
+    }
+    static void spellgunZeroImbueCooldownLimitDisablesOnlyCooldownLimit(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            try (var ignored = ApprenticeCodexServerConfig.useSpellgunConfigOverrideForGameTest(new SpellgunServerConfig.Values(
+                    0,
+                    10,
+                    20 * 10,
+                    20,
+                    20 * 20,
+                    40,
+                    20 * 30,
+                    80
+            ))) {
+                var iron = (AbstractSpellGunItem) ItemRegistry.IRON_SPELLCASTER_GUN.get();
+                var cooldownLimitedSpell = SpellRegistry.SEARCH_BEACON.get();
+                helper.assertTrue(cooldownLimitedSpell.getSpellCooldown() > 20 * 5,
+                        "Search Beacon should remain above Iron Spellcaster Gun's default cooldown limit");
+                helper.assertTrue(iron.canImbueSpell(cooldownLimitedSpell, 1),
+                        "Iron Spellcaster Gun maxInstantImbueCooldownTicks=0 should disable only the cooldown limit");
+                helper.assertFalse(iron.canImbueSpell(SpellRegistry.HIGANBANA.get(), 1),
+                        "Iron Spellcaster Gun should still reject recast spells when only the cooldown limit is disabled");
+            }
+        });
+    }
+    static void spellgunZeroCastCooldownConfigForcesZeroCooldown(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            try (var ignored = ApprenticeCodexServerConfig.useSpellgunConfigOverrideForGameTest(new SpellgunServerConfig.Values(
+                    20 * 5,
+                    0,
+                    20 * 10,
+                    0,
+                    20 * 20,
+                    0,
+                    20 * 30,
+                    0
+            ))) {
+                var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "spellgun_zero_cooldown_config_test");
+                var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+                assertSpellgunCooldownOverride(helper, player, new ItemStack(ItemRegistry.IRON_SPELLCASTER_GUN.get()), spell, 200, 0,
+                        "Iron Spellcaster Gun overriddenSpellCooldownTicks=0 should force a 0-tick cooldown");
+                assertSpellgunCooldownOverride(helper, player, new ItemStack(ItemRegistry.DIAMOND_SPELLCASTER_GUN.get()), spell, 200, 0,
+                        "Diamond Spellcaster Gun overriddenSpellCooldownTicks=0 should force a 0-tick cooldown");
+            }
         });
     }
     static void spellcasterGunRecastCastBypassesAmmoRequirement(GameTestHelper helper) {
@@ -17897,6 +17973,30 @@ public final class ApprenticeCodexGameTestScenarios {
                 AttributeModifier.Operation.ADD_VALUE,
                 itemName + " attack speed component regression"
         );
+    }
+
+    private static void assertSpellgunCooldownOverride(
+            GameTestHelper helper,
+            ServerPlayer player,
+            ItemStack stack,
+            AbstractSpell spell,
+            int originalCooldownTicks,
+            int expectedCooldownTicks,
+            String message
+    ) {
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Spellgun cooldown test could not resolve player mana data");
+        magicData.setPlayerCastingItem(stack);
+
+        var cooldownEvent = new SpellCooldownAddedEvent.Pre(
+                originalCooldownTicks,
+                spell,
+                player,
+                CastSource.SWORD
+        );
+        SpellGunCastEvent.onSpellCooldownAdded(cooldownEvent);
+        helper.assertTrue(cooldownEvent.getEffectiveCooldown() == expectedCooldownTicks,
+                message + ": expected " + expectedCooldownTicks + " but got " + cooldownEvent.getEffectiveCooldown());
     }
 
     private static void assertModifierAmount(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSpellGunItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSpellGunItem.java
@@ -50,6 +50,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 public abstract class AbstractSpellGunItem extends Item implements IPresetSpellContainer, RestrictedSpellImbuableItem,
@@ -884,9 +885,9 @@ public abstract class AbstractSpellGunItem extends Item implements IPresetSpellC
 
     public record SpellGunConfig(
             Set<SpellGunCastType> supportedCastTypes,
-            @Nullable Integer maxInstantImbueCooldownTicks,
+            @Nullable IntSupplier maxInstantImbueCooldownTicksSupplier,
             boolean requireZeroInstantRecast,
-            @Nullable Integer overriddenSpellCooldownTicks,
+            @Nullable IntSupplier overriddenSpellCooldownTicksSupplier,
             @Nullable Integer overriddenLongCastDurationTicks
     ) {
         public SpellGunConfig {
@@ -895,6 +896,22 @@ public abstract class AbstractSpellGunItem extends Item implements IPresetSpellC
 
         public boolean supports(SpellGunCastType castType) {
             return supportedCastTypes.contains(castType);
+        }
+
+        @Nullable
+        public Integer maxInstantImbueCooldownTicks() {
+            if (maxInstantImbueCooldownTicksSupplier == null) {
+                return null;
+            }
+            var ticks = maxInstantImbueCooldownTicksSupplier.getAsInt();
+            return ticks <= 0 ? null : ticks;
+        }
+
+        @Nullable
+        public Integer overriddenSpellCooldownTicks() {
+            return overriddenSpellCooldownTicksSupplier == null
+                    ? null
+                    : Math.max(0, overriddenSpellCooldownTicksSupplier.getAsInt());
         }
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/CopperSpellcasterGun.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/CopperSpellcasterGun.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.item.spellgun;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.spells.SpellRarity;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
@@ -23,9 +24,9 @@ import java.util.List;
 public class CopperSpellcasterGun extends AbstractSpellGunItem implements GeoItem {
     private static final SpellGunConfig SPELL_GUN_CONFIG = new SpellGunConfig(
             EnumSet.of(SpellGunCastType.LONG),
-            20 * 10,
+            ApprenticeCodexServerConfig::copperSpellgunMaxInstantImbueCooldownTicks,
             false,
-            20,
+            ApprenticeCodexServerConfig::copperSpellgunOverriddenSpellCooldownTicks,
             0
     );
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/DiamondSpellcasterGun.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/DiamondSpellcasterGun.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.item.spellgun;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.spells.SpellRarity;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
@@ -23,9 +24,9 @@ import java.util.List;
 public class DiamondSpellcasterGun extends AbstractSpellGunItem implements GeoItem {
     private static final SpellGunConfig SPELL_GUN_CONFIG = new SpellGunConfig(
             EnumSet.of(SpellGunCastType.INSTANT, SpellGunCastType.LONG),
-            20 * 30,
+            ApprenticeCodexServerConfig::diamondSpellgunMaxInstantImbueCooldownTicks,
             false,
-            80,
+            ApprenticeCodexServerConfig::diamondSpellgunOverriddenSpellCooldownTicks,
             0
     );
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/GoldSpellcasterGun.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/GoldSpellcasterGun.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.item.spellgun;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.spells.SpellRarity;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
@@ -23,9 +24,9 @@ import java.util.List;
 public class GoldSpellcasterGun extends AbstractSpellGunItem implements GeoItem {
     private static final SpellGunConfig SPELL_GUN_CONFIG = new SpellGunConfig(
             EnumSet.of(SpellGunCastType.INSTANT),
-            20 * 20,
+            ApprenticeCodexServerConfig::goldSpellgunMaxInstantImbueCooldownTicks,
             false,
-            40,
+            ApprenticeCodexServerConfig::goldSpellgunOverriddenSpellCooldownTicks,
             null
     );
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/IronSpellcasterGun.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/IronSpellcasterGun.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.item.spellgun;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
@@ -22,9 +23,9 @@ import java.util.EnumSet;
 public class IronSpellcasterGun extends AbstractSpellGunItem implements GeoItem {
     private static final SpellGunConfig SPELL_GUN_CONFIG = new SpellGunConfig(
             EnumSet.of(SpellGunCastType.INSTANT),
-            20 * 5,
+            ApprenticeCodexServerConfig::ironSpellgunMaxInstantImbueCooldownTicks,
             true,
-            10,
+            ApprenticeCodexServerConfig::ironSpellgunOverriddenSpellCooldownTicks,
             null
     );
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);


### PR DESCRIPTION
## 概要
- PR #556「詠唱銃の設定値をサーバー設定化」を `1.21.1-main` へ forward-port しました。
- 取り込み元コミット: 8939fd998f7c5d1e689c230ed802e2a6325a4525
- NeoForge 1.21.1 では config 読み込み前に ItemStack 正規化が走るため、詠唱銃設定値は server config 未ロード時のみ既存ハードコード相当の default 値へ fallback するよう調整しています。

## 確認
- `./gradlew.bat runGameTestServer` 成功（509 tests）
- `./gradlew.bat build` 成功