### PR TITLE
刃の結晶杖のリワーク第二弾

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatClientCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatClientCompat.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.compat.bettercombat;
 import jp.aquafactory.apprenticecodex.event.client.ClientSwingMagicAttackTrigger;
 import jp.aquafactory.apprenticecodex.event.client.ClientMultipurposeStaffrifleInputEvent;
 import jp.aquafactory.apprenticecodex.event.client.MultipurposeStaffrifleClientAdsState;
+import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.item.MultipurposeStaffrifle;
 import net.bettercombat.api.AttackHand;
 import net.bettercombat.api.WeaponAttributes;
@@ -68,12 +69,20 @@ public final class BetterCombatClientCompat {
             return;
         }
 
+        var hand = resolveHand(attackHand);
         if (!attackHand.isOffHand()
                 && player.getMainHandItem().getItem() instanceof MultipurposeStaffrifle
                 && !MultipurposeStaffrifleClientAdsState.isLocalAdsKeyHeld(player)) {
             ClientMultipurposeStaffrifleInputEvent.trySendNonAdsSpecialCast(minecraft);
         }
-        ClientSwingMagicAttackTrigger.trySendForBetterCombat(minecraft, resolveHand(attackHand));
+        if (CrystalBladedStaff.isCrystalBladedStaff(player.getItemInHand(hand))) {
+            if (targets.isEmpty()) {
+                ClientSwingMagicAttackTrigger.trySendForBetterCombat(minecraft, hand);
+            }
+            return;
+        }
+
+        ClientSwingMagicAttackTrigger.trySendForBetterCombat(minecraft, hand);
     }
 
     private static InteractionHand resolveHand(AttackHand attackHand) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSwingMagicCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSwingMagicCompat.java
@@ -2,6 +2,8 @@ package jp.aquafactory.apprenticecodex.compat.epicfight;
 
 import jp.aquafactory.apprenticecodex.item.MultipurposeStaffrifle;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
+import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
+import jp.aquafactory.apprenticecodex.item.crystalbladedstaff.CrystalBladedStaffAttackContextManager;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
@@ -19,6 +21,7 @@ import yesman.epicfight.world.entity.eventlistener.AnimationBeginEvent;
 import yesman.epicfight.world.entity.eventlistener.AnimationEndEvent;
 import yesman.epicfight.world.entity.eventlistener.AttackPhaseEndEvent;
 import yesman.epicfight.world.entity.eventlistener.BasicAttackEvent;
+import yesman.epicfight.world.entity.eventlistener.DealDamageEvent;
 import yesman.epicfight.world.entity.eventlistener.PlayerEventListener.EventType;
 
 import java.util.ArrayList;
@@ -36,6 +39,7 @@ public final class EpicFightSwingMagicCompat {
     private static final ConcurrentMap<TriggerKey, Long> LAST_TRIGGERED_TICKS = new ConcurrentHashMap<>();
     private static final ConcurrentMap<UUID, List<TimedTrigger>> TIMED_TRIGGERS = new ConcurrentHashMap<>();
     private static final ConcurrentMap<UUID, Integer> ACTIVE_SCHEDULED_ANIMATION_IDS = new ConcurrentHashMap<>();
+    private static final int CRYSTAL_BLADED_STAFF_MISS_EVALUATION_DELAY_TICKS = 2;
 
     private EpicFightSwingMagicCompat() {
     }
@@ -66,6 +70,11 @@ public final class EpicFightSwingMagicCompat {
                     EventType.ANIMATION_END_EVENT,
                     SWING_MAGIC_EVENT_UUID,
                     EpicFightSwingMagicCompat::onAnimationEnd
+            );
+            playerpatch.getEventListener().addEventListener(
+                    EventType.DEAL_DAMAGE_EVENT_DAMAGE,
+                    SWING_MAGIC_EVENT_UUID,
+                    EpicFightSwingMagicCompat::onDealDamage
             );
             INSTALLED_PLAYERS.add(player.getUUID());
         });
@@ -176,6 +185,17 @@ public final class EpicFightSwingMagicCompat {
         }
     }
 
