### PR TITLE
Iron's 3.16.1アップデート合わせのアイテムの耐性付与

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -79,6 +79,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void fireResistantEquipmentContractsStayInSync(GameTestHelper helper) {
+        EquipmentFireResistanceGameTestScenarios.fireResistantEquipmentContractsStayInSync(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void copperSwingcastStaffStartsWithBallLightningLevelOne(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.copperSwingcastStaffStartsWithBallLightningLevelOne(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentFireResistanceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentFireResistanceGameTestScenarios.java
@@ -1,0 +1,121 @@
+package jp.aquafactory.apprenticecodex.gametest;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.swingstaff.AbstractSwingcastStaffItem;
+import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+final class EquipmentFireResistanceGameTestScenarios extends ApprenticeCodexGameTestScenarios {
+    private static final TagKey<Item> CURIOS_SPELLBOOK = TagKey.create(
+            Registries.ITEM,
+            ResourceLocation.fromNamespaceAndPath("curios", "spellbook")
+    );
+
+    private EquipmentFireResistanceGameTestScenarios() {
+    }
+
+    static void fireResistantEquipmentContractsStayInSync(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    stack -> stack.is(IRONS_STAFF),
+                    "irons_spellbooks:staff tagged item"
+            );
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    stack -> stack.is(CURIOS_SPELLBOOK),
+                    "curios:spellbook tagged item"
+            );
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    stack -> stack.getItem() instanceof AbstractSwingcastStaffItem,
+                    "AbstractSwingcastStaffItem"
+            );
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    EquipmentFireResistanceGameTestScenarios::isNonStackRegisteredStaffPathItem,
+                    "non-stack registered item with staff in path"
+            );
+
+            for (var itemEntry : explicitFireResistantItems()) {
+                assertFireResistant(helper, itemEntry.get(), "explicit fire-resistant equipment");
+            }
+
+            assertNotFireResistant(
+                    helper,
+                    ItemRegistry.SCARLET_THIRST.get(),
+                    "Scarlet Thirst should stay excluded as a normal Mithril Curio"
+            );
+        });
+    }
+
+    private static List<RegistryObject<Item>> explicitFireResistantItems() {
+        return List.of(
+                ItemRegistry.SMASHCAST_SCEPTER,
+                ItemRegistry.SCROLLCASTER_GAUNTLET,
+                ItemRegistry.MANA_FORCE_BLADE,
+                ItemRegistry.ELEMENTAL_BOW,
+                ItemRegistry.DIAMOND_SPELLCASTER_GUN,
+                ItemRegistry.NETHERITE_SPELL_AMPLIFIER,
+                ItemRegistry.PHOTON_SIPHON,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_HAT,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_COAT,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_LEGGINGS,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_BOOTS,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_RIBBON,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_ROBE,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_LEGGINGS,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_BOOTS
+        );
+    }
+
+    private static void assertRegisteredItemsMatchingAreFireResistant(
+            GameTestHelper helper,
+            Predicate<ItemStack> predicate,
+            String categoryName
+    ) {
+        var stacks = ItemRegistry.ITEMS.getEntries().stream()
+                .map(RegistryObject::get)
+                .map(ItemStack::new)
+                .filter(predicate)
+                .toList();
+
+        helper.assertFalse(stacks.isEmpty(), "No items matched fire resistance category: " + categoryName);
+
+        for (var stack : stacks) {
+            assertFireResistant(helper, stack.getItem(), categoryName);
+        }
+    }
+
+    private static boolean isNonStackRegisteredStaffPathItem(ItemStack stack) {
+        var itemId = ForgeRegistries.ITEMS.getKey(stack.getItem());
+        return itemId != null
+                && ApprenticeCodex.MODID.equals(itemId.getNamespace())
+                && itemId.getPath().contains("staff")
+                && stack.getMaxStackSize() == 1;
+    }
+
+    private static void assertFireResistant(GameTestHelper helper, Item item, String categoryName) {
+        helper.assertTrue(
+                item.isFireResistant(),
+                categoryName + " should be fire resistant: " + ForgeRegistries.ITEMS.getKey(item)
+        );
+    }
+
+    private static void assertNotFireResistant(GameTestHelper helper, Item item, String message) {
+        helper.assertFalse(
+                item.isFireResistant(),
+                message + ": " + ForgeRegistries.ITEMS.getKey(item)
+        );
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
@@ -44,7 +44,18 @@ public abstract class AbstractOffhandMagicItem extends Item
             String itemKey,
             List<AttributeBonus> attributeBonuses
     ) {
-        super(createProperties(rarity));
+        this(configuredSpell, configuredSpellLevel, rarity, itemKey, attributeBonuses, false);
+    }
+
+    protected AbstractOffhandMagicItem(
+            Supplier<? extends AbstractSpell> configuredSpell,
+            int configuredSpellLevel,
+            Rarity rarity,
+            String itemKey,
+            List<AttributeBonus> attributeBonuses,
+            boolean fireResistant
+    ) {
+        super(createProperties(rarity, fireResistant));
         this.configuredSpell = Objects.requireNonNull(configuredSpell);
         this.configuredSpellLevel = configuredSpellLevel;
         this.startsWithPresetSpell = true;
@@ -75,6 +86,17 @@ public abstract class AbstractOffhandMagicItem extends Item
     protected AbstractOffhandMagicItem(
             Supplier<? extends AbstractSpell> configuredSpell,
             int configuredSpellLevel,
+            Rarity rarity,
+            String itemKey,
+            boolean fireResistant,
+            AttributeBonus... attributeBonuses
+    ) {
+        this(configuredSpell, configuredSpellLevel, rarity, itemKey, List.of(attributeBonuses), fireResistant);
+    }
+
+    protected AbstractOffhandMagicItem(
+            Supplier<? extends AbstractSpell> configuredSpell,
+            int configuredSpellLevel,
             String itemKey,
             AttributeBonus... attributeBonuses
     ) {
@@ -87,7 +109,16 @@ public abstract class AbstractOffhandMagicItem extends Item
             String itemKey,
             List<AttributeBonus> attributeBonuses
     ) {
-        super(createProperties(rarity));
+        this(rarity, itemKey, attributeBonuses, false);
+    }
+
+    protected AbstractOffhandMagicItem(
+            Rarity rarity,
+            String itemKey,
+            List<AttributeBonus> attributeBonuses,
+            boolean fireResistant
+    ) {
+        super(createProperties(rarity, fireResistant));
         this.configuredSpell = null;
         this.configuredSpellLevel = 0;
         this.startsWithPresetSpell = false;
@@ -109,6 +140,15 @@ public abstract class AbstractOffhandMagicItem extends Item
             AttributeBonus... attributeBonuses
     ) {
         this(rarity, itemKey, List.of(attributeBonuses));
+    }
+
+    protected AbstractOffhandMagicItem(
+            Rarity rarity,
+            String itemKey,
+            boolean fireResistant,
+            AttributeBonus... attributeBonuses
+    ) {
+        this(rarity, itemKey, List.of(attributeBonuses), fireResistant);
     }
 
     protected AbstractOffhandMagicItem(
@@ -248,7 +288,12 @@ public abstract class AbstractOffhandMagicItem extends Item
     }
 
     private static Item.Properties createProperties(Rarity rarity) {
-        return new Item.Properties().stacksTo(1).rarity(Objects.requireNonNull(rarity));
+        return createProperties(rarity, false);
+    }
+
+    private static Item.Properties createProperties(Rarity rarity, boolean fireResistant) {
+        var properties = new Item.Properties().stacksTo(1).rarity(Objects.requireNonNull(rarity));
+        return fireResistant ? properties.fireResistant() : properties;
     }
 
     // `bonus` ヘルパーは属性参照の受け取り方ごとにオーバーロードしている.

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractRightClickMagicWeaponItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractRightClickMagicWeaponItem.java
@@ -88,7 +88,7 @@ public abstract class AbstractRightClickMagicWeaponItem extends Item implements 
             double attackSpeed,
             List<AttributeBonus> handBonuses
     ) {
-        super(properties);
+        super(properties.fireResistant());
         this.configuredSpell = Objects.requireNonNull(configuredSpell);
         this.configuredSpellLevel = configuredSpellLevel;
         this.startsWithPresetSpell = true;
@@ -110,7 +110,7 @@ public abstract class AbstractRightClickMagicWeaponItem extends Item implements 
             double attackSpeed,
             List<AttributeBonus> handBonuses
     ) {
-        super(properties);
+        super(properties.fireResistant());
         this.configuredSpell = null;
         this.configuredSpellLevel = 0;
         this.startsWithPresetSpell = false;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ChargedTwinBladeStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ChargedTwinBladeStaff.java
@@ -93,7 +93,7 @@ public final class ChargedTwinBladeStaff extends Item implements GeoItem, NonDam
     private final Multimap<Attribute, AttributeModifier> mainhandModifiers = buildMainhandModifiers();
 
     public ChargedTwinBladeStaff() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
@@ -94,7 +94,7 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public CircuitHeatStaff() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE), CIRCUIT_HEAT_STAFF_TIER);
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE).fireResistant(), CIRCUIT_HEAT_STAFF_TIER);
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ElementalBow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ElementalBow.java
@@ -93,7 +93,7 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public ElementalBow() {
-        super(new Properties().durability(1561));
+        super(new Properties().durability(1561).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/FocusStaffbow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/FocusStaffbow.java
@@ -101,7 +101,7 @@ public final class FocusStaffbow extends CastingItem
     private final Multimap<Attribute, AttributeModifier> mainhandModifiers = buildMainhandModifiers();
 
     public FocusStaffbow() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
@@ -90,7 +90,7 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
 
     public ManaForceBlade() {
         super(Tiers.DIAMOND, 0, (float) ATTACK_SPEED_MODIFIER_AMOUNT,
-                new Item.Properties().stacksTo(1).durability(DURABILITY).rarity(Rarity.RARE));
+                new Item.Properties().stacksTo(1).durability(DURABILITY).rarity(Rarity.RARE).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/MulticastEchoStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/MulticastEchoStaff.java
@@ -50,7 +50,7 @@ public class MulticastEchoStaff extends StaffItem implements GeoItem, IPresetSpe
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public MulticastEchoStaff() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.EPIC), MULTICAST_ECHO_STAFF_TIER);
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.EPIC).fireResistant(), MULTICAST_ECHO_STAFF_TIER);
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/MultipurposeStaffrifle.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/MultipurposeStaffrifle.java
@@ -114,7 +114,7 @@ public final class MultipurposeStaffrifle extends Item
     private final Multimap<Attribute, AttributeModifier> baseMainhandModifiers = buildBaseMainhandModifiers();
 
     public MultipurposeStaffrifle() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
