### PR TITLE
刃の結晶杖＆マナスラッシュのリワーク

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -45,6 +45,12 @@ public final class ApprenticeCodexServerConfig {
         return DAMAGE_MULTIPLIER_CONFIG.value(key);
     }
 
+    public static GameTestConfigOverride useDamageMultiplierOverrideForGameTest(DamageMultiplierKey key, double value) {
+        var previousValue = DAMAGE_MULTIPLIER_CONFIG.value(key);
+        DAMAGE_MULTIPLIER_CONFIG.setValueForGameTest(key, value);
+        return () -> DAMAGE_MULTIPLIER_CONFIG.setValueForGameTest(key, previousValue);
+    }
+
     public static boolean isSpellcasterWorkbenchRecipeDenied(ResourceLocation recipeId) {
         return PROCESSING_CONFIG.isSpellcasterWorkbenchRecipeDenied(recipeId);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/DamageMultiplierServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/DamageMultiplierServerConfig.java
@@ -41,4 +41,8 @@ final class DamageMultiplierServerConfig {
     float value(DamageMultiplierKey key) {
         return values.get(key).get().floatValue();
     }
+
+    void setValueForGameTest(DamageMultiplierKey key, double value) {
+        values.get(key).set(value);
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -869,6 +869,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void manaSlashDamageMultiplierAppliesAfterMinimumDamage(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.manaSlashDamageMultiplierAppliesAfterMinimumDamage(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void manaSlashAllowsNonSwingcastPrecondition(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.manaSlashAllowsNonSwingcastPrecondition(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -869,6 +869,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void manaSlashCatalystDamageUsesStackAttributeModifiers(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.manaSlashCatalystDamageUsesStackAttributeModifiers(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void manaSlashDamageMultiplierAppliesAfterMinimumDamage(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.manaSlashDamageMultiplierAppliesAfterMinimumDamage(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -854,8 +854,28 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeldInOffhand(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeldInOffhand(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void crystalBladedStaffLegacyWheelReplacementStaysRemovableWhenHeld(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.crystalBladedStaffLegacyWheelReplacementStaysRemovableWhenHeld(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void manaSlashOffhandSwingUsesOffhandCatalystAttackDamage(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.manaSlashOffhandSwingUsesOffhandCatalystAttackDamage(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void manaSlashAllowsNonSwingcastPrecondition(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.manaSlashAllowsNonSwingcastPrecondition(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void manaSlashRequiresSwingcastCatalystWhenContextIsActive(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.manaSlashRequiresSwingcastCatalystWhenContextIsActive(helper);
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -874,6 +874,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void manaSlashCatalystDamageAppliesAttributeEventOnce(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.manaSlashCatalystDamageAppliesAttributeEventOnce(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void manaSlashDamageMultiplierAppliesAfterMinimumDamage(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.manaSlashDamageMultiplierAppliesAfterMinimumDamage(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -844,6 +844,21 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffStartsWithHiddenManaSlash(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffStartsWithHiddenManaSlash(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffLegacyWheelReplacementStaysRemovableWhenHeld(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffLegacyWheelReplacementStaysRemovableWhenHeld(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void spellGunsKeepExpectedEnchantmentSurfaces(GameTestHelper helper) {
         EquipmentEnchantmentSurfaceGameTestScenarios.spellGunsKeepExpectedEnchantmentSurfaces(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/RightClickMagicWeaponGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/RightClickMagicWeaponGameTestScenarios.java
@@ -321,8 +321,15 @@ final class RightClickMagicWeaponGameTestScenarios extends ApprenticeCodexGameTe
                     helper,
                     new ItemStack(ItemRegistry.CRYSTAL_BLADED_STAFF.get()),
                     2,
+                    "item.apprenticecodex.swingcast.common.desc",
+                    "Crystal Bladed Staff should show swingcast tooltip after offhand priority tooltips"
+            );
+            assertTooltipKeyAt(
+                    helper,
+                    new ItemStack(ItemRegistry.CRYSTAL_BLADED_STAFF.get()),
+                    3,
                     "item.apprenticecodex.crystal_bladed_staff.desc",
-                    "Crystal Bladed Staff should show its ability tooltip after offhand priority tooltips"
+                    "Crystal Bladed Staff should keep its mana orb tooltip after swingcast tooltip"
             );
             assertTooltipKeyAt(
                     helper,
@@ -393,7 +400,7 @@ final class RightClickMagicWeaponGameTestScenarios extends ApprenticeCodexGameTe
             String profileName
     ) {
         var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), profileName);
-        var mainhandStack = new ItemStack(ItemRegistry.CRYSTAL_BLADED_STAFF.get());
+        var mainhandStack = new ItemStack(ItemRegistry.SMASHCAST_SCEPTER.get());
         player.setItemInHand(InteractionHand.MAIN_HAND, mainhandStack);
         player.setItemInHand(InteractionHand.OFF_HAND, offhandStack.copy());
         var magicData = MagicData.getPlayerMagicData(player);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -1,20 +1,34 @@
 package jp.aquafactory.apprenticecodex.gametest;
 
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.api.spells.CastResult;
+import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 
 import java.util.Set;
 
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
 import jp.aquafactory.apprenticecodex.item.AbstractSwingMagicItem;
 import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
 import jp.aquafactory.apprenticecodex.item.swingstaff.AbstractSwingcastStaffItem;
 import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastCooldownMode;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
+import jp.aquafactory.apprenticecodex.spell.manaslash.ManaSlash;
+import jp.aquafactory.apprenticecodex.spell.manaslash.ManaSlashProjectileEntity;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.MobType;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.AABB;
 
 final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScenarios {
     private SwingcastStaffGameTestScenarios() {
@@ -72,6 +86,23 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Crystal Bladed Staff legacy preset should stay locked after rescue");
         });
     }
+    static void crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeldInOffhand(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+            var stack = createLegacyCrystalBladedStaffContainer(SpellRegistry.MANA_SLASH.get(), 1, true);
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "crystal_bladed_staff_legacy_offhand");
+
+            player.setItemInHand(InteractionHand.OFF_HAND, stack);
+            item.inventoryTick(stack, helper.getLevel(), player, 40, false);
+
+            var spellContainer = ISpellContainer.get(stack);
+            helper.assertTrue(spellContainer != null, "Offhand Crystal Bladed Staff rescued preset container is null");
+            helper.assertTrue(!spellContainer.isSpellWheel(),
+                    "Offhand Crystal Bladed Staff legacy preset should be removed from the spell wheel");
+            assertSpellData(helper, spellContainer, 0, SpellRegistry.MANA_SLASH.get(), 1, true,
+                    "Offhand Crystal Bladed Staff legacy preset should stay locked after rescue");
+        });
+    }
     static void crystalBladedStaffLegacyWheelReplacementStaysRemovableWhenHeld(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
@@ -89,6 +120,91 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Crystal Bladed Staff legacy replacement should stay removable after rescue");
             helper.assertTrue(spellContainer.getSpellAtIndex(0).canRemove(),
                     "Crystal Bladed Staff legacy replacement should remain extractable after rescue");
+        });
+    }
+    static void manaSlashOffhandSwingUsesOffhandCatalystAttackDamage(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var stack = new ItemStack(item);
+        item.initializeSpellContainer(stack);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mana_slash_offhand_damage");
+        player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIAMOND_SWORD));
+        player.setItemInHand(InteractionHand.OFF_HAND, stack);
+
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Mana Slash offhand damage test could not resolve player mana data");
+        magicData.setMana(100.0F);
+
+        try (var ignored = SwingcastStaffCastContext.open(player.getUUID(), stack, SpellRegistry.MANA_SLASH.get())) {
+            SpellRegistry.MANA_SLASH.get().onCast(
+                    helper.getLevel(),
+                    1,
+                    player,
+                    CastSource.SWORD,
+                    magicData
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to close Mana Slash swingcast context.", e);
+        }
+
+        helper.succeedWhen(() -> {
+            var projectiles = helper.getLevel().getEntitiesOfClass(
+                    ManaSlashProjectileEntity.class,
+                    new AABB(player.blockPosition()).inflate(8.0D)
+            );
+            helper.assertTrue(projectiles.size() == 1,
+                    "Mana Slash offhand damage test should spawn exactly one projectile but got " + projectiles.size());
+
+            var damageTag = new CompoundTag();
+            projectiles.get(0).saveWithoutId(damageTag);
+            var actualDamage = damageTag.getFloat("Damage");
+            var expectedDamage = Math.max(
+                    1.0F,
+                    ManaSlash.resolveCatalystWeaponDamage(player, stack, MobType.UNDEFINED)
+                            * SpellRegistry.MANA_SLASH.get().getSpellPower(1, player) / 100.0F
+                            * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.MANA_SLASH)
+            );
+            helper.assertTrue(Math.abs(actualDamage - expectedDamage) < 1.0e-4F,
+                    "Mana Slash offhand damage should use offhand catalyst attack damage: expected "
+                            + expectedDamage + " but got " + actualDamage);
+        });
+    }
+    static void manaSlashAllowsNonSwingcastPrecondition(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mana_slash_non_swingcast");
+            player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIAMOND_SWORD));
+            var magicData = MagicData.getPlayerMagicData(player);
+            helper.assertTrue(magicData != null, "Mana Slash non-swingcast test could not resolve player mana data");
+            magicData.setMana(100.0F);
+
+            var castResult = SpellRegistry.MANA_SLASH.get().canBeCastedBy(1, CastSource.SWORD, magicData, player);
+            helper.assertTrue(castResult.isSuccess(),
+                    "Mana Slash should keep non-swingcast cast paths available");
+        });
+    }
+    static void manaSlashRequiresSwingcastCatalystWhenContextIsActive(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mana_slash_missing_catalyst");
+            var magicData = MagicData.getPlayerMagicData(player);
+            helper.assertTrue(magicData != null, "Mana Slash missing catalyst test could not resolve player mana data");
+            magicData.setMana(100.0F);
+
+            CastResult castResult;
+            try (var ignored = SwingcastStaffCastContext.open(player.getUUID(), ItemStack.EMPTY, SpellRegistry.MANA_SLASH.get())) {
+                castResult = SpellRegistry.MANA_SLASH.get().canBeCastedBy(1, CastSource.SWORD, magicData, player);
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to close Mana Slash swingcast context.", e);
+            }
+
+            helper.assertTrue(castResult.type == CastResult.Type.FAILURE,
+                    "Mana Slash should fail before swingcast when swingcast catalyst is missing");
+            helper.assertTrue(castResult.message != null,
+                    "Mana Slash missing catalyst failure should provide a message");
+            var contents = castResult.message.getContents();
+            helper.assertTrue(contents instanceof TranslatableContents,
+                    "Mana Slash missing catalyst message should be translatable");
+            var translatableContents = (TranslatableContents) contents;
+            helper.assertTrue("ui.apprenticecodex.mana_slash.missing_catalyst".equals(translatableContents.getKey()),
+                    "Mana Slash missing catalyst message should use the dedicated translation key");
         });
     }
     static void copperSwingcastStaffReplacementSpellStaysRemovableAfterNormalization(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -6,6 +6,7 @@ import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 
 import java.util.Set;
+import java.util.UUID;
 
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
@@ -25,7 +26,10 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.AABB;
@@ -165,6 +169,26 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
             helper.assertTrue(Math.abs(actualDamage - expectedDamage) < 1.0e-4F,
                     "Mana Slash offhand damage should use offhand catalyst attack damage: expected "
                             + expectedDamage + " but got " + actualDamage);
+        });
+    }
+    static void manaSlashCatalystDamageUsesStackAttributeModifiers(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mana_slash_stack_attribute");
+            var catalystStack = new ItemStack(Items.STICK);
+            catalystStack.addAttributeModifier(
+                    Attributes.ATTACK_DAMAGE,
+                    new AttributeModifier(
+                            UUID.fromString("1af17cb4-75be-44b8-bd30-9be5760c66d9"),
+                            "Mana Slash GameTest attack damage",
+                            20.0D,
+                            AttributeModifier.Operation.ADDITION
+                    ),
+                    EquipmentSlot.MAINHAND
+            );
+
+            var resolvedDamage = ManaSlash.resolveCatalystWeaponDamage(player, catalystStack, MobType.UNDEFINED);
+            helper.assertTrue(Math.abs(resolvedDamage - 21.0F) < 1.0e-4F,
+                    "Mana Slash catalyst damage should include stack AttributeModifiers NBT: " + resolvedDamage);
         });
     }
     static void manaSlashDamageMultiplierAppliesAfterMinimumDamage(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -7,6 +7,8 @@ import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
@@ -33,6 +35,8 @@ import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.AABB;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ItemAttributeModifierEvent;
 
 final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScenarios {
     private SwingcastStaffGameTestScenarios() {
@@ -191,6 +195,51 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Mana Slash catalyst damage should include stack AttributeModifiers NBT: " + resolvedDamage);
         });
     }
+
+    static void manaSlashCatalystDamageAppliesAttributeEventOnce(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mana_slash_attribute_event");
+            var catalystStack = new ItemStack(Items.STICK);
+            catalystStack.addAttributeModifier(
+                    Attributes.ATTACK_DAMAGE,
+                    new AttributeModifier(
+                            UUID.fromString("9ecb8ab9-6cf7-46e1-befa-851e53146876"),
+                            "Mana Slash GameTest NBT attack damage",
+                            20.0D,
+                            AttributeModifier.Operation.ADDITION
+                    ),
+                    EquipmentSlot.MAINHAND
+            );
+
+            var eventCalls = new AtomicInteger();
+            Consumer<ItemAttributeModifierEvent> listener = event -> {
+                if (event.getItemStack() == catalystStack && event.getSlotType() == EquipmentSlot.MAINHAND) {
+                    eventCalls.incrementAndGet();
+                    event.addModifier(
+                            Attributes.ATTACK_DAMAGE,
+                            new AttributeModifier(
+                                    UUID.fromString("98624507-b4c7-4188-9b1c-b058c8168a6a"),
+                                    "Mana Slash GameTest event attack damage",
+                                    5.0D,
+                                    AttributeModifier.Operation.ADDITION
+                            )
+                    );
+                }
+            };
+
+            MinecraftForge.EVENT_BUS.addListener(listener);
+            try {
+                var resolvedDamage = ManaSlash.resolveCatalystWeaponDamage(player, catalystStack, MobType.UNDEFINED);
+                helper.assertTrue(eventCalls.get() == 1,
+                        "Mana Slash catalyst damage should fire ItemAttributeModifierEvent once but got " + eventCalls.get());
+                helper.assertTrue(Math.abs(resolvedDamage - 26.0F) < 1.0e-4F,
+                        "Mana Slash catalyst damage should include NBT and one event modifier: " + resolvedDamage);
+            } finally {
+                MinecraftForge.EVENT_BUS.unregister(listener);
+            }
+        });
+    }
+
     static void manaSlashDamageMultiplierAppliesAfterMinimumDamage(GameTestHelper helper) {
         var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mana_slash_low_multiplier");
         var catalystStack = new ItemStack(Items.STICK);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -5,11 +5,14 @@ import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import java.util.Set;
 
 import jp.aquafactory.apprenticecodex.item.AbstractSwingMagicItem;
+import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
+import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
 import jp.aquafactory.apprenticecodex.item.swingstaff.AbstractSwingcastStaffItem;
 import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastCooldownMode;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
+import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.item.ItemStack;
 
@@ -35,6 +38,57 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Copper Swingcast Staff preset spell mismatch: " + spellData.getSpell().getSpellResource());
             helper.assertTrue(spellData.getLevel() == 1,
                     "Copper Swingcast Staff preset spell level mismatch: " + spellData.getLevel());
+        });
+    }
+    static void crystalBladedStaffStartsWithHiddenManaSlash(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+            var stack = new ItemStack(item);
+            item.initializeSpellContainer(stack);
+
+            helper.assertTrue(item instanceof SwingTriggeredMagicItem,
+                    "Crystal Bladed Staff should trigger imbued spells on swing");
+            var spellContainer = ISpellContainer.get(stack);
+            helper.assertTrue(spellContainer != null, "Crystal Bladed Staff spell container is null");
+            helper.assertTrue(!spellContainer.isSpellWheel(),
+                    "Crystal Bladed Staff preset spell should stay hidden from the spell wheel");
+            assertSpellData(helper, spellContainer, 0, SpellRegistry.MANA_SLASH.get(), 1, true,
+                    "Crystal Bladed Staff should start with locked Mana Slash");
+        });
+    }
+    static void crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+            var stack = createLegacyCrystalBladedStaffContainer(SpellRegistry.MANA_SLASH.get(), 1, true);
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "crystal_bladed_staff_legacy_preset");
+
+            item.inventoryTick(stack, helper.getLevel(), player, 0, true);
+
+            var spellContainer = ISpellContainer.get(stack);
+            helper.assertTrue(spellContainer != null, "Crystal Bladed Staff rescued preset container is null");
+            helper.assertTrue(!spellContainer.isSpellWheel(),
+                    "Crystal Bladed Staff legacy preset should be removed from the spell wheel");
+            assertSpellData(helper, spellContainer, 0, SpellRegistry.MANA_SLASH.get(), 1, true,
+                    "Crystal Bladed Staff legacy preset should stay locked after rescue");
+        });
+    }
+    static void crystalBladedStaffLegacyWheelReplacementStaysRemovableWhenHeld(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+            var replacementSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+            var stack = createLegacyCrystalBladedStaffContainer(replacementSpell, 1, false);
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "crystal_bladed_staff_legacy_replacement");
+
+            item.inventoryTick(stack, helper.getLevel(), player, 0, true);
+
+            var spellContainer = ISpellContainer.get(stack);
+            helper.assertTrue(spellContainer != null, "Crystal Bladed Staff rescued replacement container is null");
+            helper.assertTrue(!spellContainer.isSpellWheel(),
+                    "Crystal Bladed Staff legacy replacement should be removed from the spell wheel");
+            assertSpellData(helper, spellContainer, 0, replacementSpell, 1, false,
+                    "Crystal Bladed Staff legacy replacement should stay removable after rescue");
+            helper.assertTrue(spellContainer.getSpellAtIndex(0).canRemove(),
+                    "Crystal Bladed Staff legacy replacement should remain extractable after rescue");
         });
     }
     static void copperSwingcastStaffReplacementSpellStaysRemovableAfterNormalization(GameTestHelper helper) {
@@ -189,5 +243,17 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Netherite Swingcast Staff"
             );
         });
