### PR TITLE
[codex] PR #573 を 1.21.1 へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
@@ -46,6 +46,7 @@ import jp.aquafactory.apprenticecodex.block.spellcasterworkbench.SpellcasterWork
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArchivistsGrimoireServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.SpellgunServerConfig;
@@ -575,21 +576,24 @@ final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodex
             stack.enchant(enchantmentLookup.getOrThrow(Enchantments.TENSE), 1);
 
             var modifiers = toModifierMultimap(stack.getItem().getDefaultAttributeModifiers(stack));
+            var epicFightLoaded = ModList.get().isLoaded(EpicFightCompat.MOD_ID);
+            var expectedAttackDamageBonus = epicFightLoaded ? 2.0D : 5.0D;
+            var expectedAttackSpeedBonus = epicFightLoaded ? 0.0D : -2.2D;
             assertModifierWithId(
                     helper,
                     modifiers.get(Attributes.ATTACK_DAMAGE),
                     VANILLA_BASE_ATTACK_DAMAGE_MODIFIER_ID,
                     AttributeModifier.Operation.ADD_VALUE,
-                    5.0D,
-                    "Scrollcaster Gauntlet attack damage modifier should keep vanilla weapon tooltip UUID"
+                    expectedAttackDamageBonus,
+                    "Scrollcaster Gauntlet attack damage modifier should match the loaded combat environment"
             );
             assertModifierWithId(
                     helper,
                     modifiers.get(Attributes.ATTACK_SPEED),
                     VANILLA_BASE_ATTACK_SPEED_MODIFIER_ID,
                     AttributeModifier.Operation.ADD_VALUE,
-                    -2.2D,
-                    "Scrollcaster Gauntlet attack speed modifier should keep vanilla weapon tooltip UUID"
+                    expectedAttackSpeedBonus,
+                    "Scrollcaster Gauntlet attack speed modifier should match the loaded combat environment"
             );
             assertSingleModifierAmount(
                     helper,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
@@ -9,6 +9,7 @@ import io.redspace.ironsspellbooks.api.spells.IPresetSpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.util.AnimationHolder;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
 import jp.aquafactory.apprenticecodex.utility.PresetSpellContainerStateHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -262,7 +263,7 @@ public abstract class AbstractSwingMagicItem extends AbstractRightClickMagicWeap
             int spellLevel,
             @Nullable MagicData magicData
     ) {
-        return NoopAutoCloseable.INSTANCE;
+        return SwingcastStaffCastContext.open(player.getUUID(), stack, spell);
     }
 
     protected boolean tryCastSpell(Player player, ItemStack stack, AbstractSpell spell, int spellLevel, @Nullable MagicData magicData) {
@@ -321,11 +322,4 @@ public abstract class AbstractSwingMagicItem extends AbstractRightClickMagicWeap
         lines.add(Component.translatable("item.apprenticecodex.swingcast.common.desc").withStyle(ChatFormatting.GRAY));
     }
 
-    private enum NoopAutoCloseable implements AutoCloseable {
-        INSTANCE;
-
-        @Override
-        public void close() {
-        }
-    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/MithrilFreecastStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/MithrilFreecastStaff.java
@@ -12,8 +12,9 @@ import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.util.AnimationHolder;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
-import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaffCastContext;
 import jp.aquafactory.apprenticecodex.enchantment.Enchantments;
+import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaffCastContext;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
@@ -142,7 +143,8 @@ public class MithrilFreecastStaff extends AbstractRightClickMagicWeaponItem
         }
 
         var spellLevel = spell.getLevelFor(spellData.getLevel(), player);
