### PR TITLE
魔力の剣の情報表示のnullチェック漏れを対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/boundsword/BoundSword.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/boundsword/BoundSword.java
@@ -56,10 +56,11 @@ public class BoundSword extends AbstractSpell {
         );
     }
 
-    private float getWeaponDamage(int spellLevel, LivingEntity entity) {
+    private float getWeaponDamage(int spellLevel, @Nullable LivingEntity entity) {
         var rawDamage = 3 + 3 * getSpellPower(spellLevel, entity) / 100.0f;
+        var summonBoost = entity != null ? entity.getAttributeValue(AttributeRegistry.SUMMON_DAMAGE.get()) : 1.0d;
         return rawDamage
-                * (float) entity.getAttributeValue(AttributeRegistry.SUMMON_DAMAGE.get())
+                * (float) summonBoost
                 * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.BOUND_SWORD);
     }
 


### PR DESCRIPTION
Issue #615 の修正

# 原因
- `EnderGrimoire`内で魔法の情報を描画する際に`getUniqueInfo`の第二引数が`@Nullable`なのを考慮せずAttributeを参照しようとしてしまいNull参照例外となった

# 対応内容

- `BoundSword`においてentityが`null`だった場合、Attributeを`1.0d`と仮定して参照しないように修正

# 備考

- `runClient`、`runGameTestServer`確認済み
- これは1.21.1でも再現しうるため要forward-port
- 今後`getUniqueInfo`でのnull参照はやらかしがちで`AbstractSpell`側に`@Nullable`がつけられない以上、テストを追加してリグレッション検知を対応予定