+    }
+
+    private static ItemStack createLegacyCrystalBladedStaffContainer(
+            io.redspace.ironsspellbooks.api.spells.AbstractSpell spell,
+            int spellLevel,
+            boolean locked
+    ) {
+        var stack = new ItemStack(ItemRegistry.CRYSTAL_BLADED_STAFF.get());
+        var mutable = ISpellContainer.create(1, true, false).mutableCopy();
+        mutable.addSpellAtIndex(spell, spellLevel, 0, locked);
+        ISpellContainer.set(stack, mutable.toImmutable());
+        return stack;
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -161,11 +161,49 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                     1.0F,
                     ManaSlash.resolveCatalystWeaponDamage(player, stack, MobType.UNDEFINED)
                             * SpellRegistry.MANA_SLASH.get().getSpellPower(1, player) / 100.0F
-                            * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.MANA_SLASH)
-            );
+            ) * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.MANA_SLASH);
             helper.assertTrue(Math.abs(actualDamage - expectedDamage) < 1.0e-4F,
                     "Mana Slash offhand damage should use offhand catalyst attack damage: expected "
                             + expectedDamage + " but got " + actualDamage);
+        });
+    }
+    static void manaSlashDamageMultiplierAppliesAfterMinimumDamage(GameTestHelper helper) {
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mana_slash_low_multiplier");
+        var catalystStack = new ItemStack(Items.STICK);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Mana Slash low multiplier test could not resolve player mana data");
+        magicData.setMana(100.0F);
+
+        try (var configOverride = ApprenticeCodexServerConfig.useDamageMultiplierOverrideForGameTest(
+                DamageMultiplierKey.MANA_SLASH,
+                0.5D
+        );
+             var ignored = SwingcastStaffCastContext.open(player.getUUID(), catalystStack, SpellRegistry.MANA_SLASH.get())) {
+            SpellRegistry.MANA_SLASH.get().onCast(
+                    helper.getLevel(),
+                    1,
+                    player,
+                    CastSource.SWORD,
+                    magicData
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to close Mana Slash low multiplier test context.", e);
+        }
+
+        helper.succeedWhen(() -> {
+            var projectiles = helper.getLevel().getEntitiesOfClass(
+                    ManaSlashProjectileEntity.class,
+                    new AABB(player.blockPosition()).inflate(8.0D)
+            );
+            helper.assertTrue(projectiles.size() == 1,
+                    "Mana Slash low multiplier test should spawn exactly one projectile but got " + projectiles.size());
+
+            var damageTag = new CompoundTag();
+            projectiles.get(0).saveWithoutId(damageTag);
+            var actualDamage = damageTag.getFloat("Damage");
+            helper.assertTrue(Math.abs(actualDamage - 0.5F) < 1.0e-4F,
+                    "Mana Slash low damage multiplier should apply after minimum damage: expected 0.5 but got "
+                            + actualDamage);
         });
     }
     static void manaSlashAllowsNonSwingcastPrecondition(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CrystalBladedStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CrystalBladedStaff.java
@@ -93,9 +93,7 @@ public class CrystalBladedStaff extends AbstractSwingMagicItem implements GeoIte
     @Override
     public void inventoryTick(@NotNull ItemStack stack, @NotNull Level level, @NotNull Entity entity, int slotId, boolean isSelected) {
         super.inventoryTick(stack, level, entity, slotId, isSelected);
-        if (isSelected) {
-            initializeSpellContainer(stack);
-        }
+        initializeSpellContainer(stack);
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CrystalBladedStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CrystalBladedStaff.java
@@ -1,6 +1,8 @@
 package jp.aquafactory.apprenticecodex.item;
 
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
+import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
+import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.item.UniqueItem;
 import jp.aquafactory.apprenticecodex.item.crystalbladedstaff.CrystalBladedStaffManaRecoveryManager;
 import jp.aquafactory.apprenticecodex.item.crystalbladedstaff.CrystalBladedStaffManaRecoveryManager.PendingManaRecovery;
@@ -8,10 +10,13 @@ import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.ManaSiphonOrbEffectPacket;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import jp.aquafactory.apprenticecodex.renderer.item.CrystalBladedStaffRenderer;
+import jp.aquafactory.apprenticecodex.utility.InitialSpellContainerHelper;
+import jp.aquafactory.apprenticecodex.utility.PresetSpellContainerStateHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Rarity;
@@ -33,7 +38,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import net.minecraft.world.phys.Vec3;
 
-public class CrystalBladedStaff extends AbstractRightClickMagicWeaponItem implements GeoItem, UniqueItem {
+public class CrystalBladedStaff extends AbstractSwingMagicItem implements GeoItem, UniqueItem {
     private static final String MAIN_CONTROLLER = "main";
     private static final String ACTIVATE_ANIMATION = "activate";
     private static final RawAnimation ANIM_IDLE = RawAnimation.begin().thenLoop("idle");
@@ -62,7 +67,6 @@ public class CrystalBladedStaff extends AbstractRightClickMagicWeaponItem implem
                 new Item.Properties().stacksTo(1).rarity(Rarity.RARE),
                 SpellRegistry.MANA_SLASH,
                 1,
-                true,
                 ENCHANTMENT_VALUE,
                 "CrystalBladedStaff",
                 ATTACK_DAMAGE,
@@ -71,6 +75,63 @@ public class CrystalBladedStaff extends AbstractRightClickMagicWeaponItem implem
                 bonus(AttributeRegistry.SPELL_POWER, SPELL_POWER_BONUS, net.minecraft.world.entity.ai.attributes.AttributeModifier.Operation.MULTIPLY_BASE, "spell_power")
         );
         GeoItem.registerSyncedAnimatable(this);
+    }
+
+    @Override
+    public @NotNull ItemStack getDefaultInstance() {
+        var stack = super.getDefaultInstance();
+        initializeSpellContainer(stack);
+        return stack;
+    }
+
+    @Override
+    public void onCraftedBy(@NotNull ItemStack stack, @NotNull Level level, @NotNull net.minecraft.world.entity.player.Player player) {
+        super.onCraftedBy(stack, level, player);
+        initializeSpellContainer(stack);
+    }
+
+    @Override
+    public void inventoryTick(@NotNull ItemStack stack, @NotNull Level level, @NotNull Entity entity, int slotId, boolean isSelected) {
+        super.inventoryTick(stack, level, entity, slotId, isSelected);
+        if (isSelected) {
+            initializeSpellContainer(stack);
+        }
+    }
+
+    @Override
+    protected boolean normalizeLegacyOverriddenSpellContainerIfNeeded(ItemStack stack) {
+        var spellContainer = ISpellContainer.get(stack);
+        if (spellContainer == null) {
+            return false;
+        }
+
+        if (!spellContainer.isSpellWheel()) {
+            return super.normalizeLegacyOverriddenSpellContainerIfNeeded(stack);
+        }
+
+        // 旧版の刃の結晶杖は Mana Slash/差し替え Imbue を spell wheel に出していた。
+        // 左クリック発動へ移行した後も既存ワールドの杖が同じ魔法を保持しつつ、wheel には出ないよう正規化する。
+        var spellData = spellContainer.getSpellAtIndex(0);
+        var normalized = ISpellContainer.create(1, false, false).mutableCopy();
+        if (spellData != SpellData.EMPTY && canImbueSpell(spellData)) {
+            var locked = matchesConfiguredPresetSpell(spellData) && !spellData.canRemove();
+            if (!normalized.addSpellAtIndex(spellData.getSpell(), spellData.getLevel(), 0, locked)) {
+                return false;
+            }
+
+            ISpellContainer.set(stack, normalized.toImmutable());
+            if (locked) {
+                PresetSpellContainerStateHelper.clearRememberedState(stack);
+            } else {
+                PresetSpellContainerStateHelper.rememberOverridden(stack, spellData);
+            }
+            return true;
+        }
+
+        InitialSpellContainerHelper.addInitialSpellIfEnabled(normalized, SpellRegistry.MANA_SLASH, 1, 0, true);
+        ISpellContainer.set(stack, normalized.toImmutable());
+        PresetSpellContainerStateHelper.clearRememberedState(stack);
+        return true;
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/swingstaff/SwingcastStaffCastContext.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/swingstaff/SwingcastStaffCastContext.java
@@ -5,6 +5,7 @@ import net.minecraft.world.item.ItemStack;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Optional;
 import java.util.UUID;
 
 public final class SwingcastStaffCastContext implements AutoCloseable {
@@ -18,9 +19,18 @@ public final class SwingcastStaffCastContext implements AutoCloseable {
     }
 
     public static SwingcastStaffCastContext open(UUID playerId, ItemStack stack, AbstractSpell spell) {
-        var entry = new Entry(playerId, stack.getItem(), spell.getSpellId());
+        var entry = new Entry(playerId, stack.copy(), spell.getSpellId());
         ACTIVE_CONTEXTS.get().push(entry);
         return new SwingcastStaffCastContext(entry);
+    }
+
+    public static Optional<ItemStack> getCastingStack(UUID playerId, AbstractSpell spell) {
+        if (!matches(playerId, spell.getSpellId())) {
+            return Optional.empty();
+        }
+
+        var current = ACTIVE_CONTEXTS.get().peek();
+        return current == null ? Optional.empty() : Optional.of(current.stack());
     }
 
     static boolean matches(UUID playerId, ItemStack stack, AbstractSpell spell) {
@@ -29,7 +39,7 @@ public final class SwingcastStaffCastContext implements AutoCloseable {
         }
 
         var current = ACTIVE_CONTEXTS.get().peek();
-        return current != null && current.item() == stack.getItem();
+        return current != null && current.stack().getItem() == stack.getItem();
     }
 
     public static boolean matches(UUID playerId, String spellId) {
@@ -59,6 +69,6 @@ public final class SwingcastStaffCastContext implements AutoCloseable {
         }
     }
 
-    private record Entry(UUID playerId, net.minecraft.world.item.Item item, String spellId) {
+    private record Entry(UUID playerId, ItemStack stack, String spellId) {
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
@@ -114,7 +114,7 @@ public class ManaSlash extends AbstractSpell {
             Attribute attribute,
             double baseValue
     ) {
-        var event = new ItemAttributeModifierEvent(stack, slot, stack.getItem().getAttributeModifiers(slot, stack));
+        var event = new ItemAttributeModifierEvent(stack, slot, stack.getAttributeModifiers(slot));
         MinecraftForge.EVENT_BUS.post(event);
 
         var valueWithAdditions = baseValue;

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
@@ -1,5 +1,7 @@
 package jp.aquafactory.apprenticecodex.spell.manaslash;
 
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import io.redspace.ironsspellbooks.api.config.DefaultConfig;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.SchoolRegistry;
@@ -15,6 +17,7 @@ import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.EquipmentSlot;
@@ -29,6 +32,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ItemAttributeModifierEvent;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.List;
 import java.util.Optional;
@@ -114,7 +118,7 @@ public class ManaSlash extends AbstractSpell {
             Attribute attribute,
             double baseValue
     ) {
-        var event = new ItemAttributeModifierEvent(stack, slot, stack.getAttributeModifiers(slot));
+        var event = new ItemAttributeModifierEvent(stack, slot, resolveBaseAttributeModifiers(stack, slot));
         MinecraftForge.EVENT_BUS.post(event);
 
         var valueWithAdditions = baseValue;
@@ -139,6 +143,35 @@ public class ManaSlash extends AbstractSpell {
         }
 
         return valueWithTotalMultipliers;
+    }
+
+    private static Multimap<Attribute, AttributeModifier> resolveBaseAttributeModifiers(ItemStack stack, EquipmentSlot slot) {
+        if (!stack.hasTag() || !stack.getOrCreateTag().contains("AttributeModifiers", 9)) {
+            return stack.getItem().getAttributeModifiers(slot, stack);
+        }
+
+        var modifiers = HashMultimap.<Attribute, AttributeModifier>create();
+        var nbtModifiers = stack.getOrCreateTag().getList("AttributeModifiers", 10);
+        for (var i = 0; i < nbtModifiers.size(); ++i) {
+            var modifierTag = nbtModifiers.getCompound(i);
+            if (isAttributeModifierForSlot(modifierTag, slot)) {
+                var attribute = ForgeRegistries.ATTRIBUTES.getValue(
+                        ResourceLocation.tryParse(modifierTag.getString("AttributeName"))
+                );
+                var modifier = AttributeModifier.load(modifierTag);
+                if (attribute != null
+                        && modifier != null
+                        && modifier.getId().getLeastSignificantBits() != 0L
+                        && modifier.getId().getMostSignificantBits() != 0L) {
+                    modifiers.put(attribute, modifier);
+                }
+            }
+        }
+        return modifiers;
+    }
+
+    private static boolean isAttributeModifierForSlot(CompoundTag modifierTag, EquipmentSlot slot) {
+        return !modifierTag.contains("Slot", 8) || modifierTag.getString("Slot").equals(slot.getName());
     }
 
     private Optional<ItemStack> resolveCatalystStack(LivingEntity entity) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
@@ -74,16 +74,24 @@ public class ManaSlash extends AbstractSpell {
 
     private float getDamage(int spellLevel, LivingEntity entity, ItemStack catalystStack) {
         // ベースのマナパワーが低いので武器ダメージより下がるのは意図的.
-        return Math.max(
+        var rawDamage = Math.max(
                 1,
                 resolveCatalystWeaponDamage(entity, catalystStack, MobType.UNDEFINED)
-                        * getReferencedWeaponDamagePercent(spellLevel, entity) / 100.0f
+                        * getSpellPowerPercent(spellLevel, entity) / 100.0f
         );
+        return rawDamage * getDamageMultiplier();
     }
 
     private float getReferencedWeaponDamagePercent(int spellLevel, LivingEntity entity) {
-        return getSpellPower(spellLevel, entity)
-                * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.MANA_SLASH);
+        return getSpellPowerPercent(spellLevel, entity) * getDamageMultiplier();
+    }
+
+    private float getSpellPowerPercent(int spellLevel, LivingEntity entity) {
+        return getSpellPower(spellLevel, entity);
+    }
+
+    private float getDamageMultiplier() {
+        return ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.MANA_SLASH);
     }
 
     public static float resolveCatalystWeaponDamage(LivingEntity entity, ItemStack catalystStack, MobType mobType) {
@@ -191,11 +199,14 @@ public class ManaSlash extends AbstractSpell {
         projectile.shoot(entity.getLookAngle());
         projectile.setDamage(catalystStack
                 .map(stack -> getDamage(spellLevel, entity, stack))
-                .orElseGet(() -> Math.max(
-                        1,
-                        Utils.getWeaponDamage(entity, MobType.UNDEFINED)
-                                * getReferencedWeaponDamagePercent(spellLevel, entity) / 100.0f
-                )));
+                .orElseGet(() -> {
+                    var rawDamage = Math.max(
+                            1,
+                            Utils.getWeaponDamage(entity, MobType.UNDEFINED)
+                                    * getSpellPowerPercent(spellLevel, entity) / 100.0f
+                    );
+                    return rawDamage * getDamageMultiplier();
+                }));
         level.addFreshEntity(projectile);
         super.onCast(level, spellLevel, entity, castSource, playerMagicData);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
@@ -9,20 +9,36 @@ import io.redspace.ironsspellbooks.api.util.Utils;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
+import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.MobType;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.ItemAttributeModifierEvent;
 
 import java.util.List;
 import java.util.Optional;
 
 public class ManaSlash extends AbstractSpell {
+    private static final String DAMAGE_MULTIPLIER_KEY =
+            "ui.apprenticecodex.referenced_weapon_damage_multiplier";
+    private static final String MISSING_CATALYST_KEY =
+            "ui.apprenticecodex.mana_slash.missing_catalyst";
+
     private final ResourceLocation spellId = ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "mana_slash");
 
     private final DefaultConfig config = new DefaultConfig()
@@ -49,14 +65,85 @@ public class ManaSlash extends AbstractSpell {
     @Override
     public List<MutableComponent> getUniqueInfo(int spellLevel, LivingEntity caster) {
         return List.of(
-                Component.translatable("ui.irons_spellbooks.damage", Utils.stringTruncation(getDamage(spellLevel, caster), 2))
+                Component.translatable(
+                        DAMAGE_MULTIPLIER_KEY,
+                        Utils.stringTruncation(getReferencedWeaponDamagePercent(spellLevel, caster), 1)
+                )
         );
     }
 
-    private float getDamage(int spellLevel, LivingEntity entity) {
+    private float getDamage(int spellLevel, LivingEntity entity, ItemStack catalystStack) {
         // ベースのマナパワーが低いので武器ダメージより下がるのは意図的.
-        var rawDamage = Math.max(1, Utils.getWeaponDamage(entity, MobType.UNDEFINED) * getSpellPower(spellLevel, entity) / 100.0f);
-        return rawDamage * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.MANA_SLASH);
+        return Math.max(
+                1,
+                resolveCatalystWeaponDamage(entity, catalystStack, MobType.UNDEFINED)
+                        * getReferencedWeaponDamagePercent(spellLevel, entity) / 100.0f
+        );
+    }
+
+    private float getReferencedWeaponDamagePercent(int spellLevel, LivingEntity entity) {
+        return getSpellPower(spellLevel, entity)
+                * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.MANA_SLASH);
+    }
+
+    public static float resolveCatalystWeaponDamage(LivingEntity entity, ItemStack catalystStack, MobType mobType) {
+        if (entity == null || catalystStack == null || catalystStack.isEmpty()) {
+            return 0.0f;
+        }
+
+        var baseDamage = entity.getAttributeBaseValue(Attributes.ATTACK_DAMAGE);
+        var displayDamage = resolveDisplayedAttributeValue(catalystStack, EquipmentSlot.MAINHAND, Attributes.ATTACK_DAMAGE, baseDamage);
+        if (displayDamage <= baseDamage) {
+            displayDamage -= baseDamage;
+        }
+
+        return (float) displayDamage + EnchantmentHelper.getDamageBonus(catalystStack, mobType);
+    }
+
+    private static double resolveDisplayedAttributeValue(
+            ItemStack stack,
+            EquipmentSlot slot,
+            Attribute attribute,
+            double baseValue
+    ) {
+        var event = new ItemAttributeModifierEvent(stack, slot, stack.getItem().getAttributeModifiers(slot, stack));
+        MinecraftForge.EVENT_BUS.post(event);
+
+        var valueWithAdditions = baseValue;
+        for (var modifier : event.getModifiers().get(attribute)) {
+            if (modifier.getOperation() == AttributeModifier.Operation.ADDITION) {
+                valueWithAdditions += modifier.getAmount();
+            }
+        }
+
+        var valueWithBaseMultipliers = valueWithAdditions;
+        for (var modifier : event.getModifiers().get(attribute)) {
+            if (modifier.getOperation() == AttributeModifier.Operation.MULTIPLY_BASE) {
+                valueWithBaseMultipliers += valueWithAdditions * modifier.getAmount();
+            }
+        }
+
+        var valueWithTotalMultipliers = valueWithBaseMultipliers;
+        for (var modifier : event.getModifiers().get(attribute)) {
+            if (modifier.getOperation() == AttributeModifier.Operation.MULTIPLY_TOTAL) {
+                valueWithTotalMultipliers *= 1.0d + modifier.getAmount();
+            }
+        }
+
+        return valueWithTotalMultipliers;
+    }
+
+    private Optional<ItemStack> resolveCatalystStack(LivingEntity entity) {
+        if (entity == null) {
+            return Optional.empty();
+        }
+
+        return SwingcastStaffCastContext.getCastingStack(entity.getUUID(), this)
+                .filter(stack -> !stack.isEmpty());
+    }
+
+    private boolean hasSwingcastContext(LivingEntity entity) {
+        return entity != null && SwingcastStaffCastContext.matches(entity.getUUID(), getSpellId());
     }
 
     @Override
@@ -85,11 +172,30 @@ public class ManaSlash extends AbstractSpell {
     }
 
     @Override
+    public CastResult canBeCastedBy(int spellLevel, CastSource castSource, MagicData playerMagicData, Player player) {
+        if (hasSwingcastContext(player) && resolveCatalystStack(player).isEmpty()) {
+            return new CastResult(
+                    CastResult.Type.FAILURE,
+                    Component.translatable(MISSING_CATALYST_KEY).withStyle(ChatFormatting.RED)
+            );
+        }
+
+        return super.canBeCastedBy(spellLevel, castSource, playerMagicData, player);
+    }
+
+    @Override
     public void onCast(Level level, int spellLevel, LivingEntity entity, CastSource castSource, MagicData playerMagicData) {
+        var catalystStack = resolveCatalystStack(entity);
         var projectile = new ManaSlashProjectileEntity(EntityRegistry.MANA_SLASH_PROJECTILE.get(), level, entity);
         projectile.setPos(entity.getEyePosition().add(entity.getLookAngle().scale(0.35d)));
         projectile.shoot(entity.getLookAngle());
-        projectile.setDamage(getDamage(spellLevel, entity));
+        projectile.setDamage(catalystStack
+                .map(stack -> getDamage(spellLevel, entity, stack))
+                .orElseGet(() -> Math.max(
+                        1,
+                        Utils.getWeaponDamage(entity, MobType.UNDEFINED)
+                                * getReferencedWeaponDamagePercent(spellLevel, entity) / 100.0f
+                )));
         level.addFreshEntity(projectile);
         super.onCast(level, spellLevel, entity, castSource, playerMagicData);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/manaslash/ManaSlash.java
@@ -29,14 +29,14 @@ public class ManaSlash extends AbstractSpell {
             .setMinRarity(SpellRarity.RARE)
             .setSchoolResource(SchoolRegistry.ENDER_RESOURCE)
             .setMaxLevel(1)
-            .setCooldownSeconds(8)
+            .setCooldownSeconds(0)
             .setAllowCrafting(false)
             .build();
 
     public ManaSlash() {
         baseSpellPower = 75;
         spellPowerPerLevel = 50;
-        baseManaCost = 15;
+        baseManaCost = 30;
         manaCostPerLevel = 0;
         castTime = 0;
     }
@@ -81,7 +81,7 @@ public class ManaSlash extends AbstractSpell {
 
     @Override
     public AnimationHolder getCastStartAnimation() {
-        return SpellAnimations.SLASH_ANIMATION;
+        return AnimationHolder.pass();
     }
 
     @Override

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -649,7 +649,7 @@
   "spell.apprenticecodex.earth_forge.guide": "Creates a flat patch of dirt blocks at your line of sight. While sneaking, the area is reduced to a single block.",
   "spell.apprenticecodex.moon_light.guide": "Summons a katana from beyond the laws of this world and delivers a single flash-cut. The blade's moonlit power then rends space—sharp and deep. The cast cannot be interrupted.",
   "spell.apprenticecodex.mana_charge.guide": "Recover mana quickly during casting.",
-  "spell.apprenticecodex.mana_slash.guide": "Launches a blade of condensed mana. Its damage depends heavily on your weapon. On hit, it creates orbs that restore mana.",
+  "spell.apprenticecodex.mana_slash.guide": "A latent spell unique to the Crystal Bladed Staff. Launches a blade of condensed mana. Its damage scales with the staff's attack damage. On hit, it creates orbs that restore mana.",
   "spell.apprenticecodex.force_field.guide": "Deploys an invisible field that repels enemy attacks from any direction. It consumes a large amount of mana when it knocks something away, but it can also repel certain spells. An imitation of the magic used by a long-lived race from another realm.",
   "spell.apprenticecodex.precision_jack.guide": "Summon a magical knife to cleave your target. Expect a lot more drops than usual, but you need to rotate a significant number of times before it can be activated.",
   "spell.apprenticecodex.auto_magnet.guide": "Summon a magical magnet to follow you. The magnet collects nearby items and experience orbs and transfers them to you. Item collection stops while your inventory is full.",

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -688,6 +688,7 @@
   "ui.apprenticecodex.headshot_damage_multiplier": "Headshot Damage Multiplier: %d%%",
   "ui.apprenticecodex.sneak_damage_multiplier": "Sneak Damage Multiplier: %d%%",
   "ui.apprenticecodex.reflect_damage_multiplier": "Reflect Damage Multiplier: %d%%",
+  "ui.apprenticecodex.referenced_weapon_damage_multiplier": "Referenced attack damage multiplier: %s%%",
   "ui.apprenticecodex.start_up_time": "Start up time: %s ",
   "ui.apprenticecodex.warm_up_time": "Max warm up time: %s ",
   "ui.apprenticecodex.tree_cut_time": "Minimum Tree cut time: %s ",
@@ -782,6 +783,7 @@
   "ui.apprenticecodex.echo_cast.current_count": "Mana for %d casts echoes around you...",
   "ui.apprenticecodex.echo_cast.max_reached": "The echoing mana has reached full saturation!",
   "ui.apprenticecodex.echo_cast.cannot_echo_more": "You can't echo any more mana!",
+  "ui.apprenticecodex.mana_slash.missing_catalyst": "No catalyst to form the blade!",
   "ui.apprenticecodex.divine_possession.required_all_pieces": "Divine Possession requires the full Element Maiden Robe set!",
 
   "ui.apprenticecodex.elemental_bow.mode_switched": "Switched firing mode to %s",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -654,7 +654,7 @@
   "spell.apprenticecodex.earth_forge.guide": "視線先に土ブロックを平面に生成する。スニークをしていると範囲を1ブロックのみに変化させる。",
   "spell.apprenticecodex.moon_light.guide": "世界の理の外から刀を召喚して一閃する。一閃した刀の魔力は空間を鋭く深く裂く。発動が阻止されることはない。",
   "spell.apprenticecodex.mana_charge.guide": "使用中、マナを急速に回復する。",
-  "spell.apprenticecodex.mana_slash.guide": "魔力を凝縮した刃を放つ。威力は武器に強く依存する。命中時にマナを回復するオーブを生成する。",
+  "spell.apprenticecodex.mana_slash.guide": "刃の結晶杖固有の潜在魔法。魔力を凝縮した刃を放つ。威力は結晶杖の攻撃力に比例する。命中時にマナを回復するオーブを生成する。",
   "spell.apprenticecodex.force_field.guide": "敵の攻撃を方向問わず弾く不可視のフィールドを展開する。弾き飛ばした際に大きくマナを消費するが特定の魔法も弾くことができる。異界の長命種の魔法の模造品。",
   "spell.apprenticecodex.precision_jack.guide": "魔法のナイフを召喚して目の前の対象を裂く。普段よりかなり多くのドロップを期待できるが、発動までに相当数回転させる必要がある。",
   "spell.apprenticecodex.auto_magnet.guide": "魔導仕掛けの磁石を召喚し追従させる。磁石は近くのアイテムと経験値オーブを回収して術者へ転送するが、インベントリがいっぱいの間はアイテムを回収しない。",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -693,6 +693,7 @@
   "ui.apprenticecodex.headshot_damage_multiplier": "ヘッドショット倍率: %d%%",
   "ui.apprenticecodex.sneak_damage_multiplier": "隠密ダメージ倍率: %d%%",
   "ui.apprenticecodex.reflect_damage_multiplier": "反射ダメージ倍率: %d%%",
+  "ui.apprenticecodex.referenced_weapon_damage_multiplier": "参照攻撃力倍率: %s%%",
   "ui.apprenticecodex.start_up_time": "起動時間: %s ",
   "ui.apprenticecodex.warm_up_time": "最高速度までの時間: %s ",
   "ui.apprenticecodex.tree_cut_time": "伐採にかかる最短時間: %s ",
@@ -788,6 +789,7 @@
   "ui.apprenticecodex.echo_cast.current_count": "%d回分の魔力が辺りに残響している...",
   "ui.apprenticecodex.echo_cast.max_reached": "残響している魔力が飽和しきった！",
   "ui.apprenticecodex.echo_cast.cannot_echo_more": "これ以上は魔力を残響させられない！",
+  "ui.apprenticecodex.mana_slash.missing_catalyst": "刃を生成する触媒が見つからない！",
   "ui.apprenticecodex.bound_sword.force_try_dual_wield": "強制的に二刀流錬成を実行...",
   "ui.apprenticecodex.divine_possession.required_all_pieces": "神降ろしには元素の乙女の装束を全て揃える必要がある！",
 

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -653,7 +653,7 @@
   "spell.apprenticecodex.earth_forge.guide": "在你视线位置生成一片平整的土块。潜行时，区域会缩小为单个方块。",
   "spell.apprenticecodex.moon_light.guide": "召唤一把超脱世界法则的武士刀，释放一闪斩击。刀刃的月光之力会撕裂空间，锋利且深邃。该施法过程无法被打断。",
   "spell.apprenticecodex.mana_charge.guide": "施法期间快速恢复魔力。",
-  "spell.apprenticecodex.mana_slash.guide": "发射一道凝聚魔力的刃气。伤害高度依赖你的武器。命中目标时会生成恢复魔力的宝珠。",
+  "spell.apprenticecodex.mana_slash.guide": "晶刃法杖专属的潜在法术。发射一道凝聚魔力的刃气。伤害会随法杖攻击力提升。命中目标时会生成恢复魔力的宝珠。",
   "spell.apprenticecodex.force_field.guide": "部署一个无形力场，抵挡来自任意方向的敌人攻击。击退目标时会消耗大量魔力，但也可反弹特定法术。这是对异界长寿种族所用魔法的模仿。",
   "spell.apprenticecodex.precision_jack.guide": "召唤一把魔法匕首，劈砍你的目标。可获得远超平常的掉落物，但需要旋转足够次数才能激活。",
   "spell.apprenticecodex.auto_magnet.guide": "召唤一个魔法磁石跟随你。磁石会收集附近的物品和经验球，并转移给你。背包满时停止收集物品。",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -692,6 +692,7 @@
   "ui.apprenticecodex.headshot_damage_multiplier": "爆头伤害倍率：%d%%",
   "ui.apprenticecodex.sneak_damage_multiplier": "潜行伤害倍率：%d%%",
   "ui.apprenticecodex.reflect_damage_multiplier": "反射伤害倍率：%d%%",
+  "ui.apprenticecodex.referenced_weapon_damage_multiplier": "参照攻击力倍率：%s%%",
   "ui.apprenticecodex.start_up_time": "启动时间：%s ",
   "ui.apprenticecodex.warm_up_time": "最大蓄力时间：%s ",
   "ui.apprenticecodex.tree_cut_time": "最小伐木时间：%s ",
@@ -787,6 +788,7 @@
   "ui.apprenticecodex.echo_cast.current_count": "%d 次施法的魔力正在周围回响...",
   "ui.apprenticecodex.echo_cast.max_reached": "回响的魔力已完全饱和！",
   "ui.apprenticecodex.echo_cast.cannot_echo_more": "无法再让魔力回响了！",
+  "ui.apprenticecodex.mana_slash.missing_catalyst": "未找到生成刃的催化剂！",
   "ui.apprenticecodex.divine_possession.required_all_pieces": "神降临需要集齐全套元素少女长袍！",
 
   "ui.apprenticecodex.elemental_bow.mode_switched": "已切换发射模式为 %s",


### PR DESCRIPTION
- マナスラッシュのクールダウンが0秒なのは意図的（魔法クールダウンで制御する意図はなく、武器の攻撃速度や攻撃システムMODに強く依存させるため）
- `runClient`、`runClientBetterCombat` 、`runGameTestServer`、`runGameTestBetterCombat`、`runGameTestEpicFight`は確認済み