### PR TITLE
Iron's Spells 'n Spellbooksと他の一部MODの同時導入時、魔法のレシピが壊れる救済を自分の環境用に追加

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexCommonConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexCommonConfig.java
@@ -12,6 +12,7 @@ public final class ApprenticeCodexCommonConfig {
 
     private static final ModConfigSpec.ConfigValue<java.util.List<? extends String>> SCHOOL_AFFINITY_PRIORITY;
     private static final ModConfigSpec.ConfigValue<java.util.List<? extends String>> SCHOOL_AFFINITY_DENY;
+    private static final ModConfigSpec.BooleanValue ENABLE_IRONS_SPELLBOOKS_SCHOOL_SPELL_CACHE_HOTFIX;
 
     static {
         var builder = new ModConfigSpec.Builder();
@@ -24,6 +25,11 @@ public final class ApprenticeCodexCommonConfig {
                 value -> value instanceof String text && !text.isBlank());
         SCHOOL_AFFINITY_DENY = builder.defineListAllowEmpty("schoolAffinityDeny", java.util.List.<String>of(),
                 value -> value instanceof String text && !text.isBlank());
+        builder.pop();
+        builder.comment("For those who know.")
+                .push("Compatibility");
+        ENABLE_IRONS_SPELLBOOKS_SCHOOL_SPELL_CACHE_HOTFIX =
+                builder.define("enableIronsSpellbooksSchoolSpellCacheHotfix", false);
         builder.pop();
         SPEC = builder.build();
     }
@@ -46,6 +52,10 @@ public final class ApprenticeCodexCommonConfig {
         return SCHOOL_AFFINITY_DENY.get().stream()
                 .map(String::valueOf)
                 .toList();
+    }
+
+    public static boolean enableIronsSpellbooksSchoolSpellCacheHotfix() {
+        return ENABLE_IRONS_SPELLBOOKS_SCHOOL_SPELL_CACHE_HOTFIX.get();
     }
 
     public static void onConfigLoading(ModConfigEvent.Loading event) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/IronsSpellbooksSchoolSpellCacheHotfixMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/IronsSpellbooksSchoolSpellCacheHotfixMixin.java
@@ -1,0 +1,33 @@
+package jp.aquafactory.apprenticecodex.mixin;
+
+import io.redspace.ironsspellbooks.api.config.SpellConfigManager;
+import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
+import io.redspace.ironsspellbooks.network.SyncJsonConfigPacket;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexCommonConfig;
+import net.neoforged.neoforge.event.OnDatapackSyncEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = SpellConfigManager.class, remap = false)
+public abstract class IronsSpellbooksSchoolSpellCacheHotfixMixin {
+    @Inject(method = "handleClientSync", at = @At("RETURN"))
+    private void apprentice_codex$clearSchoolSpellCacheAfterClientSync(SyncJsonConfigPacket packet, CallbackInfo ci) {
+        apprentice_codex$clearSchoolSpellCacheIfEnabled();
+    }
+
+    @Inject(method = "onDatapackSync", at = @At("RETURN"))
+    private static void apprentice_codex$clearSchoolSpellCacheAfterDatapackSync(OnDatapackSyncEvent event, CallbackInfo ci) {
+        apprentice_codex$clearSchoolSpellCacheIfEnabled();
+    }
+
+    @Unique
+    private static void apprentice_codex$clearSchoolSpellCacheIfEnabled() {
+        if (!ApprenticeCodexCommonConfig.enableIronsSpellbooksSchoolSpellCacheHotfix()) {
+            return;
+        }
+        SpellRegistry.onConfigReload();
+    }
+}

--- a/src/main/resources/mixins.apprenticecodex.json
+++ b/src/main/resources/mixins.apprenticecodex.json
@@ -23,6 +23,7 @@
     "EfisCompatPlayerAnimationEventsMixin",
     "EpicFightLivingEntityPatchMixin",
     "EpicFightPlayerPatchMixin",
+    "IronsSpellbooksSchoolSpellCacheHotfixMixin",
     "ItemNameMixin",
     "ItemEntityAccessor",
     "ItemCombinerMenuAccessor",


### PR DESCRIPTION
- 自分のプレイ環境用のため、マルチサーバーの動作は未サポート且つ対応予定無し
- `runClient`、`runGameTestServer`、実環境での動作は確認済み
- レビューは`false`時にリグレッションが発生しないかの観点のみでよく、`true`時は基本動作は自己責任扱いになります。(そのため意図的に説明も削っています)