### PR TITLE
魔力の剣の情報表示のnullチェック漏れを対応(1.21.1版)

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/boundsword/BoundSword.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/boundsword/BoundSword.java
@@ -57,10 +57,11 @@ public class BoundSword extends AbstractSpell {
         );
     }
 
-    private float getWeaponDamage(int spellLevel, LivingEntity entity) {
+    private float getWeaponDamage(int spellLevel, @Nullable LivingEntity entity) {
         var rawDamage = 3 + 3 * getSpellPower(spellLevel, entity) / 100.0f;
+        var summonBoost = entity != null ? (float) entity.getAttributeValue(AttributeRegistry.SUMMON_DAMAGE) : 1.0d;
         return rawDamage
-                * (float) entity.getAttributeValue(AttributeRegistry.SUMMON_DAMAGE)
+                * (float) summonBoost
                 * ApprenticeCodexServerConfig.damageMultiplier(DamageMultiplierKey.BOUND_SWORD);
     }
 


### PR DESCRIPTION
- Issue #615 の1.21.1側対応
- PR #616 のforward-port
- `runClient`確認済み、`runGameTestServer` All 620 test passed.