### PR TITLE
PR #586 を 1.21.1 へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -333,6 +333,18 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.manaForceBladePerfectGuardTicks();
     }
 
+    public static int manaForceBladeReleaseCooldownTicks() {
+        return ITEMS_CONFIG.manaForceBladeReleaseCooldownTicks();
+    }
+
+    public static int manaForceBladePerfectGuardReleaseCooldownGraceTicks() {
+        return ITEMS_CONFIG.manaForceBladePerfectGuardReleaseCooldownGraceTicks();
+    }
+
+    public static int manaForceBladePerfectGuardReleaseCooldownGraceUses() {
+        return ITEMS_CONFIG.manaForceBladePerfectGuardReleaseCooldownGraceUses();
+    }
+
     public static float manaShieldCharmManaPerDamage() {
         return ITEMS_CONFIG.manaShieldCharmManaPerDamage();
     }
@@ -739,6 +751,29 @@ public final class ApprenticeCodexServerConfig {
                 previousNeutralizationRecoverManaPerDamage,
                 previousShellArmorDurabilityDamage,
                 previousInvulnerableTimeTicks
+        );
+    }
+
+    public static GameTestConfigOverride useManaForceBladeCooldownConfigOverrideForGameTest(
+            int releaseCooldownTicks,
+            int perfectGuardReleaseCooldownGraceTicks,
+            int perfectGuardReleaseCooldownGraceUses
+    ) {
+        var previousReleaseCooldownTicks = ITEMS_CONFIG.manaForceBladeReleaseCooldownTicks();
+        var previousPerfectGuardReleaseCooldownGraceTicks =
+                ITEMS_CONFIG.manaForceBladePerfectGuardReleaseCooldownGraceTicks();
+        var previousPerfectGuardReleaseCooldownGraceUses =
+                ITEMS_CONFIG.manaForceBladePerfectGuardReleaseCooldownGraceUses();
+
+        ITEMS_CONFIG.setManaForceBladeCooldownConfigForGameTest(
+                releaseCooldownTicks,
+                perfectGuardReleaseCooldownGraceTicks,
+                perfectGuardReleaseCooldownGraceUses
+        );
+        return () -> ITEMS_CONFIG.setManaForceBladeCooldownConfigForGameTest(
+                previousReleaseCooldownTicks,
+                previousPerfectGuardReleaseCooldownGraceTicks,
+                previousPerfectGuardReleaseCooldownGraceUses
         );
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -270,6 +270,18 @@ final class ItemsServerConfig {
         return manaForceBladeConfig.perfectGuardTicks();
     }
 
+    int manaForceBladeReleaseCooldownTicks() {
+        return manaForceBladeConfig.releaseCooldownTicks();
+    }
+
+    int manaForceBladePerfectGuardReleaseCooldownGraceTicks() {
+        return manaForceBladeConfig.perfectGuardReleaseCooldownGraceTicks();
+    }
+
+    int manaForceBladePerfectGuardReleaseCooldownGraceUses() {
+        return manaForceBladeConfig.perfectGuardReleaseCooldownGraceUses();
+    }
+
     float manaShieldCharmManaPerDamage() {
         return manaShieldCharmConfig.manaPerDamage();
     }
@@ -735,6 +747,18 @@ final class ItemsServerConfig {
                 castTimeCooldownMultiplier,
                 cooldownCapTicks,
                 maxMulticastCount
+        );
+    }
+
+    void setManaForceBladeCooldownConfigForGameTest(
+            int releaseCooldownTicks,
+            int perfectGuardReleaseCooldownGraceTicks,
+            int perfectGuardReleaseCooldownGraceUses
+    ) {
+        manaForceBladeConfig.setCooldownConfigForGameTest(
+                releaseCooldownTicks,
+                perfectGuardReleaseCooldownGraceTicks,
+                perfectGuardReleaseCooldownGraceUses
         );
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/ManaForceBladeServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/ManaForceBladeServerConfig.java
@@ -10,6 +10,12 @@ public final class ManaForceBladeServerConfig {
     private final ModConfigSpec.DoubleValue rangedGuardManaCost;
     private final ModConfigSpec.BooleanValue disableManaRecoveryWhileGuarding;
     private final ModConfigSpec.IntValue perfectGuardTicks;
+    private final ModConfigSpec.IntValue releaseCooldownTicks;
+    private final ModConfigSpec.IntValue perfectGuardReleaseCooldownGraceTicks;
+    private final ModConfigSpec.IntValue perfectGuardReleaseCooldownGraceUses;
+    private Integer releaseCooldownTicksOverride;
+    private Integer perfectGuardReleaseCooldownGraceTicksOverride;
+    private Integer perfectGuardReleaseCooldownGraceUsesOverride;
 
     private ManaForceBladeServerConfig(
             ModConfigSpec.DoubleValue imbueDamageMultiplierScale,
@@ -18,7 +24,10 @@ public final class ManaForceBladeServerConfig {
             ModConfigSpec.DoubleValue meleeGuardManaCost,
             ModConfigSpec.DoubleValue rangedGuardManaCost,
             ModConfigSpec.BooleanValue disableManaRecoveryWhileGuarding,
-            ModConfigSpec.IntValue perfectGuardTicks
+            ModConfigSpec.IntValue perfectGuardTicks,
+            ModConfigSpec.IntValue releaseCooldownTicks,
+            ModConfigSpec.IntValue perfectGuardReleaseCooldownGraceTicks,
+            ModConfigSpec.IntValue perfectGuardReleaseCooldownGraceUses
     ) {
         this.imbueDamageMultiplierScale = imbueDamageMultiplierScale;
         this.attackManaCostMultiplier = attackManaCostMultiplier;
@@ -27,6 +36,9 @@ public final class ManaForceBladeServerConfig {
         this.rangedGuardManaCost = rangedGuardManaCost;
         this.disableManaRecoveryWhileGuarding = disableManaRecoveryWhileGuarding;
         this.perfectGuardTicks = perfectGuardTicks;
+        this.releaseCooldownTicks = releaseCooldownTicks;
+        this.perfectGuardReleaseCooldownGraceTicks = perfectGuardReleaseCooldownGraceTicks;
+        this.perfectGuardReleaseCooldownGraceUses = perfectGuardReleaseCooldownGraceUses;
     }
 
     public static ManaForceBladeServerConfig define(ModConfigSpec.Builder builder) {
@@ -47,6 +59,15 @@ public final class ManaForceBladeServerConfig {
         var perfectGuardTicks = builder
                 .comment("Ticks treated as perfect guard for vanilla-style Mana Force Blade guard. Not used when Epic Fight is installed because Epic Fight guard skills take priority.")
                 .defineInRange("perfectGuardTicks", 10, 0, 72000);
+        var releaseCooldownTicks = builder
+                .comment("Cooldown ticks applied when releasing vanilla-style Mana Force Blade guard. 0 disables the release cooldown.")
+                .defineInRange("releaseCooldownTicks", 40, 0, 72000);
+        var perfectGuardReleaseCooldownGraceTicks = builder
+                .comment("Ticks after a successful perfect guard during which releasing Mana Force Blade guard skips release cooldown. 0 disables this grace.")
+                .defineInRange("perfectGuardReleaseCooldownGraceTicks", 40, 0, 72000);
+        var perfectGuardReleaseCooldownGraceUses = builder
+                .comment("Number of release cooldown skips granted by a successful perfect guard. 0 disables this grace. Use a large value for effectively unlimited skips.")
+                .defineInRange("perfectGuardReleaseCooldownGraceUses", 1, 0, 1000000);
 
         builder.pop();
         return new ManaForceBladeServerConfig(
@@ -56,7 +77,10 @@ public final class ManaForceBladeServerConfig {
                 meleeGuardManaCost,
                 rangedGuardManaCost,
                 disableManaRecoveryWhileGuarding,
-                perfectGuardTicks
+                perfectGuardTicks,
+                releaseCooldownTicks,
+                perfectGuardReleaseCooldownGraceTicks,
+                perfectGuardReleaseCooldownGraceUses
         );
     }
 
@@ -86,5 +110,31 @@ public final class ManaForceBladeServerConfig {
 
     public int perfectGuardTicks() {
         return perfectGuardTicks.get();
+    }
+
+    public int releaseCooldownTicks() {
+        return releaseCooldownTicksOverride == null ? releaseCooldownTicks.get() : releaseCooldownTicksOverride;
+    }
+
+    public int perfectGuardReleaseCooldownGraceTicks() {
+        return perfectGuardReleaseCooldownGraceTicksOverride == null
+                ? perfectGuardReleaseCooldownGraceTicks.get()
+                : perfectGuardReleaseCooldownGraceTicksOverride;
+    }
+
+    public int perfectGuardReleaseCooldownGraceUses() {
+        return perfectGuardReleaseCooldownGraceUsesOverride == null
+                ? perfectGuardReleaseCooldownGraceUses.get()
+                : perfectGuardReleaseCooldownGraceUsesOverride;
+    }
+
+    public void setCooldownConfigForGameTest(
+            int releaseCooldownTicks,
+            int perfectGuardReleaseCooldownGraceTicks,
+            int perfectGuardReleaseCooldownGraceUses
+    ) {
+        this.releaseCooldownTicksOverride = releaseCooldownTicks;
+        this.perfectGuardReleaseCooldownGraceTicksOverride = perfectGuardReleaseCooldownGraceTicks;
+        this.perfectGuardReleaseCooldownGraceUsesOverride = perfectGuardReleaseCooldownGraceUses;
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/ManaForceBladeConfigSyncEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/ManaForceBladeConfigSyncEvents.java
@@ -67,7 +67,8 @@ public final class ManaForceBladeConfigSyncEvents {
         return new SyncManaForceBladeConfigPacket(
                 ApprenticeCodexServerConfig.manaForceBladeImbueDamageMultiplierScale(),
                 ApprenticeCodexServerConfig.manaForceBladeAttackManaCostMultiplier(),
-                ApprenticeCodexServerConfig.manaForceBladeAttackManaSchoolMultiplierScale()
+                ApprenticeCodexServerConfig.manaForceBladeAttackManaSchoolMultiplierScale(),
+                ApprenticeCodexServerConfig.manaForceBladeReleaseCooldownTicks()
         );
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -400,6 +400,16 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void manaForceBladeReleaseCooldownUsesServerConfig(GameTestHelper helper) {
+        ManaForceBladeGameTestScenarios.manaForceBladeReleaseCooldownUsesServerConfig(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void manaForceBladePerfectGuardReleaseCooldownGraceIsSingleUse(GameTestHelper helper) {
+        ManaForceBladeGameTestScenarios.manaForceBladePerfectGuardReleaseCooldownGraceIsSingleUse(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void betterCombatSpellbreakerIsTwoHandedAndAmplifierHasOffhandSpellPower(GameTestHelper helper) {
         OffhandAndBetterCombatGameTestScenarios.betterCombatSpellbreakerIsTwoHandedAndAmplifierHasOffhandSpellPower(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ManaForceBladeGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ManaForceBladeGameTestScenarios.java
@@ -186,6 +186,8 @@ import jp.aquafactory.apprenticecodex.registry.BlockRegistry;
 import jp.aquafactory.apprenticecodex.registry.CreativeTabRegistry;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
+import jp.aquafactory.apprenticecodex.item.ManaForceBlade;
+import jp.aquafactory.apprenticecodex.item.manaforceblade.ManaForceBladeGuardLogic;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.LootConditionRegistry;
 import jp.aquafactory.apprenticecodex.registry.PoiTypeRegistry;
@@ -502,6 +504,76 @@ final class ManaForceBladeGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Mana Force Blade imbue damage scale 0 should also disable hit mana cost");
         });
     }
+
+    static void manaForceBladeReleaseCooldownUsesServerConfig(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (ManaForceBlade) ItemRegistry.MANA_FORCE_BLADE.get();
+            var stack = new ItemStack(item);
+            item.initializeSpellContainer(stack);
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "mana_force_blade_release_cooldown_config_test");
+            player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+
+            try (var ignored = ApprenticeCodexServerConfig.useManaForceBladeCooldownConfigOverrideForGameTest(
+                    7,
+                    0,
+                    0
+            )) {
+                item.releaseUsing(stack, helper.getLevel(), player, item.getUseDuration(stack, player));
+            }
+
+            helper.assertTrue(player.getCooldowns().isOnCooldown(item),
+                    "Mana Force Blade release should apply server-configured cooldown");
+
+            var disabledCooldownStack = new ItemStack(item);
+            item.initializeSpellContainer(disabledCooldownStack);
+            var disabledCooldownPlayer = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 1),
+                    "mana_force_blade_release_cooldown_disabled_test");
+            disabledCooldownPlayer.setItemInHand(InteractionHand.MAIN_HAND, disabledCooldownStack);
+            try (var ignored = ApprenticeCodexServerConfig.useManaForceBladeCooldownConfigOverrideForGameTest(
+                    0,
+                    0,
+                    0
+            )) {
+                item.releaseUsing(
+                        disabledCooldownStack,
+                        helper.getLevel(),
+                        disabledCooldownPlayer,
+                        item.getUseDuration(disabledCooldownStack, disabledCooldownPlayer)
+                );
+            }
+            helper.assertFalse(disabledCooldownPlayer.getCooldowns().isOnCooldown(item),
+                    "Mana Force Blade release cooldown config 0 should disable release cooldown");
+        });
+    }
+
+    static void manaForceBladePerfectGuardReleaseCooldownGraceIsSingleUse(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (ManaForceBlade) ItemRegistry.MANA_FORCE_BLADE.get();
+            var stack = new ItemStack(item);
+            item.initializeSpellContainer(stack);
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "mana_force_blade_release_cooldown_grace_test");
+            player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+
+            try (var ignored = ApprenticeCodexServerConfig.useManaForceBladeCooldownConfigOverrideForGameTest(
+                    7,
+                    40,
+                    1
+            )) {
+                ManaForceBladeGuardLogic.tryHandleGuard(player, stack, player.damageSources().generic(), true, false);
+
+                item.releaseUsing(stack, helper.getLevel(), player, item.getUseDuration(stack, player));
+                helper.assertFalse(player.getCooldowns().isOnCooldown(item),
+                        "Mana Force Blade perfect guard grace should skip release cooldown once");
+
+                item.releaseUsing(stack, helper.getLevel(), player, item.getUseDuration(stack, player));
+                helper.assertTrue(player.getCooldowns().isOnCooldown(item),
+                        "Mana Force Blade perfect guard grace should not skip release cooldown more than once");
+            }
+        });
+    }
+
     static void manaForceBladeKeepsExpectedEnchantmentSurfaces(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var stack = new ItemStack(ItemRegistry.MANA_FORCE_BLADE.get());

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
@@ -15,8 +15,11 @@ import jp.aquafactory.apprenticecodex.renderer.item.ManaForceBladeRenderer;
 import jp.aquafactory.apprenticecodex.utility.MagicTools;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
@@ -38,6 +41,7 @@ import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.Tiers;
 import net.minecraft.world.item.UseAnim;
+import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -63,7 +67,7 @@ import java.util.function.Consumer;
 
 public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellContainer, SpellSlotUpgradeableItem {
     public static final float DISPLAY_ATTACK_DAMAGE = 6.0F;
-    public static final int COOLDOWN_TICKS = 40;
+    public static final int DEFAULT_RELEASE_COOLDOWN_TICKS = 40;
     private static final String EPICFIGHT_MOD_ID = "epicfight";
     private static final String DESCRIPTION_TRANSLATION_KEY = "item.apprenticecodex.mana_force_blade.desc";
     private static final String EPICFIGHT_DESCRIPTION_TRANSLATION_KEY = DESCRIPTION_TRANSLATION_KEY + ".epicfight";
@@ -74,6 +78,10 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
     private static final double ATTACK_DAMAGE_MODIFIER_AMOUNT = DISPLAY_ATTACK_DAMAGE - 1.0D;
     private static final double ATTACK_SPEED_MODIFIER_AMOUNT = -2.0D;
     private static final String ATTACK_MANA_SPENT_TICK_TAG = "apprenticecodex:mana_force_blade_attack_mana_spent_tick";
+    private static final String PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_TICK_TAG =
+            "apprenticecodex:mana_force_blade_perfect_guard_release_cooldown_grace_tick";
+    private static final String PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_USES_TAG =
+            "apprenticecodex:mana_force_blade_perfect_guard_release_cooldown_grace_uses";
     private static final RawAnimation ANIM_IDLE = RawAnimation.begin().thenLoop("idle");
     private static final ItemStack SWORD_ENCHANTMENT_PROBE_STACK = new ItemStack(net.minecraft.world.item.Items.DIAMOND_SWORD);
     private static final Set<String> EXTRA_ENCHANTMENTS = Set.of(
@@ -143,7 +151,14 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
     @Override
     public void releaseUsing(@NotNull ItemStack stack, @NotNull Level level, @NotNull LivingEntity livingEntity, int timeLeft) {
         if (!level.isClientSide && livingEntity instanceof Player player) {
-            player.getCooldowns().addCooldown(this, COOLDOWN_TICKS);
+            if (consumePerfectGuardReleaseCooldownGrace(stack, level)) {
+                return;
+            }
+
+            var cooldownTicks = ApprenticeCodexServerConfig.manaForceBladeReleaseCooldownTicks();
+            if (cooldownTicks > 0) {
+                player.getCooldowns().addCooldown(this, cooldownTicks);
+            }
         }
     }
 
@@ -391,6 +406,66 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
         if (player instanceof ServerPlayer serverPlayer) {
             PacketDistributor.sendToPlayer(serverPlayer, new SyncManaPacket(magicData));
         }
+    }
+
+    public static void rememberPerfectGuardReleaseCooldownGrace(ItemStack stack, long gameTime) {
+        var graceTicks = ApprenticeCodexServerConfig.manaForceBladePerfectGuardReleaseCooldownGraceTicks();
+        var graceUses = ApprenticeCodexServerConfig.manaForceBladePerfectGuardReleaseCooldownGraceUses();
+        if (stack.isEmpty() || graceTicks <= 0 || graceUses <= 0) {
+            return;
+        }
+
+        CustomData.update(DataComponents.CUSTOM_DATA, stack, tag -> {
+            tag.putLong(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_TICK_TAG, gameTime);
+            tag.putInt(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_USES_TAG, graceUses);
+        });
+    }
+
+    private static boolean consumePerfectGuardReleaseCooldownGrace(ItemStack stack, Level level) {
+        var graceTicks = ApprenticeCodexServerConfig.manaForceBladePerfectGuardReleaseCooldownGraceTicks();
+        var configuredGraceUses = ApprenticeCodexServerConfig.manaForceBladePerfectGuardReleaseCooldownGraceUses();
+        if (stack.isEmpty() || graceTicks <= 0 || configuredGraceUses <= 0) {
+            return false;
+        }
+
+        var customData = stack.get(DataComponents.CUSTOM_DATA);
+        if (customData == null) {
+            return false;
+        }
+
+        var tag = customData.copyTag();
+        if (tag == null
+                || !tag.contains(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_TICK_TAG, Tag.TAG_LONG)
+                || !tag.contains(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_USES_TAG, Tag.TAG_INT)) {
+            return false;
+        }
+
+        var remainingUses = tag.getInt(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_USES_TAG);
+        var elapsedTicks = level.getGameTime() - tag.getLong(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_TICK_TAG);
+        if (remainingUses <= 0 || elapsedTicks < 0 || elapsedTicks > graceTicks) {
+            clearPerfectGuardReleaseCooldownGrace(stack);
+            return false;
+        }
+
+        remainingUses -= 1;
+        var updatedRemainingUses = remainingUses;
+        CustomData.update(DataComponents.CUSTOM_DATA, stack, updatedTag -> {
+            if (updatedRemainingUses <= 0) {
+                clearPerfectGuardReleaseCooldownGrace(updatedTag);
+            } else {
+                updatedTag.putInt(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_USES_TAG, updatedRemainingUses);
+            }
+        });
+        return true;
+    }
+
+    private static void clearPerfectGuardReleaseCooldownGrace(ItemStack stack) {
+        CustomData.update(DataComponents.CUSTOM_DATA, stack, ManaForceBlade::clearPerfectGuardReleaseCooldownGrace);
+    }
+
+    private static void clearPerfectGuardReleaseCooldownGrace(CompoundTag tag) {
+        tag.remove(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_TICK_TAG);
+        tag.remove(PERFECT_GUARD_RELEASE_COOLDOWN_GRACE_USES_TAG);
     }
 
     private static void trySpendAttackManaOncePerTick(Player player, ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeConfigState.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeConfigState.java
@@ -4,10 +4,12 @@ public final class ManaForceBladeConfigState {
     public static final float DEFAULT_IMBUE_DAMAGE_MULTIPLIER_SCALE = 1.0F;
     public static final float DEFAULT_ATTACK_MANA_COST_MULTIPLIER = 3.0F;
     public static final float DEFAULT_ATTACK_MANA_SCHOOL_MULTIPLIER_SCALE = 1.0F;
+    public static final int DEFAULT_RELEASE_COOLDOWN_TICKS = 40;
 
     private static float imbueDamageMultiplierScale = DEFAULT_IMBUE_DAMAGE_MULTIPLIER_SCALE;
     private static float attackManaCostMultiplier = DEFAULT_ATTACK_MANA_COST_MULTIPLIER;
     private static float attackManaSchoolMultiplierScale = DEFAULT_ATTACK_MANA_SCHOOL_MULTIPLIER_SCALE;
+    private static int releaseCooldownTicks = DEFAULT_RELEASE_COOLDOWN_TICKS;
 
     private ManaForceBladeConfigState() {
     }
@@ -24,21 +26,28 @@ public final class ManaForceBladeConfigState {
         return attackManaSchoolMultiplierScale;
     }
 
+    public static int releaseCooldownTicks() {
+        return releaseCooldownTicks;
+    }
+
     public static void set(
             float imbueDamageMultiplierScale,
             float attackManaCostMultiplier,
-            float attackManaSchoolMultiplierScale
+            float attackManaSchoolMultiplierScale,
+            int releaseCooldownTicks
     ) {
         ManaForceBladeConfigState.imbueDamageMultiplierScale = imbueDamageMultiplierScale;
         ManaForceBladeConfigState.attackManaCostMultiplier = attackManaCostMultiplier;
         ManaForceBladeConfigState.attackManaSchoolMultiplierScale = attackManaSchoolMultiplierScale;
+        ManaForceBladeConfigState.releaseCooldownTicks = releaseCooldownTicks;
     }
 
     public static void reset() {
         set(
                 DEFAULT_IMBUE_DAMAGE_MULTIPLIER_SCALE,
                 DEFAULT_ATTACK_MANA_COST_MULTIPLIER,
-                DEFAULT_ATTACK_MANA_SCHOOL_MULTIPLIER_SCALE
+                DEFAULT_ATTACK_MANA_SCHOOL_MULTIPLIER_SCALE,
+                DEFAULT_RELEASE_COOLDOWN_TICKS
         );
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeGuardLogic.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/manaforceblade/ManaForceBladeGuardLogic.java
@@ -83,11 +83,13 @@ public final class ManaForceBladeGuardLogic {
             boolean perfectGuard,
             boolean playGuardEffects
     ) {
-        if (isRangedAttack(source, player)) {
-            return handleRangedGuard(player, stack, source, perfectGuard, playGuardEffects);
+        var guarded = isRangedAttack(source, player)
+                ? handleRangedGuard(player, stack, source, perfectGuard, playGuardEffects)
+                : handleMeleeGuard(player, stack, source, perfectGuard, playGuardEffects);
+        if (guarded && perfectGuard) {
+            ManaForceBlade.rememberPerfectGuardReleaseCooldownGrace(stack, player.level().getGameTime());
         }
-
-        return handleMeleeGuard(player, stack, source, perfectGuard, playGuardEffects);
+        return guarded;
     }
 
     private static boolean isRangedAttack(DamageSource source, ServerPlayer player) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -47,7 +47,7 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "36";
+    private static final String PROTOCOL_VERSION = "37";
 
     private Networks() {
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncManaForceBladeConfigPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncManaForceBladeConfigPacket.java
@@ -21,15 +21,18 @@ public final class SyncManaForceBladeConfigPacket implements CustomPacketPayload
     private final float imbueDamageMultiplierScale;
     private final float attackManaCostMultiplier;
     private final float attackManaSchoolMultiplierScale;
+    private final int releaseCooldownTicks;
 
     public SyncManaForceBladeConfigPacket(
             float imbueDamageMultiplierScale,
             float attackManaCostMultiplier,
-            float attackManaSchoolMultiplierScale
+            float attackManaSchoolMultiplierScale,
+            int releaseCooldownTicks
     ) {
         this.imbueDamageMultiplierScale = imbueDamageMultiplierScale;
         this.attackManaCostMultiplier = attackManaCostMultiplier;
         this.attackManaSchoolMultiplierScale = attackManaSchoolMultiplierScale;
+        this.releaseCooldownTicks = releaseCooldownTicks;
     }
 
     @Override
@@ -41,13 +44,15 @@ public final class SyncManaForceBladeConfigPacket implements CustomPacketPayload
         buffer.writeFloat(packet.imbueDamageMultiplierScale);
         buffer.writeFloat(packet.attackManaCostMultiplier);
         buffer.writeFloat(packet.attackManaSchoolMultiplierScale);
+        buffer.writeInt(packet.releaseCooldownTicks);
     }
 
     private static SyncManaForceBladeConfigPacket decode(FriendlyByteBuf buffer) {
         return new SyncManaForceBladeConfigPacket(
                 buffer.readFloat(),
                 buffer.readFloat(),
-                buffer.readFloat()
+                buffer.readFloat(),
+                buffer.readInt()
         );
     }
 
@@ -68,7 +73,8 @@ public final class SyncManaForceBladeConfigPacket implements CustomPacketPayload
             ManaForceBladeConfigState.set(
                     packet.imbueDamageMultiplierScale,
                     packet.attackManaCostMultiplier,
-                    packet.attackManaSchoolMultiplierScale
+                    packet.attackManaSchoolMultiplierScale,
+                    packet.releaseCooldownTicks
             );
         }
     }


### PR DESCRIPTION
## 概要
- PR #586 の変更を `1.21.1-main` へ forward-port
- 魔力の刀のガード解除クールダウン設定と、ジャストガード直後のクールダウン猶予設定を追加
- 1.21.1 側の `ModConfigSpec`、payload codec、item custom data component に合わせて調整

## 確認
- `./gradlew.bat runGameTestServer` 成功（550 tests passed）
- `./gradlew.bat build` 成功
- `runClient` はローカルで確認済み