+    private static void onDealDamage(DealDamageEvent.Damage event) {
+        var player = event.getPlayerPatch().getOriginal();
+        if (event.getTarget() == null
+                || (!CrystalBladedStaff.isCrystalBladedStaff(player.getMainHandItem())
+                        && !CrystalBladedStaff.isCrystalBladedStaff(player.getOffhandItem()))) {
+            return;
+        }
+
+        CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(player);
+    }
+
     private static void processTimedTriggers(ServerPlayer player) {
         var playerId = player.getUUID();
         var triggers = TIMED_TRIGGERS.get(playerId);
@@ -232,7 +252,14 @@ public final class EpicFightSwingMagicCompat {
             return false;
         }
 
-        if (stack.getItem() instanceof SwingTriggeredMagicItem swingTriggeredMagicItem) {
+        if (CrystalBladedStaff.isCrystalBladedStaff(stack) && player instanceof ServerPlayer serverPlayer) {
+            return CrystalBladedStaffAttackContextManager.requestMissTrigger(
+                    serverPlayer,
+                    triggerHand,
+                    true,
+                    CRYSTAL_BLADED_STAFF_MISS_EVALUATION_DELAY_TICKS
+            );
+        } else if (stack.getItem() instanceof SwingTriggeredMagicItem swingTriggeredMagicItem) {
             return swingTriggeredMagicItem.tryTriggerSpellOnSwing(player, triggerHand, true);
         } else if (triggerHand == InteractionHand.MAIN_HAND
                 && player instanceof ServerPlayer serverPlayer

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSwingMagicCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSwingMagicCompat.java
@@ -167,6 +167,7 @@ public final class EpicFightSwingMagicCompat {
         }
 
         var hand = resolveAttackHand(event);
+        recordAttackPhaseHitIfCrystalBladedStaff(event, player, hand);
         triggerSwingMagicFromAttackPhase(player, hand, getAnimationId(event.getAnimation()), event.getPhaseOrder());
     }
 
@@ -196,6 +197,26 @@ public final class EpicFightSwingMagicCompat {
         }
 
         CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(player, hand);
+    }
+
+    private static void recordAttackPhaseHitIfCrystalBladedStaff(
+            AttackPhaseEndEvent event,
+            ServerPlayer player,
+            InteractionHand hand
+    ) {
+        var triggerHand = resolveSwingMagicTriggerHand(player, hand);
+        if (!CrystalBladedStaff.isCrystalBladedStaff(player.getItemInHand(triggerHand))) {
+            return;
+        }
+
+        var hitEntities = event.getPlayerPatch().getCurrentlyActuallyHitEntities();
+        if (hitEntities == null || hitEntities.isEmpty()) {
+            return;
+        }
+
+        // Epic Fight は命中後にフェーズ終了イベントを出すため、この時点の実命中リストをmiss抑制へ反映する。
+        // 1.21.1 側ではフェーズ終了時まで ACTUALLY_HIT_ENTITIES が残るかを再確認する。
+        CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(player, triggerHand);
     }
 
     private static InteractionHand resolveDamageHand(DealDamageEvent.Damage event) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSwingMagicCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSwingMagicCompat.java
@@ -7,6 +7,7 @@ import jp.aquafactory.apprenticecodex.item.crystalbladedstaff.CrystalBladedStaff
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import yesman.epicfight.api.animation.AnimationManager;
 import yesman.epicfight.api.animation.types.AttackAnimation;
 import yesman.epicfight.api.animation.types.StaticAnimation;
@@ -187,13 +188,59 @@ public final class EpicFightSwingMagicCompat {
 
     private static void onDealDamage(DealDamageEvent.Damage event) {
         var player = event.getPlayerPatch().getOriginal();
+        var hand = resolveDamageHand(event);
         if (event.getTarget() == null
-                || (!CrystalBladedStaff.isCrystalBladedStaff(player.getMainHandItem())
-                        && !CrystalBladedStaff.isCrystalBladedStaff(player.getOffhandItem()))) {
+                || hand == null
+                || !CrystalBladedStaff.isCrystalBladedStaff(player.getItemInHand(hand))) {
             return;
         }
 
-        CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(player);
+        CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(player, hand);
+    }
+
+    private static InteractionHand resolveDamageHand(DealDamageEvent.Damage event) {
+        var player = event.getPlayerPatch().getOriginal();
+        var usedItemHand = resolveHeldHandFromUsedItem(player, event.getDamageSource().getUsedItem());
+        if (usedItemHand != null) {
+            return usedItemHand;
+        }
+
+        var animationAccessor = event.getDamageSource().getAnimation();
+        if (animationAccessor != null && animationAccessor.get() instanceof AttackAnimation attackAnimation) {
+            var animationPlayer = event.getPlayerPatch().getAnimator().getPlayer(animationAccessor);
+            if (animationPlayer != null && animationPlayer.isPresent()) {
+                var phase = attackAnimation.getPhaseByTime(animationPlayer.get().getElapsedTime());
+                if (phase != null && phase.getHand() != null) {
+                    return phase.getHand();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static InteractionHand resolveHeldHandFromUsedItem(Player player, ItemStack usedItem) {
+        if (usedItem == null || usedItem.isEmpty()) {
+            return null;
+        }
+
+        if (usedItem == player.getMainHandItem()) {
+            return InteractionHand.MAIN_HAND;
+        }
+        if (usedItem == player.getOffhandItem()) {
+            return InteractionHand.OFF_HAND;
+        }
+
+        var mainHandMatches = ItemStack.isSameItemSameTags(usedItem, player.getMainHandItem());
+        var offHandMatches = ItemStack.isSameItemSameTags(usedItem, player.getOffhandItem());
+        if (mainHandMatches && !offHandMatches) {
+            return InteractionHand.MAIN_HAND;
+        }
+        if (offHandMatches && !mainHandMatches) {
+            return InteractionHand.OFF_HAND;
+        }
+
+        return null;
     }
 
     private static void processTimedTriggers(ServerPlayer player) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSwingMagicAttackInputEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSwingMagicAttackInputEvent.java
@@ -1,19 +1,50 @@
 package jp.aquafactory.apprenticecodex.event.client;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatClientCompat;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightClientCompat;
+import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.InputEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.ModList;
+import org.lwjgl.glfw.GLFW;
 
 @Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID, value = Dist.CLIENT)
 public final class ClientSwingMagicAttackInputEvent {
     private static final String BETTER_COMBAT_MOD_ID = "bettercombat";
 
     private ClientSwingMagicAttackInputEvent() {
+    }
+
+    @SubscribeEvent
+    public static void onMouseButtonPre(InputEvent.MouseButton.Pre event) {
+        if (event.getAction() != GLFW.GLFW_PRESS) {
+            return;
+        }
+
+        var minecraft = Minecraft.getInstance();
+        if (!matchesVanillaAttackInput(minecraft, InputConstants.Type.MOUSE, event.getButton())) {
+            return;
+        }
+
+        trySendVanillaPreAttack(minecraft);
+    }
+
+    @SubscribeEvent
+    public static void onKey(InputEvent.Key event) {
+        if (event.getAction() != GLFW.GLFW_PRESS) {
+            return;
+        }
+
+        var minecraft = Minecraft.getInstance();
+        if (matchesVanillaAttackInput(minecraft, InputConstants.Type.KEYSYM, event.getKey())
+                || matchesVanillaAttackInput(minecraft, InputConstants.Type.SCANCODE, event.getScanCode())) {
+            trySendVanillaPreAttack(minecraft);
+        }
     }
 
     @SubscribeEvent
@@ -29,5 +60,32 @@ public final class ClientSwingMagicAttackInputEvent {
         }
 
         ClientSwingMagicAttackTrigger.trySend(minecraft);
+    }
+
+    private static void trySendVanillaPreAttack(Minecraft minecraft) {
+        var player = minecraft.player;
+        if (minecraft.screen != null
+                || player == null
+                || player.isSpectator()
+                || !CrystalBladedStaff.isCrystalBladedStaff(player.getMainHandItem())) {
+            return;
+        }
+
+        if (ModList.get().isLoaded(BETTER_COMBAT_MOD_ID)
+                && BetterCombatClientCompat.usesBetterCombatAttackTiming(player)) {
+            return;
+        }
+
+        if (ModList.get().isLoaded(EpicFightClientCompat.MOD_ID)
+                && EpicFightClientCompat.isBattleMode()) {
+            return;
+        }
+
+        ClientSwingMagicAttackTrigger.trySendForVanillaPreAttack(minecraft);
+    }
+
+    private static boolean matchesVanillaAttackInput(Minecraft minecraft, InputConstants.Type type, int value) {
+        var attackKey = minecraft.options.keyAttack.getKey();
+        return attackKey.getType() == type && attackKey.getValue() == value;
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSwingMagicAttackTrigger.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSwingMagicAttackTrigger.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.event.client;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.item.AbstractRightClickMagicWeaponItem;
+import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
 import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.ClientSwingMagicAttackPacket;
@@ -14,23 +15,39 @@ import java.util.EnumMap;
 
 public final class ClientSwingMagicAttackTrigger {
     private static final EnumMap<InteractionHand, Long> LAST_SENT_TICKS = new EnumMap<>(InteractionHand.class);
+    private static final int DEFAULT_MISS_EVALUATION_DELAY_TICKS = 1;
+    private static final int VANILLA_PRE_ATTACK_MISS_EVALUATION_DELAY_TICKS = 2;
 
     private ClientSwingMagicAttackTrigger() {
     }
 
     public static void trySend(Minecraft minecraft) {
-        trySend(minecraft, InteractionHand.MAIN_HAND, false, false);
+        trySend(minecraft, InteractionHand.MAIN_HAND, false, false, DEFAULT_MISS_EVALUATION_DELAY_TICKS);
+    }
+
+    public static void trySendForVanillaPreAttack(Minecraft minecraft) {
+        var player = minecraft.player;
+        if (player == null
+                || !CrystalBladedStaff.isCrystalBladedStaff(player.getMainHandItem())
+                || !AbstractRightClickMagicWeaponItem.isFullyChargedAttack(player)) {
+            return;
+        }
+
+        // バニラ空振りはクライアント側で攻撃クールダウンを即リセットするため、
+        // press 直後に確認したフルチャージ判定を採用してサーバー側の遅延判定へ渡す。
+        trySend(minecraft, InteractionHand.MAIN_HAND, true, false, VANILLA_PRE_ATTACK_MISS_EVALUATION_DELAY_TICKS);
     }
 
     public static void trySendForBetterCombat(Minecraft minecraft, InteractionHand hand) {
-        trySend(minecraft, hand, true, true);
+        trySend(minecraft, hand, true, true, DEFAULT_MISS_EVALUATION_DELAY_TICKS);
     }
 
     private static void trySend(
             Minecraft minecraft,
             InteractionHand hand,
             boolean bypassChargeCheck,
-            boolean logEmptyHandFailure
+            boolean logEmptyHandFailure,
+            int missEvaluationDelayTicks
     ) {
         var player = minecraft.player;
         if (!canSend(minecraft, player, hand, bypassChargeCheck, logEmptyHandFailure) || player == null) {
@@ -39,7 +56,7 @@ public final class ClientSwingMagicAttackTrigger {
 
         LAST_SENT_TICKS.put(hand, player.level().getGameTime());
         ClientSwingcastStaffCastContext.beginPending(player.getUUID(), player.getItemInHand(hand));
-        Networks.sendToServer(new ClientSwingMagicAttackPacket(bypassChargeCheck, hand));
+        Networks.sendToServer(new ClientSwingMagicAttackPacket(bypassChargeCheck, hand, missEvaluationDelayTicks));
     }
 
     private static boolean canSend(

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -921,6 +921,16 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffPendingMissTriggerKeepsEarlierHand(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffPendingMissTriggerKeepsEarlierHand(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffMainHandHitDoesNotSuppressOffhandMiss(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffMainHandHitDoesNotSuppressOffhandMiss(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -901,6 +901,26 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffMissSwingCastsManaSlash(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffMissSwingCastsManaSlash(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffHitSwingDoesNotCastManaSlash(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffHitSwingDoesNotCastManaSlash(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffVanillaAttackEntityHitDoesNotCastManaSlash(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffVanillaAttackEntityHitDoesNotCastManaSlash(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffDelayedHitDoesNotCastManaSlash(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffDelayedHitDoesNotCastManaSlash(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -921,6 +921,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void crystalBladedStaffMissTriggerDoesNotUseSwappedStack(GameTestHelper helper) {
+        SwingcastStaffGameTestScenarios.crystalBladedStaffMissTriggerDoesNotUseSwappedStack(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void crystalBladedStaffPendingMissTriggerKeepsEarlierHand(GameTestHelper helper) {
         SwingcastStaffGameTestScenarios.crystalBladedStaffPendingMissTriggerKeepsEarlierHand(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/RightClickMagicWeaponGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/RightClickMagicWeaponGameTestScenarios.java
@@ -321,8 +321,8 @@ final class RightClickMagicWeaponGameTestScenarios extends ApprenticeCodexGameTe
                     helper,
                     new ItemStack(ItemRegistry.CRYSTAL_BLADED_STAFF.get()),
                     2,
-                    "item.apprenticecodex.swingcast.common.desc",
-                    "Crystal Bladed Staff should show swingcast tooltip after offhand priority tooltips"
+                    "item.apprenticecodex.crystal_bladed_staff.swing_miss.desc",
+                    "Crystal Bladed Staff should show miss-swing tooltip after offhand priority tooltips"
             );
             assertTooltipKeyAt(
                     helper,

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -181,6 +181,33 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
         });
     }
 
+    static void crystalBladedStaffMissTriggerDoesNotUseSwappedStack(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var originalStack = new ItemStack(item);
+        item.initializeSpellContainer(originalStack);
+        var swappedSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+        var swappedStack = createLegacyCrystalBladedStaffContainer(swappedSpell, 1, false);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 4, 0), "crystal_bladed_staff_swap_no_cast");
+        player.setItemInHand(InteractionHand.MAIN_HAND, originalStack);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Crystal Bladed Staff swapped stack test could not resolve player mana data");
+        magicData.setMana(1000.0F);
+
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.MAIN_HAND, true, 2),
+                "Crystal Bladed Staff swapped stack miss trigger should be accepted"
+        );
+        player.setItemInHand(InteractionHand.MAIN_HAND, swappedStack);
+
+        helper.runAfterDelay(4, () -> {
+            helper.assertTrue(!SpellRegistry.MANA_SLASH.get().getSpellId().equals(magicData.getCastingSpellId()),
+                    "Crystal Bladed Staff swapped stack should not cast the original Mana Slash");
+            helper.assertTrue(!swappedSpell.getSpellId().equals(magicData.getCastingSpellId()),
+                    "Crystal Bladed Staff swapped stack should not cast the replacement staff spell");
+            helper.succeed();
+        });
+    }
+
     static void crystalBladedStaffPendingMissTriggerKeepsEarlierHand(GameTestHelper helper) {
         var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
         var mainSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -169,11 +169,77 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                 CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.MAIN_HAND, true, 2),
                 "Crystal Bladed Staff delayed hit trigger should be accepted"
         );
-        helper.runAfterDelay(1, () -> CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(player));
+        helper.runAfterDelay(1, () -> CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(
+                player,
+                InteractionHand.MAIN_HAND
+        ));
 
         helper.runAfterDelay(4, () -> {
             helper.assertTrue(countNearbyManaSlashProjectiles(helper, player.blockPosition()) == 0,
                     "Crystal Bladed Staff delayed hit should not cast Mana Slash");
+            helper.succeed();
+        });
+    }
+
+    static void crystalBladedStaffPendingMissTriggerKeepsEarlierHand(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var mainSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+        var mainStack = createLegacyCrystalBladedStaffContainer(mainSpell, 1, false);
+        var offhandStack = new ItemStack(item);
+        item.initializeSpellContainer(offhandStack);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 4, 0), "crystal_bladed_staff_dual_pending");
+        player.setItemInHand(InteractionHand.MAIN_HAND, mainStack);
+        player.setItemInHand(InteractionHand.OFF_HAND, offhandStack);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Crystal Bladed Staff dual pending test could not resolve player mana data");
+        magicData.setMana(1000.0F);
+
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.MAIN_HAND, true, 1),
+                "Crystal Bladed Staff mainhand miss trigger should be accepted"
+        );
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.OFF_HAND, true, 10),
+                "Crystal Bladed Staff offhand miss trigger should be accepted without overwriting mainhand"
+        );
+
+        helper.runAfterDelay(2, () -> {
+            helper.assertTrue(mainSpell.getSpellId().equals(magicData.getCastingSpellId()),
+                    "Crystal Bladed Staff mainhand pending trigger should cast first but got "
+                            + magicData.getCastingSpellId());
+            helper.assertTrue(io.redspace.ironsspellbooks.api.magic.SpellSelectionManager.MAINHAND.equals(
+                            magicData.getCastingEquipmentSlot()),
+                    "Crystal Bladed Staff mainhand pending trigger should mark the mainhand casting slot");
+            helper.succeed();
+        });
+    }
+
+    static void crystalBladedStaffMainHandHitDoesNotSuppressOffhandMiss(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var offhandStack = new ItemStack(item);
+        item.initializeSpellContainer(offhandStack);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "crystal_bladed_staff_offhand_miss");
+        player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIAMOND_SWORD));
+        player.setItemInHand(InteractionHand.OFF_HAND, offhandStack);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Crystal Bladed Staff offhand miss test could not resolve player mana data");
+        magicData.setMana(100.0F);
+
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.OFF_HAND, true, 2),
+                "Crystal Bladed Staff offhand miss trigger should be accepted"
+        );
+        var target = helper.spawn(EntityType.ZOMBIE, new BlockPos(1, 2, 0));
+        helper.assertTrue(target.hurt(helper.getLevel().damageSources().playerAttack(player), 1.0F),
+                "Crystal Bladed Staff offhand miss test should deal mainhand player attack damage");
+
+        helper.succeedWhen(() -> {
+            helper.assertTrue(SpellRegistry.MANA_SLASH.get().getSpellId().equals(magicData.getCastingSpellId()),
+                    "Mainhand hit should not suppress offhand Crystal Bladed Staff miss cast but got "
+                            + magicData.getCastingSpellId());
+            helper.assertTrue(io.redspace.ironsspellbooks.api.magic.SpellSelectionManager.OFFHAND.equals(
+                            magicData.getCastingEquipmentSlot()),
+                    "Offhand Crystal Bladed Staff miss cast should mark the offhand casting slot");
             helper.succeed();
         });
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -9,13 +9,13 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
 import jp.aquafactory.apprenticecodex.item.AbstractSwingMagicItem;
 import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
+import jp.aquafactory.apprenticecodex.item.crystalbladedstaff.CrystalBladedStaffAttackContextManager;
 import jp.aquafactory.apprenticecodex.item.swingstaff.AbstractSwingcastStaffItem;
 import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastCooldownMode;
 import jp.aquafactory.apprenticecodex.item.swingstaff.SwingcastStaffCastContext;
@@ -28,6 +28,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.MobType;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
@@ -37,6 +38,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.ItemAttributeModifierEvent;
+import net.minecraftforge.event.entity.player.AttackEntityEvent;
 
 final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScenarios {
     private SwingcastStaffGameTestScenarios() {
@@ -76,6 +78,103 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Crystal Bladed Staff preset spell should stay hidden from the spell wheel");
             assertSpellData(helper, spellContainer, 0, SpellRegistry.MANA_SLASH.get(), 1, true,
                     "Crystal Bladed Staff should start with locked Mana Slash");
+        });
+    }
+    static void crystalBladedStaffMissSwingCastsManaSlash(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var stack = new ItemStack(item);
+        item.initializeSpellContainer(stack);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 4, 0), "crystal_bladed_staff_miss_cast");
+        player.setYRot(0.0F);
+        player.setXRot(0.0F);
+        player.setYHeadRot(0.0F);
+        player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Crystal Bladed Staff miss cast test could not resolve player mana data");
+        magicData.setMana(100.0F);
+
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.MAIN_HAND, true),
+                "Crystal Bladed Staff miss trigger should be accepted"
+        );
+
+        helper.succeedWhen(() -> {
+            helper.assertTrue(SpellRegistry.MANA_SLASH.get().getSpellId().equals(magicData.getCastingSpellId()),
+                    "Crystal Bladed Staff miss swing should cast Mana Slash but got " + magicData.getCastingSpellId());
+            helper.assertTrue(ItemStack.isSameItemSameTags(magicData.getPlayerCastingItem(), stack),
+                    "Crystal Bladed Staff miss swing should cast with the staff stack");
+            helper.assertTrue(io.redspace.ironsspellbooks.api.magic.SpellSelectionManager.MAINHAND.equals(magicData.getCastingEquipmentSlot()),
+                    "Crystal Bladed Staff miss swing should mark the mainhand casting slot");
+            helper.succeed();
+        });
+    }
+    static void crystalBladedStaffHitSwingDoesNotCastManaSlash(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var stack = new ItemStack(item);
+        item.initializeSpellContainer(stack);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "crystal_bladed_staff_hit_no_cast");
+        player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Crystal Bladed Staff hit suppression test could not resolve player mana data");
+        magicData.setMana(100.0F);
+
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.MAIN_HAND, true),
+                "Crystal Bladed Staff hit suppression trigger should be accepted"
+        );
+        var target = helper.spawn(EntityType.ZOMBIE, new BlockPos(1, 2, 0));
+        helper.assertTrue(target.hurt(helper.getLevel().damageSources().playerAttack(player), 1.0F),
+                "Crystal Bladed Staff hit suppression test should deal direct player attack damage");
+
+        helper.runAfterDelay(3, () -> {
+            helper.assertTrue(countNearbyManaSlashProjectiles(helper, player.blockPosition()) == 0,
+                    "Crystal Bladed Staff hit swing should not cast Mana Slash");
+            helper.succeed();
+        });
+    }
+    static void crystalBladedStaffVanillaAttackEntityHitDoesNotCastManaSlash(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var stack = new ItemStack(item);
+        item.initializeSpellContainer(stack);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "crystal_bladed_staff_vanilla_hit_no_cast");
+        player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Crystal Bladed Staff vanilla hit test could not resolve player mana data");
+        magicData.setMana(100.0F);
+
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.MAIN_HAND, true, 2),
+                "Crystal Bladed Staff vanilla hit trigger should be accepted"
+        );
+        var target = helper.spawn(EntityType.ZOMBIE, new BlockPos(1, 2, 0));
+        MinecraftForge.EVENT_BUS.post(new AttackEntityEvent(player, target));
+
+        helper.runAfterDelay(4, () -> {
+            helper.assertTrue(countNearbyManaSlashProjectiles(helper, player.blockPosition()) == 0,
+                    "Crystal Bladed Staff vanilla hit should not cast Mana Slash");
+            helper.succeed();
+        });
+    }
+    static void crystalBladedStaffDelayedHitDoesNotCastManaSlash(GameTestHelper helper) {
+        var item = (CrystalBladedStaff) ItemRegistry.CRYSTAL_BLADED_STAFF.get();
+        var stack = new ItemStack(item);
+        item.initializeSpellContainer(stack);
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "crystal_bladed_staff_delayed_hit_no_cast");
+        player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Crystal Bladed Staff delayed hit test could not resolve player mana data");
+        magicData.setMana(100.0F);
+
+        helper.assertTrue(
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(player, InteractionHand.MAIN_HAND, true, 2),
+                "Crystal Bladed Staff delayed hit trigger should be accepted"
+        );
+        helper.runAfterDelay(1, () -> CrystalBladedStaffAttackContextManager.recordRecentCrystalBladedStaffHit(player));
+
+        helper.runAfterDelay(4, () -> {
+            helper.assertTrue(countNearbyManaSlashProjectiles(helper, player.blockPosition()) == 0,
+                    "Crystal Bladed Staff delayed hit should not cast Mana Slash");
+            helper.succeed();
         });
     }
     static void crystalBladedStaffLegacyWheelPresetIsHiddenWhenHeld(GameTestHelper helper) {
@@ -482,5 +581,12 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
         mutable.addSpellAtIndex(spell, spellLevel, 0, locked);
         ISpellContainer.set(stack, mutable.toImmutable());
         return stack;
+    }
+
+    private static int countNearbyManaSlashProjectiles(GameTestHelper helper, BlockPos origin) {
+        return helper.getLevel().getEntitiesOfClass(
+                ManaSlashProjectileEntity.class,
+                new AABB(origin).inflate(32.0D)
+        ).size();
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SwingcastStaffGameTestScenarios.java
@@ -127,7 +127,7 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
                 "Crystal Bladed Staff hit suppression test should deal direct player attack damage");
 
         helper.runAfterDelay(3, () -> {
-            helper.assertTrue(countNearbyManaSlashProjectiles(helper, player.blockPosition()) == 0,
+            helper.assertTrue(!SpellRegistry.MANA_SLASH.get().getSpellId().equals(magicData.getCastingSpellId()),
                     "Crystal Bladed Staff hit swing should not cast Mana Slash");
             helper.succeed();
         });
@@ -150,7 +150,7 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
         MinecraftForge.EVENT_BUS.post(new AttackEntityEvent(player, target));
 
         helper.runAfterDelay(4, () -> {
-            helper.assertTrue(countNearbyManaSlashProjectiles(helper, player.blockPosition()) == 0,
+            helper.assertTrue(!SpellRegistry.MANA_SLASH.get().getSpellId().equals(magicData.getCastingSpellId()),
                     "Crystal Bladed Staff vanilla hit should not cast Mana Slash");
             helper.succeed();
         });
@@ -175,7 +175,7 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
         ));
 
         helper.runAfterDelay(4, () -> {
-            helper.assertTrue(countNearbyManaSlashProjectiles(helper, player.blockPosition()) == 0,
+            helper.assertTrue(!SpellRegistry.MANA_SLASH.get().getSpellId().equals(magicData.getCastingSpellId()),
                     "Crystal Bladed Staff delayed hit should not cast Mana Slash");
             helper.succeed();
         });
@@ -676,10 +676,4 @@ final class SwingcastStaffGameTestScenarios extends ApprenticeCodexGameTestScena
         return stack;
     }
 
