### PR TITLE
ミラージュアヴォイドの落下距離キャンセル範囲を調整

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/capability/codexspelldata/spellstates/MirageAvoidanceState.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/capability/codexspelldata/spellstates/MirageAvoidanceState.java
@@ -9,7 +9,6 @@ public class MirageAvoidanceState implements ICodexSpellState {
     public long invulnerableUntilGameTime;
     public float movementForward;
     public float movementStrafe;
-    public boolean suppressFallDamageUntilGround;
 
     public void reset() {
         startGameTime = 0L;
@@ -17,7 +16,6 @@ public class MirageAvoidanceState implements ICodexSpellState {
         invulnerableUntilGameTime = 0L;
         movementForward = 0.0F;
         movementStrafe = 0.0F;
-        suppressFallDamageUntilGround = false;
     }
 
     @Override
@@ -28,7 +26,6 @@ public class MirageAvoidanceState implements ICodexSpellState {
         tag.putLong("invulnerableUntilGameTime", invulnerableUntilGameTime);
         tag.putFloat("movementForward", movementForward);
         tag.putFloat("movementStrafe", movementStrafe);
-        tag.putBoolean("suppressFallDamageUntilGround", suppressFallDamageUntilGround);
         return tag;
     }
 
@@ -39,6 +36,5 @@ public class MirageAvoidanceState implements ICodexSpellState {
         invulnerableUntilGameTime = tag.getLong("invulnerableUntilGameTime");
         movementForward = tag.getFloat("movementForward");
         movementStrafe = tag.getFloat("movementStrafe");
-        suppressFallDamageUntilGround = tag.getBoolean("suppressFallDamageUntilGround");
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -5971,17 +5971,16 @@ public class ApprenticeCodexGameTestScenarios {
             s.startGameTime = level.getGameTime() - MirageAvoidanceEvents.INVULNERABLE_TICKS;
             s.invulnerableUntilGameTime = level.getGameTime();
             s.activeUntilGameTime = level.getGameTime() + 30;
-            s.suppressFallDamageUntilGround = true;
         }));
 
         var vulnerableAttack = postLivingAttackEventForGameTest(player, level.damageSources().lava(), 4.0F);
         helper.assertFalse(vulnerableAttack.isCanceled(), "MirageAvoidance should allow normal damage after tick 20");
         var fallAttack = postLivingAttackEventForGameTest(player, level.damageSources().fall(), 4.0F);
-        helper.assertTrue(fallAttack.isCanceled(), "MirageAvoidance should still cancel fall damage after invulnerability ends");
+        helper.assertFalse(fallAttack.isCanceled(), "MirageAvoidance should allow fall damage after invulnerability ends");
         helper.succeed();
     }
 
-    static void mirageAvoidanceFreezesThenSlidesAndSuppressesFallDamage(GameTestHelper helper) {
+    static void mirageAvoidanceFreezesThenSlidesAndResetsFallDistance(GameTestHelper helper) {
         var level = helper.getLevel();
         var player = createTrackedEquipmentTestPlayer(helper, new BlockPos(0, 5, 0), "mirage_avoidance_motion_test");
         var spell = SpellRegistry.MIRAGE_AVOIDANCE.get();
@@ -5997,8 +5996,8 @@ public class ApprenticeCodexGameTestScenarios {
         var startupMovement = player.getDeltaMovement();
         helper.assertTrue(startupMovement.lengthSqr() < 1.0E-6D,
                 "MirageAvoidance freeze startup should remove movement");
-        helper.assertTrue(player.fallDistance == 0.0F,
-                "MirageAvoidance should reset fall distance during startup");
+        helper.assertTrue(player.fallDistance == 8.0F,
+                "MirageAvoidance should not reset fall distance before sliding starts");
 
         Capabilities.withSpellData(player, data -> data.edit(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE, s -> {
             s.startGameTime = level.getGameTime() - MirageAvoidanceEvents.FREEZE_TICKS - 2;
@@ -6016,6 +6015,25 @@ public class ApprenticeCodexGameTestScenarios {
                 "MirageAvoidance slide should clamp falling speed");
         helper.assertTrue(player.fallDistance == 0.0F,
                 "MirageAvoidance should keep fall distance reset while sliding");
+
+        Capabilities.withSpellData(player, data -> data.edit(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE, s -> {
+            s.startGameTime = level.getGameTime() - MirageAvoidanceEvents.VULNERABLE_RECOVERY_START_TICK;
+            s.activeUntilGameTime = level.getGameTime() + 5;
+        }));
+        player.fallDistance = 6.0F;
+        MirageAvoidanceEvents.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.START, player));
+        MirageAvoidanceEvents.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player));
+        helper.assertTrue(player.fallDistance == 6.0F,
+                "MirageAvoidance should stop resetting fall distance during recovery");
+
+        Capabilities.withSpellData(player, data -> data.edit(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE, s -> {
+            s.startGameTime = level.getGameTime() - MirageAvoidanceEvents.EFFECT_DURATION_TICKS;
+            s.activeUntilGameTime = level.getGameTime();
+        }));
+        player.fallDistance = 7.0F;
+        MirageAvoidanceEvents.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.START, player));
+        helper.assertTrue(player.fallDistance == 7.0F,
+                "MirageAvoidance should not reset fall distance after the effect ends");
         helper.succeed();
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -228,8 +228,8 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     }
 
     @GameTest(template = TEMPLATE, batch = MIRAGE_AVOIDANCE_ISOLATED_BATCH, timeoutTicks = 80)
