### PR TITLE
PR #592 を 1.21.1 へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/create/CreateExposedItemProcessingBridge.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/create/CreateExposedItemProcessingBridge.java
@@ -7,6 +7,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.neoforged.fml.ModList;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 public final class CreateExposedItemProcessingBridge {
     private static boolean hasLoggedInitializationFailure;
@@ -19,7 +20,8 @@ public final class CreateExposedItemProcessingBridge {
             Iterable<BlockPos> positions,
             int maxProcessCount,
             Set<Object> skipTransportedItems,
-            ItemStackProcessor processor
+            ItemStackProcessor processor,
+            Consumer<BlockPos> processedBlockCallback
     ) {
         if (maxProcessCount <= 0 || !ModList.get().isLoaded(CreateCompat.MOD_ID)) {
             return 0;
@@ -31,7 +33,8 @@ public final class CreateExposedItemProcessingBridge {
                     positions,
                     maxProcessCount,
                     skipTransportedItems,
-                    processor
+                    processor,
+                    processedBlockCallback
             );
         } catch (LinkageError error) {
             logInitializationFailureOnce(error);

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/create/CreateExposedItemProcessingBridgeImpl.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/create/CreateExposedItemProcessingBridgeImpl.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 final class CreateExposedItemProcessingBridgeImpl {
     private CreateExposedItemProcessingBridgeImpl() {
@@ -32,7 +33,8 @@ final class CreateExposedItemProcessingBridgeImpl {
             Iterable<BlockPos> positions,
             int maxProcessCount,
             Set<Object> skipTransportedItems,
-            ItemStackProcessor processor
+            ItemStackProcessor processor,
+            Consumer<BlockPos> processedBlockCallback
     ) {
         if (maxProcessCount <= 0) {
             return 0;
@@ -44,13 +46,17 @@ final class CreateExposedItemProcessingBridgeImpl {
                 break;
             }
 
-            processedCount += processBlock(
+            var blockProcessedCount = processBlock(
                     level,
                     pos,
                     maxProcessCount - processedCount,
                     skipTransportedItems,
                     processor
             );
+            if (blockProcessedCount > 0) {
+                processedBlockCallback.accept(pos);
+            }
+            processedCount += blockProcessedCount;
         }
         return processedCount;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/grindrunner/GrindRunnerWheelEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/grindrunner/GrindRunnerWheelEntity.java
@@ -605,7 +605,8 @@ public class GrindRunnerWheelEntity extends SummonWeaponEntity implements GeoEnt
                     sampleNearbyCreateProcessTargets(),
                     maxProcessCount - processedCount,
                     skipProcessingTransportedItems,
-                    (inputStack, remainingBudget) -> tryBuildProcessingResult(level, inputStack, remainingBudget)
+                    (inputStack, remainingBudget) -> tryBuildProcessingResult(level, inputStack, remainingBudget),
+                    processedPos -> playCreateItemProcessedSound(level, processedPos)
             );
         }
 
@@ -996,6 +997,10 @@ public class GrindRunnerWheelEntity extends SummonWeaponEntity implements GeoEnt
                 0.1,
                 0.01
         );
+    }
+
+    private void playCreateItemProcessedSound(ServerLevel level, BlockPos sourcePos) {
+        AudioTools.playSoundFromPosition(level, sourcePos.getCenter(), SoundRegistry.WHEEL_PROCESS.get(), SoundSource.NEUTRAL, 0.6f, 1.0f, 0.15f);
     }
 
     private void performLaunchDamage(LivingEntity owner, double horizontalSpeed) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/heavenlyfist/HeavenlyFistPressingProcessor.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/heavenlyfist/HeavenlyFistPressingProcessor.java
@@ -87,7 +87,9 @@ final class HeavenlyFistPressingProcessor {
                     processTargets,
                     maxProcessOperations - processed,
                     skipTransportedItems,
-                    (inputStack, remainingBudget) -> tryBuildPressingResult(level, inputStack, remainingBudget)
+                    (inputStack, remainingBudget) -> tryBuildPressingResult(level, inputStack, remainingBudget),
+                    processedPos -> {
+                    }
             );
         }
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/thermalprocess/ThermalProcessThrowerEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/thermalprocess/ThermalProcessThrowerEntity.java
@@ -8,6 +8,7 @@ import jp.aquafactory.apprenticecodex.entity.SummonWeaponEntity;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import jp.aquafactory.apprenticecodex.utility.*;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
@@ -283,7 +284,8 @@ public class ThermalProcessThrowerEntity extends SummonWeaponEntity {
                     List.of(blockHit.getBlockPos()),
                     maxProcessCount - processedCount,
                     skipProcessingTransportedItems,
-                    (inputStack, remainingBudget) -> tryBuildProcessingResult(level, inputStack, remainingBudget)
+                    (inputStack, remainingBudget) -> tryBuildProcessingResult(level, inputStack, remainingBudget),
+                    processedPos -> playCreateItemProcessedSound(level, processedPos)
             );
         }
 
@@ -452,6 +454,10 @@ public class ThermalProcessThrowerEntity extends SummonWeaponEntity {
                 0.1,
                 0.01
         );
+    }
+
+    private void playCreateItemProcessedSound(ServerLevel level, BlockPos sourcePos) {
+        AudioTools.playSoundFromPosition(level, sourcePos.getCenter(), SoundEvents.ITEM_PICKUP, SoundSource.NEUTRAL);
     }
 
     private void applyOrUpdateThermalProcessing(LivingEntity target) {


### PR DESCRIPTION
## 概要
- #592 の変更を `1.21.1-main` へ forward-port しました。
- Create ブロック内で加工処理が行われた際、グラインドランナーとサーマルプロセスの加工音が再生されるようにします。
- HeavenlyFist は元 PR と同様、加工音がないため空 callback のみで対応しています。

## 確認
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat runGameTestServerCompat`
- `./gradlew.bat build`
- `./gradlew.bat runClientCompat`（ユーザー確認済み）

## 備考
- `src/generated/resources` に差分はありません。
- PR 作成前のローカル作業ツリーはクリーンです。