-    private static int countNearbyManaSlashProjectiles(GameTestHelper helper, BlockPos origin) {
-        return helper.getLevel().getEntitiesOfClass(
-                ManaSlashProjectileEntity.class,
-                new AABB(origin).inflate(32.0D)
-        ).size();
-    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/AbstractSwingMagicItem.java
@@ -327,7 +327,10 @@ public abstract class AbstractSwingMagicItem extends AbstractRightClickMagicWeap
     public void appendHoverText(@NotNull ItemStack stack, @Nullable Level level, @NotNull List<Component> lines,
                                 @NotNull TooltipFlag flag) {
         super.appendHoverText(stack, level, lines, flag);
-        lines.add(Component.translatable("item.apprenticecodex.swingcast.common.desc").withStyle(ChatFormatting.GRAY));
+        lines.add(Component.translatable(getSwingCastTooltipTranslationKey()).withStyle(ChatFormatting.GRAY));
     }
 
+    protected String getSwingCastTooltipTranslationKey() {
+        return "item.apprenticecodex.swingcast.common.desc";
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CrystalBladedStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CrystalBladedStaff.java
@@ -166,6 +166,11 @@ public class CrystalBladedStaff extends AbstractSwingMagicItem implements GeoIte
     }
 
     @Override
+    protected String getSwingCastTooltipTranslationKey() {
+        return getDescriptionId() + ".swing_miss.desc";
+    }
+
+    @Override
     public AnimatableInstanceCache getAnimatableInstanceCache() {
         return cache;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/crystalbladedstaff/CrystalBladedStaffAttackContextManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/crystalbladedstaff/CrystalBladedStaffAttackContextManager.java
@@ -59,6 +59,7 @@ public final class CrystalBladedStaffAttackContextManager {
                 player,
                 level.getGameTime(),
                 hand,
+                stack,
                 bypassChargeCheck,
                 Math.max(1, evaluationDelayTicks)
         ));
@@ -203,6 +204,12 @@ public final class CrystalBladedStaffAttackContextManager {
 
     private static void triggerMissSpell(ServerPlayer player, PendingMissTrigger trigger) {
         var stack = player.getItemInHand(trigger.hand());
+        // 遅延中に持ち替えた場合は不発にする。SpellDataを固定して別経路で詠唱すると契約が広がるため、
+        // 1-2tickのエッジケースには、振った同一スタックが手に残っている場合だけ通常経路へ渡す。
+        if (stack != trigger.stack()) {
+            return;
+        }
+
         if (!CrystalBladedStaff.isCrystalBladedStaff(stack)) {
             return;
         }
@@ -300,6 +307,7 @@ public final class CrystalBladedStaffAttackContextManager {
             ServerPlayer player,
             long requestGameTime,
             InteractionHand hand,
+            ItemStack stack,
             boolean bypassChargeCheck,
             int evaluationDelayTicks
     ) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/crystalbladedstaff/CrystalBladedStaffAttackContextManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/crystalbladedstaff/CrystalBladedStaffAttackContextManager.java
@@ -26,7 +26,7 @@ import java.util.WeakHashMap;
 @Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID)
 public final class CrystalBladedStaffAttackContextManager {
     private static final Map<ServerLevel, Map<UUID, PendingAttackContext>> PENDING_ATTACKS = new WeakHashMap<>();
-    private static final Map<ServerLevel, Map<UUID, PendingMissTrigger>> PENDING_MISS_TRIGGERS = new WeakHashMap<>();
+    private static final Map<ServerLevel, Map<HitKey, PendingMissTrigger>> PENDING_MISS_TRIGGERS = new WeakHashMap<>();
     private static final Map<ServerLevel, Map<HitKey, Long>> RECENT_HIT_TICKS = new WeakHashMap<>();
     private static final long HIT_MEMORY_TICKS = 1L;
 
@@ -54,8 +54,8 @@ public final class CrystalBladedStaffAttackContextManager {
         }
 
         var level = player.serverLevel();
-        var triggersByPlayer = PENDING_MISS_TRIGGERS.computeIfAbsent(level, ignored -> new LinkedHashMap<>());
-        triggersByPlayer.put(player.getUUID(), new PendingMissTrigger(
+        var triggersByPlayerAndHand = PENDING_MISS_TRIGGERS.computeIfAbsent(level, ignored -> new LinkedHashMap<>());
+        triggersByPlayerAndHand.put(new HitKey(player.getUUID(), hand), new PendingMissTrigger(
                 player,
                 level.getGameTime(),
                 hand,
@@ -75,7 +75,7 @@ public final class CrystalBladedStaffAttackContextManager {
             return;
         }
 
-        recordRecentCrystalBladedStaffHit(attacker);
+        recordRecentCrystalBladedStaffHit(attacker, InteractionHand.MAIN_HAND);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -93,7 +93,7 @@ public final class CrystalBladedStaffAttackContextManager {
             return;
         }
 
-        recordRecentCrystalBladedStaffHit(attacker);
+        recordRecentCrystalBladedStaffHit(attacker, InteractionHand.MAIN_HAND);
 
         if (!(event.getEntity() instanceof Mob mob)) {
             return;
@@ -169,12 +169,12 @@ public final class CrystalBladedStaffAttackContextManager {
     }
 
     private static void processMissTriggers(ServerLevel serverLevel, long gameTime) {
-        var triggersByPlayer = PENDING_MISS_TRIGGERS.get(serverLevel);
-        if (triggersByPlayer == null || triggersByPlayer.isEmpty()) {
+        var triggersByPlayerAndHand = PENDING_MISS_TRIGGERS.get(serverLevel);
+        if (triggersByPlayerAndHand == null || triggersByPlayerAndHand.isEmpty()) {
             return;
         }
 
-        var iterator = triggersByPlayer.entrySet().iterator();
+        var iterator = triggersByPlayerAndHand.entrySet().iterator();
         while (iterator.hasNext()) {
             var entry = iterator.next();
             var trigger = entry.getValue();
@@ -183,19 +183,20 @@ public final class CrystalBladedStaffAttackContextManager {
                 continue;
             }
 
-            var player = serverLevel.getServer().getPlayerList().getPlayer(entry.getKey());
+            var triggerKey = entry.getKey();
+            var player = serverLevel.getServer().getPlayerList().getPlayer(triggerKey.playerUuid());
             if (player == null) {
                 player = trigger.player();
             }
             if (player != null
                     && player.serverLevel() == serverLevel
-                    && !hasRecentHit(serverLevel, entry.getKey(), trigger.hand(), trigger.requestGameTime())) {
+                    && !hasRecentHit(serverLevel, triggerKey.playerUuid(), trigger.hand(), trigger.requestGameTime())) {
                 triggerMissSpell(player, trigger);
             }
             iterator.remove();
         }
 
-        if (triggersByPlayer.isEmpty()) {
+        if (triggersByPlayerAndHand.isEmpty()) {
             PENDING_MISS_TRIGGERS.remove(serverLevel);
         }
     }
@@ -212,22 +213,15 @@ public final class CrystalBladedStaffAttackContextManager {
         }
     }
 
-    public static void recordRecentCrystalBladedStaffHit(ServerPlayer attacker) {
+    public static void recordRecentCrystalBladedStaffHit(ServerPlayer attacker, InteractionHand hand) {
         var level = attacker.serverLevel();
         var gameTime = level.getGameTime();
         var hitsByPlayerAndHand = RECENT_HIT_TICKS.computeIfAbsent(level, ignored -> new LinkedHashMap<>());
         recordRecentHitIfCrystalBladedStaff(
                 hitsByPlayerAndHand,
                 attacker.getUUID(),
-                InteractionHand.MAIN_HAND,
-                attacker.getMainHandItem(),
-                gameTime
-        );
-        recordRecentHitIfCrystalBladedStaff(
-                hitsByPlayerAndHand,
-                attacker.getUUID(),
-                InteractionHand.OFF_HAND,
-                attacker.getOffhandItem(),
+                hand,
+                attacker.getItemInHand(hand),
                 gameTime
         );
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/crystalbladedstaff/CrystalBladedStaffAttackContextManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/crystalbladedstaff/CrystalBladedStaffAttackContextManager.java
@@ -2,13 +2,18 @@ package jp.aquafactory.apprenticecodex.item.crystalbladedstaff;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
+import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageTypes;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
+import net.minecraftforge.event.entity.player.AttackEntityEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -21,8 +26,56 @@ import java.util.WeakHashMap;
 @Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID)
 public final class CrystalBladedStaffAttackContextManager {
     private static final Map<ServerLevel, Map<UUID, PendingAttackContext>> PENDING_ATTACKS = new WeakHashMap<>();
+    private static final Map<ServerLevel, Map<UUID, PendingMissTrigger>> PENDING_MISS_TRIGGERS = new WeakHashMap<>();
+    private static final Map<ServerLevel, Map<HitKey, Long>> RECENT_HIT_TICKS = new WeakHashMap<>();
+    private static final long HIT_MEMORY_TICKS = 1L;
 
     private CrystalBladedStaffAttackContextManager() {
+    }
+
+    public static boolean requestMissTrigger(ServerPlayer player, InteractionHand hand, boolean bypassChargeCheck) {
+        return requestMissTrigger(player, hand, bypassChargeCheck, 1);
+    }
+
+    public static boolean requestMissTrigger(
+            ServerPlayer player,
+            InteractionHand hand,
+            boolean bypassChargeCheck,
+            int evaluationDelayTicks
+    ) {
+        if (player == null || player.isSpectator()) {
+            return false;
+        }
+
+        var stack = player.getItemInHand(hand);
+        if (!CrystalBladedStaff.isCrystalBladedStaff(stack)
+                || (!bypassChargeCheck && !CrystalBladedStaff.isFullyChargedAttack(player))) {
+            return false;
+        }
+
+        var level = player.serverLevel();
+        var triggersByPlayer = PENDING_MISS_TRIGGERS.computeIfAbsent(level, ignored -> new LinkedHashMap<>());
+        triggersByPlayer.put(player.getUUID(), new PendingMissTrigger(
+                player,
+                level.getGameTime(),
+                hand,
+                bypassChargeCheck,
+                Math.max(1, evaluationDelayTicks)
+        ));
+        return true;
+    }
+
+    @SubscribeEvent(priority = EventPriority.LOWEST)
+    public static void onAttackEntity(AttackEntityEvent event) {
+        var player = event.getEntity();
+        if (player.level().isClientSide
+                || event.isCanceled()
+                || !(player instanceof ServerPlayer attacker)
+                || !(event.getTarget() instanceof LivingEntity)) {
+            return;
+        }
+
+        recordRecentCrystalBladedStaffHit(attacker);
     }
 
     @SubscribeEvent(priority = EventPriority.LOWEST)
@@ -35,12 +88,19 @@ public final class CrystalBladedStaffAttackContextManager {
             return;
         }
 
+        var attacker = resolveDirectPlayerAttack(event);
+        if (attacker == null) {
+            return;
+        }
+
+        recordRecentCrystalBladedStaffHit(attacker);
+
         if (!(event.getEntity() instanceof Mob mob)) {
             return;
         }
 
-        var attacker = resolveStaffAttacker(event);
-        if (attacker == null || !CrystalBladedStaff.isFullyChargedAttack(attacker)) {
+        if (!CrystalBladedStaff.isCrystalBladedStaff(attacker.getMainHandItem())
+                || !CrystalBladedStaff.isFullyChargedAttack(attacker)) {
             return;
         }
 
@@ -66,28 +126,29 @@ public final class CrystalBladedStaffAttackContextManager {
             return;
         }
 
-        var attacksByPlayer = PENDING_ATTACKS.get(serverLevel);
-        if (attacksByPlayer == null || attacksByPlayer.isEmpty()) {
-            return;
-        }
-
         var gameTime = serverLevel.getGameTime();
-        var iterator = attacksByPlayer.entrySet().iterator();
-        while (iterator.hasNext()) {
-            var entry = iterator.next();
-            var attackContext = entry.getValue();
+        var attacksByPlayer = PENDING_ATTACKS.get(serverLevel);
+        if (attacksByPlayer != null && !attacksByPlayer.isEmpty()) {
+            var iterator = attacksByPlayer.entrySet().iterator();
+            while (iterator.hasNext()) {
+                var entry = iterator.next();
+                var attackContext = entry.getValue();
 
-            if (attackContext.gameTime > gameTime) {
-                continue;
+                if (attackContext.gameTime > gameTime) {
+                    continue;
+                }
+
+                processAttack(serverLevel, entry.getKey(), attackContext);
+                iterator.remove();
             }
 
-            processAttack(serverLevel, entry.getKey(), attackContext);
-            iterator.remove();
+            if (attacksByPlayer.isEmpty()) {
+                PENDING_ATTACKS.remove(serverLevel);
+            }
         }
 
-        if (attacksByPlayer.isEmpty()) {
-            PENDING_ATTACKS.remove(serverLevel);
-        }
+        processMissTriggers(serverLevel, gameTime);
+        cleanupRecentHits(serverLevel, gameTime);
     }
 
     private static void processAttack(ServerLevel serverLevel, UUID playerUuid, PendingAttackContext attackContext) {
@@ -107,7 +168,105 @@ public final class CrystalBladedStaffAttackContextManager {
         }
     }
 
-    private static ServerPlayer resolveStaffAttacker(LivingDamageEvent event) {
+    private static void processMissTriggers(ServerLevel serverLevel, long gameTime) {
+        var triggersByPlayer = PENDING_MISS_TRIGGERS.get(serverLevel);
+        if (triggersByPlayer == null || triggersByPlayer.isEmpty()) {
+            return;
+        }
+
+        var iterator = triggersByPlayer.entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
+            var trigger = entry.getValue();
+
+            if (gameTime < trigger.evaluationGameTime()) {
+                continue;
+            }
+
+            var player = serverLevel.getServer().getPlayerList().getPlayer(entry.getKey());
+            if (player == null) {
+                player = trigger.player();
+            }
+            if (player != null
+                    && player.serverLevel() == serverLevel
+                    && !hasRecentHit(serverLevel, entry.getKey(), trigger.hand(), trigger.requestGameTime())) {
+                triggerMissSpell(player, trigger);
+            }
+            iterator.remove();
+        }
+
+        if (triggersByPlayer.isEmpty()) {
+            PENDING_MISS_TRIGGERS.remove(serverLevel);
+        }
+    }
+
+    private static void triggerMissSpell(ServerPlayer player, PendingMissTrigger trigger) {
+        var stack = player.getItemInHand(trigger.hand());
+        if (!CrystalBladedStaff.isCrystalBladedStaff(stack)) {
+            return;
+        }
+
+        if (stack.getItem() instanceof SwingTriggeredMagicItem swingTriggeredMagicItem
+                && swingTriggeredMagicItem.canTriggerSpellOnSwing(player, trigger.hand())) {
+            swingTriggeredMagicItem.tryTriggerSpellOnSwing(player, trigger.hand(), trigger.bypassChargeCheck());
+        }
+    }
+
+    public static void recordRecentCrystalBladedStaffHit(ServerPlayer attacker) {
+        var level = attacker.serverLevel();
+        var gameTime = level.getGameTime();
+        var hitsByPlayerAndHand = RECENT_HIT_TICKS.computeIfAbsent(level, ignored -> new LinkedHashMap<>());
+        recordRecentHitIfCrystalBladedStaff(
+                hitsByPlayerAndHand,
+                attacker.getUUID(),
+                InteractionHand.MAIN_HAND,
+                attacker.getMainHandItem(),
+                gameTime
+        );
+        recordRecentHitIfCrystalBladedStaff(
+                hitsByPlayerAndHand,
+                attacker.getUUID(),
+                InteractionHand.OFF_HAND,
+                attacker.getOffhandItem(),
+                gameTime
+        );
+    }
+
+    private static void recordRecentHitIfCrystalBladedStaff(
+            Map<HitKey, Long> hitsByPlayerAndHand,
+            UUID playerUuid,
+            InteractionHand hand,
+            ItemStack stack,
+            long gameTime
+    ) {
+        if (CrystalBladedStaff.isCrystalBladedStaff(stack)) {
+            hitsByPlayerAndHand.put(new HitKey(playerUuid, hand), gameTime);
+        }
+    }
+
+    private static boolean hasRecentHit(ServerLevel serverLevel, UUID playerUuid, InteractionHand hand, long requestGameTime) {
+        var hitsByPlayerAndHand = RECENT_HIT_TICKS.get(serverLevel);
+        if (hitsByPlayerAndHand == null) {
+            return false;
+        }
+
+        var hitGameTime = hitsByPlayerAndHand.get(new HitKey(playerUuid, hand));
+        return hitGameTime != null && hitGameTime >= requestGameTime - HIT_MEMORY_TICKS;
+    }
+
+    private static void cleanupRecentHits(ServerLevel serverLevel, long gameTime) {
+        var hitsByPlayerAndHand = RECENT_HIT_TICKS.get(serverLevel);
+        if (hitsByPlayerAndHand == null || hitsByPlayerAndHand.isEmpty()) {
+            return;
+        }
+
+        hitsByPlayerAndHand.values().removeIf(hitGameTime -> gameTime - hitGameTime > HIT_MEMORY_TICKS + 2L);
+        if (hitsByPlayerAndHand.isEmpty()) {
+            RECENT_HIT_TICKS.remove(serverLevel);
+        }
+    }
+
+    private static ServerPlayer resolveDirectPlayerAttack(LivingDamageEvent event) {
         ServerPlayer player = null;
         if (event.getSource().getDirectEntity() instanceof ServerPlayer directPlayer) {
             player = directPlayer;
@@ -127,11 +286,7 @@ public final class CrystalBladedStaffAttackContextManager {
             return null;
         }
 
-        if (CrystalBladedStaff.isCrystalBladedStaff(player.getMainHandItem())) {
-            return player;
-        }
-
-        return null;
+        return player;
     }
 
     private static final class PendingAttackContext {
@@ -145,5 +300,20 @@ public final class CrystalBladedStaffAttackContextManager {
         private void recordHit(UUID targetUuid, Vec3 impactPosition) {
             targetsByUuid.putIfAbsent(targetUuid, impactPosition);
         }
+    }
+
+    private record PendingMissTrigger(
+            ServerPlayer player,
+            long requestGameTime,
+            InteractionHand hand,
+            boolean bypassChargeCheck,
+            int evaluationDelayTicks
+    ) {
+        private long evaluationGameTime() {
+            return requestGameTime + evaluationDelayTicks;
+        }
+    }
+
+    private record HitKey(UUID playerUuid, InteractionHand hand) {
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -57,7 +57,7 @@ import net.minecraftforge.network.simple.SimpleChannel;
 import java.util.Optional;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "44";
+    private static final String PROTOCOL_VERSION = "45";
     private static int nextPacketId = 0;
 
     private static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientSwingMagicAttackPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientSwingMagicAttackPacket.java
@@ -1,20 +1,27 @@
 package jp.aquafactory.apprenticecodex.network.packet;
 
+import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
+import jp.aquafactory.apprenticecodex.item.crystalbladedstaff.CrystalBladedStaffAttackContextManager;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.InteractionHand;
 import net.minecraftforge.network.NetworkEvent;
 
 import java.util.function.Supplier;
 
-public record ClientSwingMagicAttackPacket(boolean bypassChargeCheck, InteractionHand hand) {
+public record ClientSwingMagicAttackPacket(boolean bypassChargeCheck, InteractionHand hand, int missEvaluationDelayTicks) {
     public static void encode(ClientSwingMagicAttackPacket packet, FriendlyByteBuf buffer) {
         buffer.writeBoolean(packet.bypassChargeCheck());
         buffer.writeEnum(packet.hand());
+        buffer.writeVarInt(packet.missEvaluationDelayTicks());
     }
 
     public static ClientSwingMagicAttackPacket decode(FriendlyByteBuf buffer) {
-        return new ClientSwingMagicAttackPacket(buffer.readBoolean(), buffer.readEnum(InteractionHand.class));
+        return new ClientSwingMagicAttackPacket(
+                buffer.readBoolean(),
+                buffer.readEnum(InteractionHand.class),
+                buffer.readVarInt()
+        );
     }
 
     public static void handle(ClientSwingMagicAttackPacket packet, Supplier<NetworkEvent.Context> contextSupplier) {
@@ -26,6 +33,16 @@ public record ClientSwingMagicAttackPacket(boolean bypassChargeCheck, Interactio
             }
 
             var stack = sender.getItemInHand(packet.hand());
+            if (CrystalBladedStaff.isCrystalBladedStaff(stack)) {
+                CrystalBladedStaffAttackContextManager.requestMissTrigger(
+                        sender,
+                        packet.hand(),
+                        packet.bypassChargeCheck(),
+                        packet.missEvaluationDelayTicks()
+                );
+                return;
+            }
+
             if (stack.getItem() instanceof SwingTriggeredMagicItem swingTriggeredMagicItem
                     && swingTriggeredMagicItem.canTriggerSpellOnSwing(sender, packet.hand())) {
                 swingTriggeredMagicItem.tryTriggerSpellOnSwing(

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -164,6 +164,7 @@
   "item.apprenticecodex.focus_staffbow.loan_mana": "Mana loan is being repaid, so focused casting is unavailable.",
   "item.apprenticecodex.focus_staffbow.loan_mana.rest": "Remaining loan mana: %s",
   "item.apprenticecodex.crystal_bladed_staff.desc": "When hitting attacks, generates mana orbs.",
+  "item.apprenticecodex.crystal_bladed_staff.swing_miss.desc": "Casts its imbued spell when you miss a staff swing.",
   "item.apprenticecodex.spellstained_runic_tablet.desc": "Inscribed scrolls improve its performance.",
   "item.apprenticecodex.spellstained_runic_tablet.desc.hint": "Hold Shift to show details for conditional bonuses",
   "item.apprenticecodex.spellstained_runic_tablet.desc.cooldown": "Cooldown reduction: %1$s%% (schools: %2$s)",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -165,6 +165,7 @@
   "item.apprenticecodex.focus_staffbow.loan_mana": "不足分のマナを補ったことにより、現在集中詠唱は動作しない。",
   "item.apprenticecodex.focus_staffbow.loan_mana.rest": "残り前借りマナ: %s",
   "item.apprenticecodex.crystal_bladed_staff.desc": "攻撃が命中するとマナオーブを生成する。",
+  "item.apprenticecodex.crystal_bladed_staff.swing_miss.desc": "杖を空振りした時に注入されている魔法を放つ。",
   "item.apprenticecodex.zenith_staff.desc_1": "この杖は系統を問わず%s%%の補正を受けて詠唱できる。",
   "item.apprenticecodex.zenith_staff.desc_2": "ただし、[%1$s]以外の系統の消費マナが%2$s%%になる。",
   "item.apprenticecodex.zenith_staff.no_bonus": "この杖は系統の補正を受けている時に効果を発揮する。",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -165,6 +165,7 @@
   "item.apprenticecodex.focus_staffbow.loan_mana": "法力值借贷尚未偿还，无法使用聚焦施法。",
   "item.apprenticecodex.focus_staffbow.loan_mana.rest": "剩余待还法力值：%s",
   "item.apprenticecodex.crystal_bladed_staff.desc": "攻击命中时生成法力宝珠。",
+  "item.apprenticecodex.crystal_bladed_staff.swing_miss.desc": "法杖挥空时释放注入的法术。",
   "item.apprenticecodex.zenith_staff.desc_1": "这把法杖无论派系都能以%s%%的加成施法。",
   "item.apprenticecodex.zenith_staff.desc_2": "但是，除[%1$s]以外派系的法力值消耗会变为%2$s%%。",
   "item.apprenticecodex.zenith_staff.no_bonus": "这把法杖在受到派系加成时才会发挥效果。",


### PR DESCRIPTION
- マナスラッシュの発動を攻撃空振り時に限定するように変更
- 基本的に遅延評価は3tickを上限しており、これを超えるものは意図的に対応を見送っています
    - EpicFightのみモーションと紐づけて検知できるようなのでこれだけ例外で対応
- `runClient`、`runClientBetterCombat`、`runClientEpicFight`、`runGameTestServer`、`runGameTestServerBetterCombat`、`runGameTestEpicFight`は確認済み