-    public static void mirageAvoidanceFreezesThenSlidesAndSuppressesFallDamage(GameTestHelper helper) {
-        ApprenticeCodexGameTestScenarios.mirageAvoidanceFreezesThenSlidesAndSuppressesFallDamage(helper);
+    public static void mirageAvoidanceFreezesThenSlidesAndResetsFallDistance(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.mirageAvoidanceFreezesThenSlidesAndResetsFallDistance(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = HARVEST_MOON_ISOLATED_BATCH)

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -57,7 +57,7 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import java.util.Optional;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "43";
+    private static final String PROTOCOL_VERSION = "44";
     private static int nextPacketId = 0;
 
     private static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncMirageAvoidanceStatePacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncMirageAvoidanceStatePacket.java
@@ -19,17 +19,15 @@ public class SyncMirageAvoidanceStatePacket {
     private final long invulnerableUntilGameTime;
     private final float movementForward;
     private final float movementStrafe;
-    private final boolean suppressFallDamageUntilGround;
 
     public SyncMirageAvoidanceStatePacket(int entityId, long startGameTime, long activeUntilGameTime, long invulnerableUntilGameTime,
-                                          float movementForward, float movementStrafe, boolean suppressFallDamageUntilGround) {
+                                          float movementForward, float movementStrafe) {
         this.entityId = entityId;
         this.startGameTime = startGameTime;
         this.activeUntilGameTime = activeUntilGameTime;
         this.invulnerableUntilGameTime = invulnerableUntilGameTime;
         this.movementForward = movementForward;
         this.movementStrafe = movementStrafe;
-        this.suppressFallDamageUntilGround = suppressFallDamageUntilGround;
     }
 
     public static void encode(SyncMirageAvoidanceStatePacket packet, FriendlyByteBuf buffer) {
@@ -39,7 +37,6 @@ public class SyncMirageAvoidanceStatePacket {
         buffer.writeLong(packet.invulnerableUntilGameTime);
         buffer.writeFloat(packet.movementForward);
         buffer.writeFloat(packet.movementStrafe);
-        buffer.writeBoolean(packet.suppressFallDamageUntilGround);
     }
 
     public static SyncMirageAvoidanceStatePacket decode(FriendlyByteBuf buffer) {
@@ -49,8 +46,7 @@ public class SyncMirageAvoidanceStatePacket {
                 buffer.readLong(),
                 buffer.readLong(),
                 buffer.readFloat(),
-                buffer.readFloat(),
-                buffer.readBoolean()
+                buffer.readFloat()
         );
     }
 
@@ -80,7 +76,6 @@ public class SyncMirageAvoidanceStatePacket {
                         state.invulnerableUntilGameTime = packet.invulnerableUntilGameTime;
                         state.movementForward = packet.movementForward;
                         state.movementStrafe = packet.movementStrafe;
-                        state.suppressFallDamageUntilGround = packet.suppressFallDamageUntilGround;
                     })
             );
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidance.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidance.java
@@ -112,14 +112,12 @@ public class MirageAvoidance extends AbstractSpell {
                     state.invulnerableUntilGameTime = level.getGameTime() + getDuration();
                     state.movementForward = input.forward();
                     state.movementStrafe = input.strafe();
-                    state.suppressFallDamageUntilGround = true;
                 });
                 if (player instanceof ServerPlayer serverPlayer) {
                     MirageAvoidanceSync.syncToClient(serverPlayer, data.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE));
                 }
             });
             spawnStartupPulse(player);
-            player.fallDistance = 0.0F;
         }
         super.onCast(level, spellLevel, entity, castSource, playerMagicData);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidanceEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidanceEvents.java
@@ -15,7 +15,6 @@ import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
-import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
@@ -60,7 +59,7 @@ public final class MirageAvoidanceEvents {
         var level = player.level();
         var state = spellData.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE);
         if (!isActive(level, state)) {
-            tickFallDamageSuppression(spellData, player, state);
+            resetInactiveState(spellData, player, state);
             return;
         }
 
