### PR TITLE
[codex] 仮想ブロック使用時のAutoStock誤反応を防ぐ

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -6070,6 +6070,46 @@ public class ApprenticeCodexGameTestScenarios {
         });
     }
 
+    static void blockToolsTemporaryUseKeepsOneCountStackAndHands(GameTestHelper helper) {
+        var placePos = new BlockPos(2, 3, 2);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(1, 4, 1), "block_tools_temporary_use_test");
+        var originalMainHand = new ItemStack(Items.STICK);
+        var inventoryDirt = new ItemStack(Items.DIRT, 32);
+        var virtualDirt = new ItemStack(Items.DIRT);
+
+        helper.setBlock(placePos.below(), Blocks.STONE);
+        player.setItemInHand(InteractionHand.MAIN_HAND, originalMainHand.copy());
+        player.getInventory().setItem(9, inventoryDirt.copy());
+
+        helper.runAtTickTime(1, () -> {
+            var result = BlockTools.useItemOnBlockByPlayerMainHand(
+                    helper.getLevel(),
+                    player,
+                    helper.absolutePos(placePos),
+                    virtualDirt,
+                    Direction.UP
+            );
+
+            helper.assertTrue(result.consumesAction(), "Temporary dirt use should consume action");
+            helper.assertBlockPresent(Blocks.DIRT, placePos);
+            helper.assertTrue(
+                    ItemStack.isSameItemSameTags(player.getMainHandItem(), originalMainHand)
+                            && player.getMainHandItem().getCount() == originalMainHand.getCount(),
+                    "Temporary use should restore original main hand"
+            );
+            helper.assertTrue(
+                    virtualDirt.is(Items.DIRT) && virtualDirt.getCount() == 1,
+                    "Temporary one-count stack should not be consumed"
+            );
+            var storedDirt = player.getInventory().getItem(9);
+            helper.assertTrue(
+                    storedDirt.is(Items.DIRT) && storedDirt.getCount() == inventoryDirt.getCount(),
+                    "Inventory dirt should stay in its original slot"
+            );
+            helper.succeed();
+        });
+    }
+
     static void counterspellCompatMagicMobEffectsAreMagicMobEffects(GameTestHelper helper) {
         helper.succeedIf(() -> {
             assertMagicMobEffect(helper, EffectRegistry.ARCANE_CHARGE.get(), "ArcaneCharge");

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -255,6 +255,11 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
         ApprenticeCodexGameTestScenarios.earthForgeReplacesWaterButKeepsUnsafeFluidBlocks(helper);
     }
 
+    @GameTest(template = TEMPLATE, batch = EARTH_FORGE_ISOLATED_BATCH)
+    public static void blockToolsTemporaryUseKeepsOneCountStackAndHands(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.blockToolsTemporaryUseKeepsOneCountStackAndHands(helper);
+    }
+
     @GameTest(template = TEMPLATE, batch = COMPOUND_PHIAL_ISOLATED_BATCH, timeoutTicks = 40)
     public static void compoundPhialSplashDamageUsesWeakFalloffAndKeepsSelfHit(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.compoundPhialSplashDamageUsesWeakFalloffAndKeepsSelfHit(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/BlockTools.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/BlockTools.java
@@ -91,15 +91,29 @@ public final class BlockTools {
         }
 
         var originalItem = player.getMainHandItem();
+        var effectiveInteractionStack = normalizeInteractionStackForTemporaryUse(interactionStack);
         // まずは通常の useItemOn 経路へ流し、mod 独自の右クリック収穫を優先する。
         var hitResult = new BlockHitResult(Vec3.atCenterOf(pos), hitFace, pos, false);
         try {
             // 右クリック判定だけ現在手持ちのコピーへ差し替え、耐久や個数は本物へ反映しない。
-            player.setItemInHand(InteractionHand.MAIN_HAND, interactionStack);
-            return player.gameMode.useItemOn(player, level, interactionStack, InteractionHand.MAIN_HAND, hitResult);
+            player.setItemInHand(InteractionHand.MAIN_HAND, effectiveInteractionStack);
+            return player.gameMode.useItemOn(player, level, effectiveInteractionStack, InteractionHand.MAIN_HAND, hitResult);
         } finally {
             player.setItemInHand(InteractionHand.MAIN_HAND, originalItem);
         }
+    }
+
+    private static ItemStack normalizeInteractionStackForTemporaryUse(ItemStack interactionStack) {
+        if (interactionStack.isEmpty()) {
+            return interactionStack;
+        }
+
+        var normalizedStack = interactionStack.copy();
+        // 仮想スタックが空になると AutoStock 系 mod が本物の手持ちスロットを補充対象と誤認しうる。
+        if (normalizedStack.getCount() <= 1 && normalizedStack.getMaxStackSize() > 1) {
+            normalizedStack.setCount(2);
+        }
+        return normalizedStack;
     }
 
     public static InteractionResult useBlockByPlayerMainHand(Level level, ServerPlayer player, BlockPos pos,


### PR DESCRIPTION
## 概要
- PR #580 の仮想ブロック使用時の AutoStock 誤反応対策を 1.20.1 側にも取り込みました。
- `BlockTools.useItemOnBlockByPlayerMainHand` で仮想手持ちスタックをコピーしてから使用するように変更しました。
- stackable かつ 1 個以下の仮想スタックは、一時使用用コピーだけ 2 個へ正規化し、設置後に空スタック化しないようにしました。
- 1 個の仮想 Dirt 使用後も元手持ち、仮想スタック、インベントリ Dirt が維持される GameTest を追加しました。

## 背景
ScrollcasterGauntlet で EarthForge を詠唱した際、土ブロック設置用の仮想手持ちスタックが消費されて空になり、Quark などの AutoStock 系機能が本物の手持ちスロットを補充対象と誤認しうる状態になっていました。

## 検証
- `./gradlew.bat build` 成功
- `./gradlew.bat runGameTestServer` 成功、531 required tests passed