@@ -59,7 +59,7 @@ public class PastelStaff extends StaffItem implements GeoItem, IPresetSpellConta
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public PastelStaff() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.EPIC), PASTEL_STAFF_TIER);
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.EPIC).fireResistant(), PASTEL_STAFF_TIER);
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
@@ -123,7 +123,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public ScrollcasterGauntlet() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ZenithStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ZenithStaff.java
@@ -51,7 +51,7 @@ public class ZenithStaff extends StaffItem implements GeoItem, UniqueItem {
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public ZenithStaff() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.EPIC), ZENITH_STAFF_TIER);
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.EPIC).fireResistant(), ZENITH_STAFF_TIER);
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
@@ -48,7 +48,7 @@ public class ChromaticMagiaDressItem extends ArmorItem implements GeoItem, IPres
     private final Multimap<Attribute, AttributeModifier> armorAttributeModifiers;
 
     public ChromaticMagiaDressItem(Type type) {
-        super(ChromaticMagiaDressStats.MATERIAL, type, new Properties());
+        super(ChromaticMagiaDressStats.MATERIAL, type, new Properties().fireResistant());
         this.armorType = type;
         this.armorAttributeModifiers = ChromaticMagiaDressStats.createAttributeModifiers(type);
         GeoItem.registerSyncedAnimatable(this);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ElementMaidenRobeItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ElementMaidenRobeItem.java
@@ -64,7 +64,7 @@ public class ElementMaidenRobeItem extends ArmorItem implements GeoItem, IPreset
     private final Multimap<Attribute, AttributeModifier> armorAttributeModifiers;
 
     public ElementMaidenRobeItem(Type type) {
-        super(ElementMaidenRobeStats.MATERIAL, type, new Properties().rarity(Rarity.EPIC));
+        super(ElementMaidenRobeStats.MATERIAL, type, new Properties().rarity(Rarity.EPIC).fireResistant());
         this.armorType = type;
         this.armorAttributeModifiers = ElementMaidenRobeStats.createAttributeModifiers(type);
         GeoItem.registerSyncedAnimatable(this);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/archivistsgrimoire/ArchivistsGrimoire.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/archivistsgrimoire/ArchivistsGrimoire.java
@@ -60,7 +60,7 @@ public class ArchivistsGrimoire extends Item implements ICurioItem, ISpellbook, 
     };
 
     public ArchivistsGrimoire() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON).fireResistant());
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/endergrimoire/EnderGrimoire.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/endergrimoire/EnderGrimoire.java
@@ -51,7 +51,7 @@ public class EnderGrimoire extends Item implements ICurioItem, ISpellbook, IPres
     };
 
     public EnderGrimoire() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON).fireResistant());
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/explorerscodex/ExplorersCodex.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/explorerscodex/ExplorersCodex.java
@@ -21,4 +21,9 @@ public class ExplorersCodex extends UniqueSpellBook {
                 AttributeModifier.Operation.ADDITION
         ));
     }
