### PR TITLE
[codex] PR #600 を 1.21.1-main へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -79,6 +79,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void fireResistantEquipmentContractsStayInSync(GameTestHelper helper) {
+        EquipmentFireResistanceGameTestScenarios.fireResistantEquipmentContractsStayInSync(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void copperSwingcastStaffStartsWithBallLightningLevelOne(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.copperSwingcastStaffStartsWithBallLightningLevelOne(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -3642,7 +3642,7 @@ public class ApprenticeCodexGameTestScenarios {
     static void isekaiTravelGuidebookStartsWithTwoFixedSpellsAndNoAttributes(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var stack = new ItemStack(ItemRegistry.ISEKAI_TRAVEL_GUIDEBOOK.get());
-            var item = (io.redspace.ironsspellbooks.item.UniqueSpellBook) stack.getItem();
+            var item = (jp.aquafactory.apprenticecodex.item.curios.FireResistantUniqueSpellBook) stack.getItem();
             item.initializeSpellContainer(stack);
 
             helper.assertTrue(ISpellContainer.isSpellContainer(stack),

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentFireResistanceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentFireResistanceGameTestScenarios.java
@@ -2,20 +2,25 @@ package jp.aquafactory.apprenticecodex.gametest;
 
 import java.util.List;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.item.swingstaff.AbstractSwingcastStaffItem;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
 
 final class EquipmentFireResistanceGameTestScenarios extends ApprenticeCodexGameTestScenarios {
+    private static final TagKey<Item> IRONS_STAFF = TagKey.create(
+            Registries.ITEM,
+            ResourceLocation.fromNamespaceAndPath("irons_spellbooks", "staff")
+    );
     private static final TagKey<Item> CURIOS_SPELLBOOK = TagKey.create(
             Registries.ITEM,
             ResourceLocation.fromNamespaceAndPath("curios", "spellbook")
@@ -59,7 +64,7 @@ final class EquipmentFireResistanceGameTestScenarios extends ApprenticeCodexGame
         });
     }
 
-    private static List<RegistryObject<Item>> explicitFireResistantItems() {
+    private static List<Supplier<? extends Item>> explicitFireResistantItems() {
         return List.of(
                 ItemRegistry.SMASHCAST_SCEPTER,
                 ItemRegistry.SCROLLCASTER_GAUNTLET,
@@ -85,7 +90,7 @@ final class EquipmentFireResistanceGameTestScenarios extends ApprenticeCodexGame
             String categoryName
     ) {
         var stacks = ItemRegistry.ITEMS.getEntries().stream()
-                .map(RegistryObject::get)
+                .map(Supplier::get)
                 .map(ItemStack::new)
                 .filter(predicate)
                 .toList();
@@ -98,7 +103,7 @@ final class EquipmentFireResistanceGameTestScenarios extends ApprenticeCodexGame
     }
 
     private static boolean isNonStackRegisteredStaffPathItem(ItemStack stack) {
-        var itemId = ForgeRegistries.ITEMS.getKey(stack.getItem());
+        var itemId = BuiltInRegistries.ITEM.getKey(stack.getItem());
         return itemId != null
                 && ApprenticeCodex.MODID.equals(itemId.getNamespace())
                 && itemId.getPath().contains("staff")
@@ -107,15 +112,15 @@ final class EquipmentFireResistanceGameTestScenarios extends ApprenticeCodexGame
 
     private static void assertFireResistant(GameTestHelper helper, Item item, String categoryName) {
         helper.assertTrue(
-                item.isFireResistant(),
-                categoryName + " should be fire resistant: " + ForgeRegistries.ITEMS.getKey(item)
+                new ItemStack(item).has(DataComponents.FIRE_RESISTANT),
+                categoryName + " should be fire resistant: " + BuiltInRegistries.ITEM.getKey(item)
         );
     }
 
     private static void assertNotFireResistant(GameTestHelper helper, Item item, String message) {
         helper.assertFalse(
-                item.isFireResistant(),
-                message + ": " + ForgeRegistries.ITEMS.getKey(item)
+                new ItemStack(item).has(DataComponents.FIRE_RESISTANT),
+                message + ": " + BuiltInRegistries.ITEM.getKey(item)
         );
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentFireResistanceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentFireResistanceGameTestScenarios.java
@@ -1,0 +1,121 @@
+package jp.aquafactory.apprenticecodex.gametest;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.swingstaff.AbstractSwingcastStaffItem;
+import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+final class EquipmentFireResistanceGameTestScenarios extends ApprenticeCodexGameTestScenarios {
+    private static final TagKey<Item> CURIOS_SPELLBOOK = TagKey.create(
+            Registries.ITEM,
+            ResourceLocation.fromNamespaceAndPath("curios", "spellbook")
+    );
+
+    private EquipmentFireResistanceGameTestScenarios() {
+    }
+
+    static void fireResistantEquipmentContractsStayInSync(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    stack -> stack.is(IRONS_STAFF),
+                    "irons_spellbooks:staff tagged item"
+            );
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    stack -> stack.is(CURIOS_SPELLBOOK),
+                    "curios:spellbook tagged item"
+            );
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    stack -> stack.getItem() instanceof AbstractSwingcastStaffItem,
+                    "AbstractSwingcastStaffItem"
+            );
+            assertRegisteredItemsMatchingAreFireResistant(
+                    helper,
+                    EquipmentFireResistanceGameTestScenarios::isNonStackRegisteredStaffPathItem,
+                    "non-stack registered item with staff in path"
+            );
+
+            for (var itemEntry : explicitFireResistantItems()) {
+                assertFireResistant(helper, itemEntry.get(), "explicit fire-resistant equipment");
+            }
+
+            assertNotFireResistant(
+                    helper,
+                    ItemRegistry.SCARLET_THIRST.get(),
+                    "Scarlet Thirst should stay excluded as a normal Mithril Curio"
+            );
+        });
+    }
+
+    private static List<RegistryObject<Item>> explicitFireResistantItems() {
+        return List.of(
+                ItemRegistry.SMASHCAST_SCEPTER,
+                ItemRegistry.SCROLLCASTER_GAUNTLET,
+                ItemRegistry.MANA_FORCE_BLADE,
+                ItemRegistry.ELEMENTAL_BOW,
+                ItemRegistry.DIAMOND_SPELLCASTER_GUN,
+                ItemRegistry.NETHERITE_SPELL_AMPLIFIER,
+                ItemRegistry.PHOTON_SIPHON,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_HAT,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_COAT,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_LEGGINGS,
+                ItemRegistry.CHROMATIC_MAGIA_DRESS_BOOTS,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_RIBBON,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_ROBE,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_LEGGINGS,
+                ItemRegistry.ELEMENT_MAIDEN_ROBE_BOOTS
+        );
+    }
+
+    private static void assertRegisteredItemsMatchingAreFireResistant(
+            GameTestHelper helper,
+            Predicate<ItemStack> predicate,
+            String categoryName
+    ) {
+        var stacks = ItemRegistry.ITEMS.getEntries().stream()
+                .map(RegistryObject::get)
+                .map(ItemStack::new)
+                .filter(predicate)
+                .toList();
+
+        helper.assertFalse(stacks.isEmpty(), "No items matched fire resistance category: " + categoryName);
+
+        for (var stack : stacks) {
+            assertFireResistant(helper, stack.getItem(), categoryName);
+        }
+    }
+
+    private static boolean isNonStackRegisteredStaffPathItem(ItemStack stack) {
+        var itemId = ForgeRegistries.ITEMS.getKey(stack.getItem());
+        return itemId != null
+                && ApprenticeCodex.MODID.equals(itemId.getNamespace())
+                && itemId.getPath().contains("staff")
+                && stack.getMaxStackSize() == 1;
+    }
+
+    private static void assertFireResistant(GameTestHelper helper, Item item, String categoryName) {
+        helper.assertTrue(
+                item.isFireResistant(),
+                categoryName + " should be fire resistant: " + ForgeRegistries.ITEMS.getKey(item)
+        );
+    }
+
+    private static void assertNotFireResistant(GameTestHelper helper, Item item, String message) {
+        helper.assertFalse(
+                item.isFireResistant(),
+                message + ": " + ForgeRegistries.ITEMS.getKey(item)
+        );
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
@@ -55,7 +55,7 @@ public abstract class AbstractOffhandMagicItem extends Item
             String itemKey,
             List<AttributeBonus> offhandBonuses
     ) {
-        this(configuredSpell, configuredSpellLevel, rarity, itemKey, attributeBonuses, false);
+        this(configuredSpell, configuredSpellLevel, rarity, itemKey, offhandBonuses, false);
     }
 
     protected AbstractOffhandMagicItem(
@@ -71,7 +71,7 @@ public abstract class AbstractOffhandMagicItem extends Item
         this.configuredSpellLevel = configuredSpellLevel;
         this.startsWithPresetSpell = true;
         this.itemKey = normalizeKeyToken(itemKey);
-        this.offhandBonuses = List.copyOf(offhandBonuses);
+        this.offhandBonuses = List.copyOf(attributeBonuses);
         this.baseOffhandModifiers = buildBaseOffhandModifiers();
     }
 
@@ -119,7 +119,7 @@ public abstract class AbstractOffhandMagicItem extends Item
             String itemKey,
             List<AttributeBonus> offhandBonuses
     ) {
-        this(rarity, itemKey, attributeBonuses, false);
+        this(rarity, itemKey, offhandBonuses, false);
     }
 
     protected AbstractOffhandMagicItem(
@@ -133,7 +133,7 @@ public abstract class AbstractOffhandMagicItem extends Item
         this.configuredSpellLevel = 0;
         this.startsWithPresetSpell = false;
         this.itemKey = normalizeKeyToken(itemKey);
-        this.offhandBonuses = List.copyOf(offhandBonuses);
+        this.offhandBonuses = List.copyOf(attributeBonuses);
         this.baseOffhandModifiers = buildBaseOffhandModifiers();
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractOffhandMagicItem.java
@@ -55,7 +55,18 @@ public abstract class AbstractOffhandMagicItem extends Item
             String itemKey,
             List<AttributeBonus> offhandBonuses
     ) {
-        super(createProperties(rarity));
+        this(configuredSpell, configuredSpellLevel, rarity, itemKey, attributeBonuses, false);
+    }
+
+    protected AbstractOffhandMagicItem(
+            Supplier<? extends AbstractSpell> configuredSpell,
+            int configuredSpellLevel,
+            Rarity rarity,
+            String itemKey,
+            List<AttributeBonus> attributeBonuses,
+            boolean fireResistant
+    ) {
+        super(createProperties(rarity, fireResistant));
         this.configuredSpell = Objects.requireNonNull(configuredSpell);
         this.configuredSpellLevel = configuredSpellLevel;
         this.startsWithPresetSpell = true;
@@ -86,6 +97,17 @@ public abstract class AbstractOffhandMagicItem extends Item
     protected AbstractOffhandMagicItem(
             Supplier<? extends AbstractSpell> configuredSpell,
             int configuredSpellLevel,
+            Rarity rarity,
+            String itemKey,
+            boolean fireResistant,
+            AttributeBonus... attributeBonuses
+    ) {
+        this(configuredSpell, configuredSpellLevel, rarity, itemKey, List.of(attributeBonuses), fireResistant);
+    }
+
+    protected AbstractOffhandMagicItem(
+            Supplier<? extends AbstractSpell> configuredSpell,
+            int configuredSpellLevel,
             String itemKey,
             AttributeBonus... attributeBonuses
     ) {
@@ -97,7 +119,16 @@ public abstract class AbstractOffhandMagicItem extends Item
             String itemKey,
             List<AttributeBonus> offhandBonuses
     ) {
-        super(createProperties(rarity));
+        this(rarity, itemKey, attributeBonuses, false);
+    }
+
+    protected AbstractOffhandMagicItem(
+            Rarity rarity,
+            String itemKey,
+            List<AttributeBonus> attributeBonuses,
+            boolean fireResistant
+    ) {
+        super(createProperties(rarity, fireResistant));
         this.configuredSpell = null;
         this.configuredSpellLevel = 0;
         this.startsWithPresetSpell = false;
@@ -119,6 +150,15 @@ public abstract class AbstractOffhandMagicItem extends Item
             AttributeBonus... attributeBonuses
     ) {
         this(rarity, itemKey, List.of(attributeBonuses));
+    }
+
+    protected AbstractOffhandMagicItem(
+            Rarity rarity,
+            String itemKey,
+            boolean fireResistant,
+            AttributeBonus... attributeBonuses
+    ) {
+        this(rarity, itemKey, List.of(attributeBonuses), fireResistant);
     }
 
     protected AbstractOffhandMagicItem(
@@ -453,7 +493,12 @@ public abstract class AbstractOffhandMagicItem extends Item
     }
 
     private static Item.Properties createProperties(Rarity rarity) {
-        return new Item.Properties().stacksTo(1).rarity(Objects.requireNonNull(rarity));
+        return createProperties(rarity, false);
+    }
+
+    private static Item.Properties createProperties(Rarity rarity, boolean fireResistant) {
+        var properties = new Item.Properties().stacksTo(1).rarity(Objects.requireNonNull(rarity));
+        return fireResistant ? properties.fireResistant() : properties;
     }
 
     // `bonus` ヘルパーは属性参照の受け取り方ごとにオーバーロードしている.

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractRightClickMagicWeaponItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractRightClickMagicWeaponItem.java
@@ -73,7 +73,7 @@ public abstract class AbstractRightClickMagicWeaponItem extends Item implements 
             double attackSpeed,
             List<AttributeBonus> handBonuses
     ) {
-        super(withBaseMainhandAttributes(properties, itemKey, attackDamage, attackSpeed, handBonuses));
+        super(withBaseMainhandAttributes(properties.fireResistant(), itemKey, attackDamage, attackSpeed, handBonuses));
         this.configuredSpell = Objects.requireNonNull(configuredSpell);
         this.configuredSpellLevel = configuredSpellLevel;
         this.startsWithPresetSpell = true;
@@ -95,7 +95,7 @@ public abstract class AbstractRightClickMagicWeaponItem extends Item implements 
             double attackSpeed,
             List<AttributeBonus> handBonuses
     ) {
-        super(withBaseMainhandAttributes(properties, itemKey, attackDamage, attackSpeed, handBonuses));
+        super(withBaseMainhandAttributes(properties.fireResistant(), itemKey, attackDamage, attackSpeed, handBonuses));
         this.configuredSpell = null;
         this.configuredSpellLevel = 0;
         this.startsWithPresetSpell = false;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ChargedTwinBladeStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ChargedTwinBladeStaff.java
@@ -99,6 +99,7 @@ public final class ChargedTwinBladeStaff extends Item implements GeoItem, NonDam
         super(new Item.Properties()
                 .stacksTo(1)
                 .rarity(Rarity.RARE)
+                .fireResistant()
                 .attributes(buildMainhandModifiers()));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
@@ -89,6 +89,7 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
         super(new Item.Properties()
                 .stacksTo(1)
                 .rarity(Rarity.RARE)
+                .fireResistant()
                 .attributes(ExtendedSwordItem.createAttributes(CIRCUIT_HEAT_STAFF_TIER)));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ElementalBow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ElementalBow.java
@@ -92,7 +92,7 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public ElementalBow() {
-        super(new Properties().durability(1561));
+        super(new Properties().durability(1561).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/FocusStaffbow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/FocusStaffbow.java
@@ -101,6 +101,7 @@ public final class FocusStaffbow extends CastingItem
         super(new Item.Properties()
                 .stacksTo(1)
                 .rarity(Rarity.RARE)
+                .fireResistant()
                 .attributes(buildMainhandModifiers()));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ManaForceBlade.java
@@ -99,6 +99,7 @@ public class ManaForceBlade extends SwordItem implements GeoItem, IPresetSpellCo
                 .stacksTo(1)
                 .durability(DURABILITY)
                 .rarity(Rarity.RARE)
+                .fireResistant()
                 .attributes(SwordItem.createAttributes(Tiers.DIAMOND, 0, (float) ATTACK_SPEED_MODIFIER_AMOUNT)));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/MulticastEchoStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/MulticastEchoStaff.java
@@ -58,6 +58,7 @@ public class MulticastEchoStaff extends StaffItem implements GeoItem, IPresetSpe
         super(new Item.Properties()
                 .stacksTo(1)
                 .rarity(Rarity.EPIC)
+                .fireResistant()
                 .attributes(ExtendedSwordItem.createAttributes(MULTICAST_ECHO_STAFF_TIER)));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/MultipurposeStaffrifle.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/MultipurposeStaffrifle.java
@@ -95,7 +95,7 @@ public final class MultipurposeStaffrifle extends Item
     private final ItemAttributeModifiers baseMainhandModifiers = buildBaseMainhandModifiers();
 
     public MultipurposeStaffrifle() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/PastelStaff.java
@@ -63,6 +63,7 @@ public class PastelStaff extends StaffItem implements GeoItem, IPresetSpellConta
         super(new Item.Properties()
                         .stacksTo(1)
                         .rarity(Rarity.EPIC)
+                        .fireResistant()
                         .attributes(ExtendedSwordItem.createAttributes(PASTEL_STAFF_WEAPON_TIER)));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ScrollcasterGauntlet.java
@@ -119,7 +119,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     private final AnimatableInstanceCache cache = GeckoLibUtil.createInstanceCache(this);
 
     public ScrollcasterGauntlet() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.RARE).fireResistant());
         GeoItem.registerSyncedAnimatable(this);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ZenithStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ZenithStaff.java
@@ -60,6 +60,7 @@ public class ZenithStaff extends StaffItem implements GeoItem, UniqueItem {
         super(new Item.Properties()
                 .stacksTo(1)
                 .rarity(Rarity.EPIC)
+                .fireResistant()
                 .attributes(ExtendedSwordItem.createAttributes(ZENITH_STAFF_TIER)));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressItem.java
@@ -41,7 +41,7 @@ public class ChromaticMagiaDressItem extends ArmorItem implements GeoItem, IPres
     private final ItemAttributeModifiers armorAttributeModifiers;
 
     public ChromaticMagiaDressItem(Type type) {
-        super(Holder.direct(ChromaticMagiaDressStats.MATERIAL), type, ChromaticMagiaDressStats.createProperties(type));
+        super(Holder.direct(ChromaticMagiaDressStats.MATERIAL), type, ChromaticMagiaDressStats.createProperties(type).fireResistant());
         this.armorAttributeModifiers = ChromaticMagiaDressStats.createAttributeModifiers(type);
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ElementMaidenRobeItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ElementMaidenRobeItem.java
@@ -61,7 +61,7 @@ public class ElementMaidenRobeItem extends ArmorItem implements GeoItem, IPreset
     private final ItemAttributeModifiers armorAttributeModifiers;
 
     public ElementMaidenRobeItem(Type type) {
-        super(Holder.direct(ElementMaidenRobeStats.MATERIAL), type, ElementMaidenRobeStats.createProperties(type).rarity(Rarity.EPIC));
+        super(Holder.direct(ElementMaidenRobeStats.MATERIAL), type, ElementMaidenRobeStats.createProperties(type).rarity(Rarity.EPIC).fireResistant());
         this.armorAttributeModifiers = ElementMaidenRobeStats.createAttributeModifiers(type);
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/FireResistantUniqueSpellBook.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/FireResistantUniqueSpellBook.java
@@ -1,0 +1,65 @@
+package jp.aquafactory.apprenticecodex.item.curios;
+
+import io.redspace.ironsspellbooks.api.registry.SpellDataRegistryHolder;
+import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
+import io.redspace.ironsspellbooks.api.spells.SpellData;
+import io.redspace.ironsspellbooks.item.SpellBook;
+import io.redspace.ironsspellbooks.item.UniqueItem;
+import io.redspace.ironsspellbooks.registries.ComponentRegistry;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Rarity;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class FireResistantUniqueSpellBook extends SpellBook implements UniqueItem {
+    private List<SpellData> spellData = null;
+    private SpellDataRegistryHolder[] spellDataRegistryHolders;
+
+    public FireResistantUniqueSpellBook(SpellDataRegistryHolder[] spellDataRegistryHolders) {
+        this(spellDataRegistryHolders, 0);
+    }
+
+    public FireResistantUniqueSpellBook(SpellDataRegistryHolder[] spellDataRegistryHolders, int additionalSlots) {
+        super(spellDataRegistryHolders.length + additionalSlots, new Item.Properties()
+                .stacksTo(1)
+                .rarity(Rarity.UNCOMMON)
+                .fireResistant());
+        this.spellDataRegistryHolders = spellDataRegistryHolders;
+    }
+
+    public List<SpellData> getSpells() {
+        if (spellData == null) {
+            spellData = Arrays.stream(spellDataRegistryHolders).map(SpellDataRegistryHolder::getSpellData).toList();
+            spellDataRegistryHolders = null;
+        }
+        return spellData;
+    }
+
+    @Override
+    public Component getName(ItemStack stack) {
+        return stack.has(ComponentRegistry.SPELL_CONTAINER) && stack.get(ComponentRegistry.SPELL_CONTAINER).isImproved()
+                ? Component.translatable("tooltip.irons_spellbooks.improved_format", super.getName(stack))
+                : super.getName(stack);
+    }
+
+    @Override
+    public boolean isUnique() {
+        return true;
+    }
+
+    @Override
+    public void initializeSpellContainer(ItemStack itemStack) {
+        if (itemStack == null) {
+            return;
+        }
+
+        if (!ISpellContainer.isSpellContainer(itemStack)) {
+            var spellContainer = ISpellContainer.create(getMaxSpellSlots(), true, true).mutableCopy();
+            getSpells().forEach(spellSlot -> spellContainer.addSpell(spellSlot.getSpell(), spellSlot.getLevel(), true));
+            ISpellContainer.set(itemStack, spellContainer.toImmutable());
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/archivistsgrimoire/ArchivistsGrimoire.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/archivistsgrimoire/ArchivistsGrimoire.java
@@ -64,7 +64,7 @@ public class ArchivistsGrimoire extends Item implements ICurioItem, ISpellbook, 
     };
 
     public ArchivistsGrimoire() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON).fireResistant());
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/endergrimoire/EnderGrimoire.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/endergrimoire/EnderGrimoire.java
@@ -51,7 +51,7 @@ public class EnderGrimoire extends Item implements ICurioItem, ISpellbook, IPres
     };
 
     public EnderGrimoire() {
-        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON));
+        super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON).fireResistant());
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/explorerscodex/ExplorersCodex.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/explorerscodex/ExplorersCodex.java
@@ -21,4 +21,9 @@ public class ExplorersCodex extends UniqueSpellBook {
                 AttributeModifier.Operation.ADD_VALUE
         ));
     }
+
+    @Override
+    public boolean isFireResistant() {
+        return true;
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/explorerscodex/ExplorersCodex.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/explorerscodex/ExplorersCodex.java
@@ -2,12 +2,12 @@ package jp.aquafactory.apprenticecodex.item.curios.explorerscodex;
 
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.registry.SpellDataRegistryHolder;
-import io.redspace.ironsspellbooks.item.UniqueSpellBook;
 import io.redspace.ironsspellbooks.item.weapons.AttributeContainer;
+import jp.aquafactory.apprenticecodex.item.curios.FireResistantUniqueSpellBook;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 
-public class ExplorersCodex extends UniqueSpellBook {
+public class ExplorersCodex extends FireResistantUniqueSpellBook {
     public ExplorersCodex() {
         super(SpellDataRegistryHolder.of(
                 new SpellDataRegistryHolder(SpellRegistry.ASSIST_WINGS, 1),
@@ -22,8 +22,4 @@ public class ExplorersCodex extends UniqueSpellBook {
         ));
     }
 
-    @Override
-    public boolean isFireResistant() {
-        return true;
-    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/isekaitravelguidebook/IsekaiTravelGuidebook.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/isekaitravelguidebook/IsekaiTravelGuidebook.java
@@ -1,7 +1,7 @@
 package jp.aquafactory.apprenticecodex.item.curios.isekaitravelguidebook;
 
 import io.redspace.ironsspellbooks.api.registry.SpellDataRegistryHolder;
-import io.redspace.ironsspellbooks.item.UniqueSpellBook;
+import jp.aquafactory.apprenticecodex.item.curios.FireResistantUniqueSpellBook;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -12,17 +12,12 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public final class IsekaiTravelGuidebook extends UniqueSpellBook {
+public final class IsekaiTravelGuidebook extends FireResistantUniqueSpellBook {
     public IsekaiTravelGuidebook() {
         super(new SpellDataRegistryHolder[] {
                 new SpellDataRegistryHolder(SpellRegistry.HEALING_BLOOM, 1),
                 new SpellDataRegistryHolder(SpellRegistry.COMPANION_TRUNK, 1)
         });
-    }
-
-    @Override
-    public boolean isFireResistant() {
-        return true;
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/isekaitravelguidebook/IsekaiTravelGuidebook.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/isekaitravelguidebook/IsekaiTravelGuidebook.java
@@ -21,6 +21,11 @@ public final class IsekaiTravelGuidebook extends UniqueSpellBook {
     }
 
     @Override
+    public boolean isFireResistant() {
+        return true;
+    }
+
+    @Override
     public void appendHoverText(@NotNull ItemStack stack, Item.TooltipContext context, @NotNull List<Component> lines, @NotNull TooltipFlag flag) {
         super.appendHoverText(stack, context, lines, flag);
         if (!IsekaiTravelGuidebookTooltipState.shouldShowTooltip()) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.TooltipFlag;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.loading.FMLEnvironment;
@@ -37,12 +38,7 @@ public class SpellStainedRunicTablet extends SpellBook implements IJeiInfoItem {
     private static final String TOOLTIP_KEY_PREFIX = "item.apprenticecodex.spellstained_runic_tablet.desc";
 
     public SpellStainedRunicTablet() {
-        super(8);
-    }
-
-    @Override
-    public boolean isFireResistant() {
-        return true;
+        super(8, new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON).fireResistant());
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellstainedrunictablet/SpellStainedRunicTablet.java
@@ -41,6 +41,11 @@ public class SpellStainedRunicTablet extends SpellBook implements IJeiInfoItem {
     }
 
     @Override
+    public boolean isFireResistant() {
+        return true;
+    }
+
+    @Override
     public @NotNull Multimap<Holder<Attribute>, AttributeModifier> getAttributeModifiers(
             SlotContext slotContext,
             ResourceLocation id,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/AbstractSpellAmplifierItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/AbstractSpellAmplifierItem.java
@@ -46,6 +46,20 @@ public abstract class AbstractSpellAmplifierItem extends AbstractOffhandMagicIte
         GeoItem.registerSyncedAnimatable(this);
     }
 
+    protected AbstractSpellAmplifierItem(
+            Rarity rarity,
+            String itemKey,
+            boolean fireResistant,
+            AttributeBonus... attributeBonuses
+    ) {
+        super(rarity, itemKey, fireResistant, attributeBonuses);
+        this.textureLocation = ResourceLocation.fromNamespaceAndPath(
+                ApprenticeCodex.MODID,
+                "textures/geo/" + itemKey + ".png"
+        );
+        GeoItem.registerSyncedAnimatable(this);
+    }
+
     public ResourceLocation getTextureLocation() {
         return textureLocation;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/NetheriteSpellAmplifier.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/NetheriteSpellAmplifier.java
@@ -11,6 +11,7 @@ public class NetheriteSpellAmplifier extends AbstractSpellAmplifierItem {
         super(
                 Rarity.RARE,
                 "netherite_spell_amplifier",
+                true,
                 bonus(AttributeRegistry.CASTING_MOVESPEED, 0.50, AttributeModifier.Operation.ADD_VALUE),
                 bonus(Attributes.ARMOR, 4.0D, AttributeModifier.Operation.ADD_VALUE),
                 bonus(Attributes.ARMOR_TOUGHNESS, 2.0D, AttributeModifier.Operation.ADD_VALUE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/PhotonSiphon.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/PhotonSiphon.java
@@ -31,6 +31,7 @@ public class PhotonSiphon extends AbstractOffhandMagicItem implements GeoItem {
                 1,
                 Rarity.RARE,
                 "photon_siphon",
+                true,
                 bonus(AttributeRegistry.MANA_REGEN, 1.0, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
         );
         this.textureLocation = ResourceLocation.fromNamespaceAndPath(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/DiamondSpellcasterGun.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/DiamondSpellcasterGun.java
@@ -33,7 +33,7 @@ public class DiamondSpellcasterGun extends AbstractSpellGunItem implements GeoIt
 
     public DiamondSpellcasterGun() {
         super(
-                new Properties().stacksTo(1).rarity(Rarity.COMMON),
+                new Properties().stacksTo(1).rarity(Rarity.COMMON).fireResistant(),
                 SPELL_GUN_CONFIG,
                 "DiamondSpellcasterGun",
                 bonus(AttributeRegistry.SPELL_POWER, 0.10, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)


### PR DESCRIPTION
## 概要
- main 向け PR #600 を 1.21.1-main へ forward-port
- アイテム火耐性付与と契約確認 GameTest を移植
- 1.21.1/NeoForge 向けに registry API と fire-resistant component 判定を調整

## 取り込み元
- #600
- ac69a81a70883b244810891ad43e3eff827c4532
- 129014a7d1e26dd3359855a3ed0789a758a7f84d

## 1.21.1 向け調整
- `ForgeRegistries` / `RegistryObject` 前提を `BuiltInRegistries` / `Supplier` ベースに変更
- `Item#isFireResistant()` がないため `DataComponents.FIRE_RESISTANT` で GameTest 検証
- `UniqueSpellBook` に `Item.Properties` を渡せない魔法書用に、火耐性付きのローカル基底クラスを追加

## 検証
- `./gradlew.bat runGameTestServer` 成功（585 required tests passed）
- `./gradlew.bat build` 成功（`checkTextEncodingHygiene` 含む）