-        try (var ignored = MithrilFreecastStaffCastContext.open(player.getUUID(), stack, spell)) {
+        try (var swingTriggeredContext = SwingcastStaffCastContext.open(player.getUUID(), stack, spell);
+             var ignored = MithrilFreecastStaffCastContext.open(player.getUUID(), stack, spell)) {
             var casted = spell.attemptInitiateCast(
                     stack,
                     spellLevel,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
@@ -14,6 +14,7 @@ import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.item.Scroll;
 import io.redspace.ironsspellbooks.item.UniqueItem;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.compat.malum.MalumCompatibility;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
@@ -56,6 +57,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.item.enchantment.ItemEnchantments;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -98,6 +100,8 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     private static final RawAnimation ANIM_CAST = RawAnimation.begin().thenPlay("cast");
     private static final double ATTACK_DAMAGE_BONUS = 5.0D;
     private static final double ATTACK_SPEED_BONUS = -2.2D;
+    private static final double EPIC_FIGHT_ATTACK_DAMAGE_BONUS = 2.0D;
+    private static final double EPIC_FIGHT_ATTACK_SPEED_BONUS = 0.0D;
     private static final double SPELL_POWER_BONUS = 0.05D;
     private static final double SCHOOL_SPELL_POWER_BONUS = 0.10D;
     private static final ResourceLocation SPELL_POWER_MODIFIER_ID =
@@ -264,11 +268,13 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
     private static Multimap<Holder<Attribute>, AttributeModifier> buildMainhandModifiers(ItemStack stack) {
         var builder = ImmutableMultimap.<Holder<Attribute>, AttributeModifier>builder();
+        var attackDamageBonus = getAttackDamageBonus();
+        var attackSpeedBonus = getAttackSpeedBonus();
         builder.put(
                 Attributes.ATTACK_DAMAGE,
                 new AttributeModifier(
                         Item.BASE_ATTACK_DAMAGE_ID,
-                        ATTACK_DAMAGE_BONUS,
+                        attackDamageBonus,
                         AttributeModifier.Operation.ADD_VALUE
                 )
         );
@@ -276,7 +282,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
                 Attributes.ATTACK_SPEED,
                 new AttributeModifier(
                         Item.BASE_ATTACK_SPEED_ID,
-                        ATTACK_SPEED_BONUS,
+                        attackSpeedBonus,
                         AttributeModifier.Operation.ADD_VALUE
                 )
         );
@@ -301,6 +307,19 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
             );
         }
         return builder.build();
+    }
+
+    private static double getAttackDamageBonus() {
+        return isEpicFightLoaded() ? EPIC_FIGHT_ATTACK_DAMAGE_BONUS : ATTACK_DAMAGE_BONUS;
+    }
+
+    private static double getAttackSpeedBonus() {
+        return isEpicFightLoaded() ? EPIC_FIGHT_ATTACK_SPEED_BONUS : ATTACK_SPEED_BONUS;
+    }
+
+    private static boolean isEpicFightLoaded() {
+        // Epic Fight の fist モーションは攻撃速度 4 前提のため、導入時だけ表示値ごとグローブ相当に寄せる。
+        return ModList.get().isLoaded(EpicFightCompat.MOD_ID);
     }
 
     private static ItemAttributeModifiers buildMergedMainhandAttributeModifiers(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/swingstaff/SwingcastStaffCastContext.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/swingstaff/SwingcastStaffCastContext.java
@@ -24,6 +24,15 @@ public final class SwingcastStaffCastContext implements AutoCloseable {
     }
 
     static boolean matches(UUID playerId, ItemStack stack, AbstractSpell spell) {
+        if (!matches(playerId, spell.getSpellId())) {
+            return false;
+        }
+
+        var current = ACTIVE_CONTEXTS.get().peek();
+        return current != null && current.item() == stack.getItem();
+    }
+
+    public static boolean matches(UUID playerId, String spellId) {
         var contexts = ACTIVE_CONTEXTS.get();
         if (contexts.isEmpty()) {
             return false;
@@ -32,8 +41,7 @@ public final class SwingcastStaffCastContext implements AutoCloseable {
         var current = contexts.peek();
         return current != null
                 && current.playerId().equals(playerId)
-                && current.item() == stack.getItem()
-                && current.spellId().equals(spell.getSpellId());
+                && current.spellId().equals(spellId);
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/ApprenticeCodexMixinPlugin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/ApprenticeCodexMixinPlugin.java
@@ -14,11 +14,13 @@ public final class ApprenticeCodexMixinPlugin implements IMixinConfigPlugin {
     private static final String JEI_MOD_ID = "jei";
     private static final String EPIC_FIGHT_MOD_ID = "epicfight";
     private static final String BETTER_COMBAT_MOD_ID = "bettercombat";
+    private static final String EFIS_COMPAT_MOD_ID = "efiscompat";
     private static final String EASY_MAGIC_MIXIN = "jp.aquafactory.apprenticecodex.mixin.EasyMagicModEnchantmentMenuMixin";
     private static final String ARCANE_ANVIL_JEI_RECIPE_MIXIN =
             "jp.aquafactory.apprenticecodex.mixin.ArcaneAnvilJeiRecipeMixin";
     private static final String EPIC_FIGHT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.EpicFight";
     private static final String BETTER_COMBAT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.BetterCombat";
+    private static final String EFIS_COMPAT_MIXIN_PREFIX = "jp.aquafactory.apprenticecodex.mixin.EfisCompat";
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -52,6 +54,10 @@ public final class ApprenticeCodexMixinPlugin implements IMixinConfigPlugin {
         if (mixinClassName.startsWith(BETTER_COMBAT_MIXIN_PREFIX)) {
             var loadingModList = FMLLoader.getLoadingModList();
             return loadingModList != null && loadingModList.getModFileById(BETTER_COMBAT_MOD_ID) != null;
+        }
+        if (mixinClassName.startsWith(EFIS_COMPAT_MIXIN_PREFIX)) {
+            var loadingModList = FMLLoader.getLoadingModList();
+            return loadingModList != null && loadingModList.getModFileById(EFIS_COMPAT_MOD_ID) != null;
         }
         return true;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/EfisCompatPlayerAnimationEventsMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/EfisCompatPlayerAnimationEventsMixin.java
@@ -1,0 +1,37 @@
+package jp.aquafactory.apprenticecodex.mixin;
+
+import io.redspace.ironsspellbooks.api.events.SpellPreCastEvent;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
+
+@Pseudo
+@Mixin(targets = "com.yukami.efiscompat.player.PlayerAnimationEvents", remap = false)
+public abstract class EfisCompatPlayerAnimationEventsMixin {
+    @Inject(method = "beforeSpellCast", at = @At("HEAD"), cancellable = true, require = 0)
+    private static void apprenticecodex$skipSwingcastActionGate(SpellPreCastEvent event, CallbackInfo callback) {
+        var player = event.getEntity();
+        if (player == null) {
+            return;
+        }
+
+        // Swingcast は Epic Fight の攻撃判定から詠唱を開始するため、efiscompat の攻撃直後キャンセルだけを通過させる。
+        // スタン中の詠唱キャンセルは efiscompat 側の制御を維持する。
+        if (SwingcastStaffCastContext.matches(player.getUUID(), event.getSpellId()) && !apprenticecodex$isStunned(player)) {
+            callback.cancel();
+        }
+    }
+
+    @Unique
+    private static boolean apprenticecodex$isStunned(net.minecraft.world.entity.player.Player player) {
+        return EpicFightCapabilities.getUnparameterizedEntityPatch(player, ServerPlayerPatch.class)
+                .map(ServerPlayerPatch::isStunned)
+                .orElse(false);
+    }
+}

--- a/src/main/resources/mixins.apprenticecodex.json
+++ b/src/main/resources/mixins.apprenticecodex.json
@@ -20,6 +20,7 @@
     "EnchantmentMenuMixin",
     "FluidStackMixin",
     "EntitySharedFlagAccessor",
+    "EfisCompatPlayerAnimationEventsMixin",
     "EpicFightLivingEntityPatchMixin",
     "EpicFightPlayerPatchMixin",
     "ItemNameMixin",


### PR DESCRIPTION
## 概要
- PR #573 の Epic Fight / EFIS Compat 連携対応を `1.21.1-main` へ forward-port
- EFIS Compat 1.21.1 版でも `PlayerAnimationEvents#beforeSpellCast` が攻撃直後の詠唱を cancel しうるため、Swingcast 系だけ攻撃直後キャンセルを通過させる mixin を追加
- Epic Fight 導入時の Scrollcaster Gauntlet を攻撃力 3 / 攻撃速度 4 相当へ調整

## 確認
- `./gradlew.bat compileJava`
- `./gradlew.bat runGameTestServer`（535 tests passed）
- `./gradlew.bat runGameTestServerEpicFight`（535 tests passed）
- `./gradlew.bat build`
- ユーザー側で `runClientEpicFight` 動作確認済み

## 補足
- `runData` 対象の generated/resource 変更はなし
- PR #573 の非 merge コミット 2 件を `git cherry-pick -x` で取り込み