+
+    @Override
+    public boolean isFireResistant() {
+        return true;
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/isekaitravelguidebook/IsekaiTravelGuidebook.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/isekaitravelguidebook/IsekaiTravelGuidebook.java
@@ -22,6 +22,11 @@ public final class IsekaiTravelGuidebook extends UniqueSpellBook {
     }
 
     @Override
+    public boolean isFireResistant() {
+        return true;
+    }
+
+    @Override
     public void appendHoverText(@NotNull ItemStack stack, @Nullable Level level, @NotNull List<Component> lines, @NotNull TooltipFlag flag) {
         super.appendHoverText(stack, level, lines, flag);
         if (!IsekaiTravelGuidebookTooltipState.shouldShowTooltip()) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
@@ -42,6 +42,11 @@ public class SpellStainedRunicTablet extends SpellBook implements IJeiInfoItem {
     }
 
     @Override
+    public boolean isFireResistant() {
+        return true;
+    }
+
+    @Override
     public Multimap<Attribute, AttributeModifier> getAttributeModifiers(SlotContext slotContext, UUID uuid, ItemStack stack) {
         var baseModifiers = super.getAttributeModifiers(slotContext, uuid, stack);
         if (!Curios.SPELLBOOK_SLOT.equals(slotContext.identifier())) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/AbstractSpellAmplifierItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/AbstractSpellAmplifierItem.java
@@ -50,6 +50,20 @@ public abstract class AbstractSpellAmplifierItem extends AbstractOffhandMagicIte
         GeoItem.registerSyncedAnimatable(this);
     }
 
+    protected AbstractSpellAmplifierItem(
+            Rarity rarity,
+            String itemKey,
+            boolean fireResistant,
+            AttributeBonus... attributeBonuses
+    ) {
+        super(rarity, itemKey, fireResistant, attributeBonuses);
+        this.textureLocation = ResourceLocation.fromNamespaceAndPath(
+                ApprenticeCodex.MODID,
+                "textures/geo/" + itemKey + ".png"
+        );
+        GeoItem.registerSyncedAnimatable(this);
+    }
+
     public ResourceLocation getTextureLocation() {
         return textureLocation;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/NetheriteSpellAmplifier.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/NetheriteSpellAmplifier.java
@@ -11,6 +11,7 @@ public class NetheriteSpellAmplifier extends AbstractSpellAmplifierItem {
         super(
                 Rarity.RARE,
                 "netherite_spell_amplifier",
+                true,
                 bonus(AttributeRegistry.CASTING_MOVESPEED, 0.50, AttributeModifier.Operation.ADDITION),
                 bonus(Attributes.ARMOR, 4.0D, AttributeModifier.Operation.ADDITION),
                 bonus(Attributes.ARMOR_TOUGHNESS, 2.0D, AttributeModifier.Operation.ADDITION)

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/PhotonSiphon.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/PhotonSiphon.java
@@ -36,6 +36,7 @@ public class PhotonSiphon extends AbstractOffhandMagicItem implements GeoItem {
                 1,
                 Rarity.RARE,
                 "photon_siphon",
+                true,
                 bonus(AttributeRegistry.MANA_REGEN, 1.0, AttributeModifier.Operation.MULTIPLY_BASE)
         );
         this.textureLocation = ResourceLocation.fromNamespaceAndPath(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/DiamondSpellcasterGun.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/DiamondSpellcasterGun.java
@@ -36,7 +36,7 @@ public class DiamondSpellcasterGun extends AbstractSpellGunItem implements GeoIt
 
     public DiamondSpellcasterGun() {
         super(
-                new Properties().stacksTo(1).rarity(Rarity.COMMON),
+                new Properties().stacksTo(1).rarity(Rarity.COMMON).fireResistant(),
                 SPELL_GUN_CONFIG,
                 "DiamondSpellcasterGun",
                 bonus(AttributeRegistry.SPELL_POWER, 0.10, AttributeModifier.Operation.MULTIPLY_BASE)


### PR DESCRIPTION
- 杖全て、ミスリルを使う詠唱具及び防具、魔法書が対象
- 合わせて本来あるべきネザライト製アイテムの耐性も付与(弾薬除く)
- ミスリルを使うアクセサリはIron's側が対応していないため、こちらも耐性をつけていない
- `runGameTestServer`で確認済み