### PR TITLE
PR #618を1.21.1へforward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -512,6 +512,33 @@ public class ApprenticeCodexGameTestScenarios {
             }
         });
     }
+
+    static void ownSpellsUniqueInfoAcceptsNullCaster(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var failures = new ArrayList<String>();
+            for (var spellEntry : SpellRegistry.SPELLS.getEntries()) {
+                var spell = spellEntry.get();
+                var spellId = String.valueOf(spell.getSpellResource());
+                for (var spellLevel = spell.getMinLevel(); spellLevel <= spell.getMaxLevel(); spellLevel++) {
+                    try {
+                        var uniqueInfo = spell.getUniqueInfo(spellLevel, null);
+                        if (uniqueInfo == null) {
+                            failures.add(spellId + " level " + spellLevel + " returned null");
+                        } else if (uniqueInfo.stream().anyMatch(Objects::isNull)) {
+                            failures.add(spellId + " level " + spellLevel + " returned a null component");
+                        }
+                    } catch (RuntimeException exception) {
+                        failures.add(spellId + " level " + spellLevel + " threw "
+                                + exception.getClass().getSimpleName() + ": " + exception.getMessage());
+                    }
+                }
+            }
+
+            helper.assertTrue(failures.isEmpty(),
+                    "Apprentice spell getUniqueInfo must accept null caster: " + String.join("; ", failures));
+        });
+    }
+
     static void tinyLumberjackRecognizesMalumRunewoodAndSoulwoodLogs(GameTestHelper helper) {
         helper.succeedIf(() -> {
             if (!ModList.get().isLoaded(MALUM_MOD_ID)) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -42,6 +42,11 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     private ApprenticeCodexSpellBehaviorGameTests() {
     }
 
+    @GameTest(template = TEMPLATE)
+    public static void ownSpellsUniqueInfoAcceptsNullCaster(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.ownSpellsUniqueInfoAcceptsNullCaster(helper);
+    }
+
     @GameTest(template = TEMPLATE, batch = SENSE_EVIL_ISOLATED_BATCH)
     public static void senseEvilUsesSameCubeForSpawnersAndEntities(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.senseEvilUsesSameCubeForSpawnersAndEntities(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/CircuitHeatStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/CircuitHeatStaffGameTestScenarios.java
@@ -889,15 +889,34 @@ final class CircuitHeatStaffGameTestScenarios extends ApprenticeCodexGameTestSce
     }
 
     static void circuitHeatStaffDropCoolingConsumesWaterSource(GameTestHelper helper) {
-        var waterPos = new BlockPos(0, 2, 0);
-        placeWaterTestBasin(helper, waterPos);
-        helper.setBlock(waterPos, Blocks.WATER);
+        helper.succeedIf(() -> {
+            var waterPos = new BlockPos(0, 2, 0);
+            placeWaterTestBasin(helper, waterPos);
+            helper.setBlock(waterPos, Blocks.WATER);
 
-        var staffStack = new ItemStack(ItemRegistry.CIRCUIT_HEAT_STAFF.get());
-        CircuitHeatStaff.startStaffOverheat(staffStack, helper.getLevel(), 20 * 60);
-        var itemEntity = spawnItem(helper, waterPos, staffStack);
+            var staffStack = new ItemStack(ItemRegistry.CIRCUIT_HEAT_STAFF.get());
+            CircuitHeatStaff.startStaffOverheat(staffStack, helper.getLevel(), 20 * 60);
+            var itemEntity = spawnItem(helper, waterPos, staffStack);
 
-        helper.runAtTickTime(40, () -> {
+            try (var ignored = ApprenticeCodexServerConfig.useCircuitHeatStaffConfigOverrideForGameTest(
+                    20 * 10,
+                    0.10D,
+                    0.10D,
+                    0,
+                    List.of(),
+                    1.0D,
+                    20 * 10,
+                    0,
+                    true,
+                    10,
+                    20 * 10,
+                    3,
+                    true,
+                    true
+            )) {
+                runDropCoolingProcesses(itemEntity, 3);
+            }
+
             var remainingTicks = CircuitHeatStaff.getStaffOverheatRemainingTicks(itemEntity.getItem(), helper.getLevel());
             helper.assertTrue(itemEntity.getAge() == Short.MIN_VALUE,
                     "Circuit Heat Staff drop should use unlimited lifetime while dropped: " + itemEntity.getAge());
@@ -906,7 +925,6 @@ final class CircuitHeatStaffGameTestScenarios extends ApprenticeCodexGameTestSce
                             + remainingTicks);
             helper.assertTrue(helper.getBlockState(waterPos).isAir(),
                     "Circuit Heat Staff water-source cooling should consume the source after three cycles");
-            helper.succeed();
         });
     }
 


### PR DESCRIPTION
## 概要
- #618 の GameTest 修正を `1.21.1-main` へ forward-port
- `getUniqueInfo` の null caster リグレッション検知 GameTest を追加
- 熱回路の杖の水冷リグレッション検知 GameTest を同期的な検証に変更し、flaky になりにくく調整

## 取り込み元
- #618
- 4808b73c76231885d0e59c13e16397f721f7215b
- 5d98d0a0c51874c58ee96c46eba169c66d46f73f

## 検証
- `./gradlew.bat runGameTestServer`
- `./gradlew.bat build`