### PR TITLE
EpicFight環境での特定MODとの相性解決及び調整

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.item.armor.ApprenticeMageRobeItem;
@@ -50,6 +51,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.storage.loot.functions.EnchantRandomlyFunction;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
 
 final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodexGameTestScenarios {
@@ -246,21 +248,24 @@ final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodex
             stack.enchant(EnchantmentRegistry.TENSE.get(), 1);
 
             var modifiers = stack.getAttributeModifiers(EquipmentSlot.MAINHAND);
+            var epicFightLoaded = ModList.get().isLoaded(EpicFightCompat.MOD_ID);
+            var expectedAttackDamageBonus = epicFightLoaded ? 2.0D : 5.0D;
+            var expectedAttackSpeedBonus = epicFightLoaded ? 0.0D : -2.2D;
             assertModifierWithId(
                     helper,
                     modifiers.get(Attributes.ATTACK_DAMAGE),
                     VANILLA_BASE_ATTACK_DAMAGE_MODIFIER_ID,
                     AttributeModifier.Operation.ADDITION,
-                    5.0D,
-                    "Scrollcaster Gauntlet attack damage modifier should keep vanilla weapon tooltip UUID"
+                    expectedAttackDamageBonus,
+                    "Scrollcaster Gauntlet attack damage modifier should match the loaded combat environment"
             );
             assertModifierWithId(
                     helper,
                     modifiers.get(Attributes.ATTACK_SPEED),
                     VANILLA_BASE_ATTACK_SPEED_MODIFIER_ID,
                     AttributeModifier.Operation.ADDITION,
-                    -2.2D,
-                    "Scrollcaster Gauntlet attack speed modifier should keep vanilla weapon tooltip UUID"
+                    expectedAttackSpeedBonus,
+                    "Scrollcaster Gauntlet attack speed modifier should match the loaded combat environment"
             );
             assertSingleModifierAmount(
                     helper,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
@@ -9,6 +9,7 @@ import io.redspace.ironsspellbooks.api.spells.IPresetSpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.util.AnimationHolder;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
 import jp.aquafactory.apprenticecodex.utility.PresetSpellContainerStateHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -262,7 +263,7 @@ public abstract class AbstractSwingMagicItem extends AbstractRightClickMagicWeap
             int spellLevel,
             @Nullable MagicData magicData
     ) {
-        return NoopAutoCloseable.INSTANCE;
+        return SwingcastStaffCastContext.open(player.getUUID(), stack, spell);
     }
 
     protected boolean tryCastSpell(Player player, ItemStack stack, AbstractSpell spell, int spellLevel, @Nullable MagicData magicData) {
@@ -321,11 +322,4 @@ public abstract class AbstractSwingMagicItem extends AbstractRightClickMagicWeap
         lines.add(Component.translatable("item.apprenticecodex.swingcast.common.desc").withStyle(ChatFormatting.GRAY));
     }
 
-    private enum NoopAutoCloseable implements AutoCloseable {
-        INSTANCE;
-
-        @Override
-        public void close() {
-        }
-    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/MithrilFreecastStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/MithrilFreecastStaff.java
@@ -13,6 +13,7 @@ import io.redspace.ironsspellbooks.api.util.AnimationHolder;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaffCastContext;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
 import jp.aquafactory.apprenticecodex.registry.EnchantmentRegistry;
 import jp.aquafactory.apprenticecodex.renderer.item.MithrilFreecastStaffRenderer;
 import net.minecraft.ChatFormatting;
@@ -140,7 +141,8 @@ public class MithrilFreecastStaff extends AbstractRightClickMagicWeaponItem
         }
 
         var spellLevel = spell.getLevelFor(spellData.getLevel(), player);
-        try (var ignored = MithrilFreecastStaffCastContext.open(player.getUUID(), stack, spell)) {
+        try (var swingTriggeredContext = SwingcastStaffCastContext.open(player.getUUID(), stack, spell);
+             var ignored = MithrilFreecastStaffCastContext.open(player.getUUID(), stack, spell)) {
             var casted = spell.attemptInitiateCast(
                     stack,
                     spellLevel,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
@@ -14,6 +14,7 @@ import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.item.Scroll;
 import io.redspace.ironsspellbooks.item.UniqueItem;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.registry.EnchantmentRegistry;
@@ -51,6 +52,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.extensions.common.IClientItemExtensions;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import org.jetbrains.annotations.NotNull;
@@ -104,6 +106,8 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     private static final RawAnimation ANIM_CAST = RawAnimation.begin().thenPlay("cast");
     private static final double ATTACK_DAMAGE_BONUS = 5.0D;
     private static final double ATTACK_SPEED_BONUS = -2.2D;
+    private static final double EPIC_FIGHT_ATTACK_DAMAGE_BONUS = 2.0D;
+    private static final double EPIC_FIGHT_ATTACK_SPEED_BONUS = 0.0D;
     private static final double SPELL_POWER_BONUS = 0.05D;
     private static final double SCHOOL_SPELL_POWER_BONUS = 0.10D;
     private static final UUID SPELL_POWER_MODIFIER_ID = UUID.fromString("be797f84-cdc5-41fd-871f-685cebb23f5c");
@@ -282,12 +286,14 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
     private static Multimap<Attribute, AttributeModifier> buildMainhandModifiers(ItemStack stack) {
         var builder = ImmutableMultimap.<Attribute, AttributeModifier>builder();
+        var attackDamageBonus = getAttackDamageBonus();
+        var attackSpeedBonus = getAttackSpeedBonus();
         builder.put(
                 Attributes.ATTACK_DAMAGE,
                 new AttributeModifier(
                         Item.BASE_ATTACK_DAMAGE_UUID,
                         "Weapon modifier",
-                        ATTACK_DAMAGE_BONUS,
+                        attackDamageBonus,
                         AttributeModifier.Operation.ADDITION
                 )
         );
@@ -296,7 +302,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
                 new AttributeModifier(
                         Item.BASE_ATTACK_SPEED_UUID,
                         "Weapon modifier",
-                        ATTACK_SPEED_BONUS,
+                        attackSpeedBonus,
                         AttributeModifier.Operation.ADDITION
                 )
         );
@@ -323,6 +329,19 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
             );
         }
         return builder.build();
+    }
+
+    private static double getAttackDamageBonus() {
+        return isEpicFightLoaded() ? EPIC_FIGHT_ATTACK_DAMAGE_BONUS : ATTACK_DAMAGE_BONUS;
+    }
+
+    private static double getAttackSpeedBonus() {
+        return isEpicFightLoaded() ? EPIC_FIGHT_ATTACK_SPEED_BONUS : ATTACK_SPEED_BONUS;
+    }
+
+    private static boolean isEpicFightLoaded() {
+        // Epic Fight の fist モーションは攻撃速度 4 前提のため、導入時だけ表示値ごとグローブ相当に寄せる。
+        return ModList.get().isLoaded(EpicFightCompat.MOD_ID);
     }
 
     private static boolean shouldApplyBaseSpellPowerBonus(ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/swingstaff/SwingcastStaffCastContext.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/swingstaff/SwingcastStaffCastContext.java
@@ -24,6 +24,15 @@ public final class SwingcastStaffCastContext implements AutoCloseable {
     }
 
     static boolean matches(UUID playerId, ItemStack stack, AbstractSpell spell) {
+        if (!matches(playerId, spell.getSpellId())) {
+            return false;
+        }
+
+        var current = ACTIVE_CONTEXTS.get().peek();
+        return current != null && current.item() == stack.getItem();
+    }
+
+    public static boolean matches(UUID playerId, String spellId) {
         var contexts = ACTIVE_CONTEXTS.get();
         if (contexts.isEmpty()) {
             return false;
@@ -32,8 +41,7 @@ public final class SwingcastStaffCastContext implements AutoCloseable {
         var current = contexts.peek();
         return current != null
                 && current.playerId().equals(playerId)
-                && current.item() == stack.getItem()
-                && current.spellId().equals(spell.getSpellId());
+                && current.spellId().equals(spellId);
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/ApprenticeCodexMixinPlugin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/ApprenticeCodexMixinPlugin.java
@@ -14,11 +14,13 @@ public final class ApprenticeCodexMixinPlugin implements IMixinConfigPlugin {
     private static final String JEI_MOD_ID = "jei";
     private static final String EPIC_FIGHT_MOD_ID = "epicfight";
     private static final String BETTER_COMBAT_MOD_ID = "bettercombat";
+    private static final String EFIS_COMPAT_MOD_ID = "efiscompat";
     private static final String EASY_MAGIC_MIXIN = "jp.aquafactory.apprenticecodex.mixin.EasyMagicModEnchantmentMenuMixin";
     private static final String ARCANE_ANVIL_JEI_RECIPE_MIXIN =
             "jp.aquafactory.apprenticecodex.mixin.ArcaneAnvilJeiRecipeMixin";
     private static final String EPIC_FIGHT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.EpicFight";
     private static final String BETTER_COMBAT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.BetterCombat";
+    private static final String EFIS_COMPAT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.EfisCompat";
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -50,6 +52,10 @@ public final class ApprenticeCodexMixinPlugin implements IMixinConfigPlugin {
         if (mixinClassName.startsWith(BETTER_COMBAT_MIXIN_PREFIX)) {
             var loadingModList = FMLLoader.getLoadingModList();
             return loadingModList != null && loadingModList.getModFileById(BETTER_COMBAT_MOD_ID) != null;
+        }
+        if (mixinClassName.startsWith(EFIS_COMPAT_MIXIN_PREFIX)) {
+            var loadingModList = FMLLoader.getLoadingModList();
+            return loadingModList != null && loadingModList.getModFileById(EFIS_COMPAT_MOD_ID) != null;
         }
         return true;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/EfisCompatPlayerAnimationEventsMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/EfisCompatPlayerAnimationEventsMixin.java
@@ -1,0 +1,37 @@
+package jp.aquafactory.apprenticecodex.mixin;
+
+import io.redspace.ironsspellbooks.api.events.SpellPreCastEvent;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
+
+@Pseudo
+@Mixin(targets = "com.yukami.efiscompat.player.PlayerAnimationEvents", remap = false)
+public abstract class EfisCompatPlayerAnimationEventsMixin {
+    @Inject(method = "beforeSpellCast", at = @At("HEAD"), cancellable = true, require = 0)
+    private static void apprenticecodex$skipSwingcastActionGate(SpellPreCastEvent event, CallbackInfo callback) {
+        var player = event.getEntity();
+        if (player == null) {
+            return;
+        }
+
+        // Swingcast は Epic Fight の攻撃判定から詠唱を開始するため、efiscompat の攻撃直後キャンセルだけを通過させる。
+        // スタン中の詠唱キャンセルは efiscompat 側の制御を維持する。
+        if (SwingcastStaffCastContext.matches(player.getUUID(), event.getSpellId()) && !apprenticecodex$isStunned(player)) {
+            callback.cancel();
+        }
+    }
+
+    @Unique
+    private static boolean apprenticecodex$isStunned(net.minecraft.world.entity.player.Player player) {
+        return EpicFightCapabilities.getUnparameterizedEntityPatch(player, ServerPlayerPatch.class)
+                .map(ServerPlayerPatch::isStunned)
+                .orElse(false);
+    }
+}

--- a/src/main/resources/mixins.apprenticecodex.json
+++ b/src/main/resources/mixins.apprenticecodex.json
@@ -20,6 +20,7 @@
     "EasyMagicModEnchantmentMenuMixin",
     "EnchantmentMenuMixin",
     "EntitySharedFlagAccessor",
+    "EfisCompatPlayerAnimationEventsMixin",
     "EpicFightLivingEntityPatchMixin",
     "EpicFightPlayerPatchMixin",
     "ItemNameMixin",


### PR DESCRIPTION
- Epic Fight x Iron's Spells: Enhanced Animations導入時、このMODの機能でモーション中の詠唱キャンセルが`Swingcast`系の処理をキャンセルしていたため、それの迂回路を追加
- `ScrollcasterGauntlet`はEpicFight上だとナックル系武器として振る舞うが、攻撃速度4相当が期待される武器種において攻撃速度1.8は遅すぎてプレイフィールが著しく悪かったため、EpicFight環境では攻撃力3攻撃速度4の武器として振る舞うように調整
- `runClient`、`runClientEpicFight`、`runGameTestServer`、`runGameTestServerEpicFight`は確認済み
- 特定MODは1.21.1でも出ているため、このPRは1.21.1-forward-port予定