@@ -75,7 +74,9 @@ public final class MirageAvoidanceEvents {
         } else {
             stabilizePostPhysicsMovement(player, elapsedTicks);
         }
-        player.fallDistance = 0.0F;
+        if (shouldResetFallDistance(elapsedTicks)) {
+            player.fallDistance = 0.0F;
+        }
 
         if (event.phase == TickEvent.Phase.START && !level.isClientSide) {
             spawnTrailParticles(player, elapsedTicks);
@@ -94,9 +95,8 @@ public final class MirageAvoidanceEvents {
         }
 
         var state = spellData.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE);
-        if (isInvulnerable(player.level(), state) || shouldSuppressFallDamage(player, state, event.getSource())) {
+        if (isInvulnerable(player.level(), state)) {
             event.setCanceled(true);
-            player.fallDistance = 0.0F;
         }
     }
 
@@ -166,13 +166,12 @@ public final class MirageAvoidanceEvents {
         return state.invulnerableUntilGameTime > level.getGameTime();
     }
 
-    private static boolean shouldSuppressFallDamage(Player player, MirageAvoidanceState state, net.minecraft.world.damagesource.DamageSource source) {
-        return source.is(DamageTypes.FALL)
-                && (isActive(player.level(), state) || state.suppressFallDamageUntilGround);
-    }
-
     private static int getElapsedTicks(Level level, MirageAvoidanceState state) {
         return Math.max(0, (int) (level.getGameTime() - state.startGameTime));
+    }
+
+    private static boolean shouldResetFallDistance(int elapsedTicks) {
+        return elapsedTicks >= FREEZE_TICKS && elapsedTicks < VULNERABLE_RECOVERY_START_TICK;
     }
 
     private static void applyMovement(Player player, MirageAvoidanceState state, int elapsedTicks) {
@@ -234,15 +233,8 @@ public final class MirageAvoidanceEvents {
         }
     }
 
-    private static void tickFallDamageSuppression(CodexSpellData spellData, Player player, MirageAvoidanceState state) {
-        if (state.activeUntilGameTime == 0L && !state.suppressFallDamageUntilGround) {
-            return;
-        }
-
-        if (state.suppressFallDamageUntilGround) {
-            player.fallDistance = 0.0F;
-        }
-        if (state.suppressFallDamageUntilGround && !player.onGround()) {
+    private static void resetInactiveState(CodexSpellData spellData, Player player, MirageAvoidanceState state) {
+        if (state.activeUntilGameTime == 0L) {
             return;
         }
 
@@ -253,15 +245,11 @@ public final class MirageAvoidanceEvents {
     }
 
     private static void deactivate(CodexSpellData spellData, Player player, MirageAvoidanceState state, boolean stopMovement) {
-        if (state.activeUntilGameTime == 0L && !state.suppressFallDamageUntilGround) {
+        if (state.activeUntilGameTime == 0L) {
             return;
         }
 
-        spellData.edit(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE, s -> {
-            s.reset();
-            s.suppressFallDamageUntilGround = true;
-        });
-        player.fallDistance = 0.0F;
+        spellData.edit(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE, MirageAvoidanceState::reset);
         if (stopMovement) {
             player.setDeltaMovement(Vec3.ZERO);
             markMovementChanged(player);

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidanceSync.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidanceSync.java
@@ -16,8 +16,7 @@ public final class MirageAvoidanceSync {
                 state.activeUntilGameTime,
                 state.invulnerableUntilGameTime,
                 state.movementForward,
-                state.movementStrafe,
-                state.suppressFallDamageUntilGround
+                state.movementStrafe
         ));
     }
 }


### PR DESCRIPTION
## 概要
- PR #601 の `0d4e5f1158e6ba09a82ab493a10b1fdae91e15c4` 相当の変更を 1.20.1 側へ取り込み
- ミラージュアヴォイドの落下ダメージ抑制用 state を廃止し、滑走中だけ `fallDistance` をリセットする挙動へ変更
- 同期 packet の不要 boolean を削除し、ネットワークプロトコルを更新
- GameTest の期待値を新しい挙動に合わせて更新

## 背景
従来の落下ダメージケアは効果終了後や接地まで広く効きすぎており、他の落下距離参照ロジックと干渉する余地がありました。今回の変更では、ミラージュアヴォイドが実際に滑走制御している期間だけ落下距離を消すよう範囲を絞っています。

## 確認
- `./scripts/use-java.ps1; ./gradlew.bat build`
- `./scripts/use-java.ps1; ./gradlew.bat runGameTestServer`（576 件成功）