### PR TITLE
召喚武器魔法がRemoteOwner系で発動するとアンカーがダメージ主として扱われてダメージが変化するおそれがあるのを修正

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/entity/PersistentSummonWeaponEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/entity/PersistentSummonWeaponEntity.java
@@ -1,7 +1,12 @@
 package jp.aquafactory.apprenticecodex.entity;
 
+import jp.aquafactory.apprenticecodex.utility.CombatOwnerResolver;
+import jp.aquafactory.apprenticecodex.utility.CombatOwnerUuidHolder;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -13,12 +18,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public abstract class PersistentSummonWeaponEntity extends Entity implements TraceableEntity {
+public abstract class PersistentSummonWeaponEntity extends Entity implements TraceableEntity, CombatOwnerUuidHolder {
 
     private static final double FOLLOW_MAX_DISTANCE = 0.5;
 
     private UUID ownerUUID;
     private Entity cachedOwner;
+    private UUID combatOwnerUuid;
 
     public PersistentSummonWeaponEntity(EntityType<?> pEntityType, Level pLevel) {
         super(pEntityType, pLevel);
@@ -37,6 +43,7 @@ public abstract class PersistentSummonWeaponEntity extends Entity implements Tra
             ownerUUID = pCompound.getUUID("OwnerUUID");
             cachedOwner = null;
         }
+        loadCombatOwnerUuid(pCompound);
     }
 
     @Override
@@ -44,11 +51,12 @@ public abstract class PersistentSummonWeaponEntity extends Entity implements Tra
         if (ownerUUID != null) {
             pCompound.putUUID("OwnerUUID", ownerUUID);
         }
+        saveCombatOwnerUuid(pCompound);
     }
 
     @Override
     public void tick(){
-        @SuppressWarnings("resource") var level = level();
+        var level = level();
         super.tick();
 
         if (level.isClientSide) {
@@ -64,7 +72,7 @@ public abstract class PersistentSummonWeaponEntity extends Entity implements Tra
 
     @Override
     public final @Nullable Entity getOwner() {
-        @SuppressWarnings("resource") var level = level();
+        var level = level();
         if (cachedOwner != null && !cachedOwner.isRemoved()) {
             return cachedOwner;
         }
@@ -81,7 +89,27 @@ public abstract class PersistentSummonWeaponEntity extends Entity implements Tra
         if (pOwner != null) {
             ownerUUID = pOwner.getUUID();
             cachedOwner = pOwner;
+            combatOwnerUuid = CombatOwnerResolver.captureCombatOwnerUuid(pOwner);
         }
+    }
+
+    protected final DamageSource createCombatDamageSource(ResourceKey<DamageType> damageType) {
+        return createCombatDamageSource(this, damageType);
+    }
+
+    protected final DamageSource createCombatDamageSource(Entity directEntity, ResourceKey<DamageType> damageType) {
+        return CombatOwnerResolver.createDamageSourcePreservingCurrentOwner(
+                level(),
+                directEntity,
+                getOwner(),
+                combatOwnerUuid,
+                damageType
+        );
+    }
+
+    protected final DamageSource createOwnerDirectCombatDamageSource(ResourceKey<DamageType> damageType) {
+        var owner = getOwner();
+        return createCombatDamageSource(owner != null ? owner : this, damageType);
     }
 
     public final void followTargetPosition(Vec3 targetPos){
@@ -111,5 +139,15 @@ public abstract class PersistentSummonWeaponEntity extends Entity implements Tra
 
     public void releaseWeapon(){
         discard();
+    }
+
+    @Override
+    public @Nullable UUID getCombatOwnerUuid() {
+        return combatOwnerUuid;
+    }
+
+    @Override
+    public void setCombatOwnerUuid(@Nullable UUID combatOwnerUuid) {
+        this.combatOwnerUuid = combatOwnerUuid;
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/entity/SummonWeaponEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/entity/SummonWeaponEntity.java
@@ -1,7 +1,12 @@
 package jp.aquafactory.apprenticecodex.entity;
 
+import jp.aquafactory.apprenticecodex.utility.CombatOwnerResolver;
+import jp.aquafactory.apprenticecodex.utility.CombatOwnerUuidHolder;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -13,13 +18,14 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public abstract class SummonWeaponEntity extends Entity implements TraceableEntity {
+public abstract class SummonWeaponEntity extends Entity implements TraceableEntity, CombatOwnerUuidHolder {
 
     private static final double FOLLOW_MAX_DISTANCE = 0.5;
 
     // オーナー系を隠すために意図的にprivate.
     private UUID ownerUUID;
     private Entity cachedOwner;
+    private UUID combatOwnerUuid;
 
     public SummonWeaponEntity(EntityType<?> pEntityType, Level pLevel) {
         super(pEntityType, pLevel);
@@ -33,10 +39,11 @@ public abstract class SummonWeaponEntity extends Entity implements TraceableEnti
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         // SummonWeaponEntity はログアウトをまたぐ所有者復元を許可しない.
         ownerUUID = null;
         cachedOwner = null;
+        combatOwnerUuid = null;
     }
 
     @Override
@@ -46,7 +53,7 @@ public abstract class SummonWeaponEntity extends Entity implements TraceableEnti
 
     @Override
     public void tick(){
-        @SuppressWarnings("resource") var level = level();
+        var level = level();
         super.tick();
 
         if (level.isClientSide) {
@@ -62,7 +69,7 @@ public abstract class SummonWeaponEntity extends Entity implements TraceableEnti
 
     @Override
     public final @Nullable Entity getOwner() {
-        @SuppressWarnings("resource") var level = level();
+        var level = level();
         if (cachedOwner != null && !cachedOwner.isRemoved()) {
             return cachedOwner;
         }
@@ -79,7 +86,27 @@ public abstract class SummonWeaponEntity extends Entity implements TraceableEnti
         if (pOwner != null) {
             ownerUUID = pOwner.getUUID();
             cachedOwner = pOwner;
+            combatOwnerUuid = CombatOwnerResolver.captureCombatOwnerUuid(pOwner);
         }
+    }
+
+    protected final DamageSource createCombatDamageSource(ResourceKey<DamageType> damageType) {
+        return createCombatDamageSource(this, damageType);
+    }
+
+    protected final DamageSource createCombatDamageSource(Entity directEntity, ResourceKey<DamageType> damageType) {
+        return CombatOwnerResolver.createDamageSourcePreservingCurrentOwner(
+                level(),
+                directEntity,
+                getOwner(),
+                combatOwnerUuid,
+                damageType
+        );
+    }
+
+    protected final DamageSource createOwnerDirectCombatDamageSource(ResourceKey<DamageType> damageType) {
+        var owner = getOwner();
+        return createCombatDamageSource(owner != null ? owner : this, damageType);
     }
 
     public final void followTargetPosition(Vec3 targetPos){
@@ -109,5 +136,15 @@ public abstract class SummonWeaponEntity extends Entity implements TraceableEnti
 
     public void releaseWeapon(){
         discard();
+    }
+
+    @Override
+    public @Nullable UUID getCombatOwnerUuid() {
+        return combatOwnerUuid;
+    }
+
+    @Override
+    public void setCombatOwnerUuid(@Nullable UUID combatOwnerUuid) {
+        this.combatOwnerUuid = combatOwnerUuid;
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
@@ -25,6 +25,7 @@ import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerOriginMode;
 import jp.aquafactory.apprenticecodex.spell.AbstractSummonWeaponSpell;
 import jp.aquafactory.apprenticecodex.spell.artisansmash.ArtisanSmashShellEntity;
 import jp.aquafactory.apprenticecodex.spell.flyswatter.FlySwatterProjectileEntity;
+import jp.aquafactory.apprenticecodex.spell.higanbana.HiganbanaKatanaEntity;
 import jp.aquafactory.apprenticecodex.spell.inscribeice.InscribeIce;
 import jp.aquafactory.apprenticecodex.spell.inscribeice.InscribeIceDaggerEntity;
 import jp.aquafactory.apprenticecodex.utility.CombatOwnerResolver;
@@ -33,6 +34,8 @@ import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.MinecraftForge;
@@ -256,6 +259,49 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void remoteOwnerSummonWeaponDamageSourceUsesBoundOwner(GameTestHelper helper) {
+        var level = helper.getLevel();
+        var owner = new FakePlayer(level, new GameProfile(UUID.randomUUID(), "remote_owner_summon_source_test"));
+        level.addFreshEntity(owner);
+
+        var anchor = new RemoteOwnerCastAnchorEntity(EntityRegistry.REMOTE_OWNER_CAST_ANCHOR.get(), level);
+        anchor.bindOwnerName(owner);
+        var anchorPos = helper.absoluteVec(new Vec3(2.5D, 2.0D, 2.5D));
+        anchor.moveTo(anchorPos.x, anchorPos.y, anchorPos.z, 0.0F, 0.0F);
+        level.addFreshEntity(anchor);
+
+        var weapon = new TestHiganbanaKatanaEntity(level, anchor);
+        weapon.setPos(anchorPos.x, anchorPos.y, anchorPos.z);
+        level.addFreshEntity(weapon);
+
+        var directOwnerWeapon = new TestHiganbanaKatanaEntity(level, owner);
+        level.addFreshEntity(directOwnerWeapon);
+
+        try {
+            helper.assertTrue(owner.getUUID().equals(weapon.getCombatOwnerUuid()),
+                    "Remote Owner summon weapon should capture the bound owner UUID.");
+            var source = weapon.createTestDamageSource();
+            helper.assertTrue(source.getEntity() == owner,
+                    "Remote Owner summon weapon DamageSource should use the bound owner.");
+            helper.assertTrue(source.getDirectEntity() == weapon,
+                    "Remote Owner summon weapon DamageSource should keep the weapon as direct entity.");
+
+            var directOwnerSource = directOwnerWeapon.createTestDamageSource();
+            helper.assertTrue(directOwnerSource.getEntity() == owner,
+                    "Summon weapon DamageSource should preserve a current FakePlayer owner when it is not a proxy.");
+            helper.assertTrue(directOwnerSource.getDirectEntity() == directOwnerWeapon,
+                    "Summon weapon DamageSource should keep the normal weapon as direct entity.");
+        } finally {
+            weapon.discard();
+            directOwnerWeapon.discard();
+            anchor.discard();
+            owner.discard();
+        }
+
+        helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void remoteOwnerCastDatagenIncludesRaiseDeadImpactProfile(GameTestHelper helper) {
         var raiseDeadId = requireId(SpellRegistry.RAISE_DEAD_SPELL.getId());
         var profile = RemoteOwnerCastSpellProfileDataGenerator.createProfileDefinitions().stream()
@@ -434,5 +480,15 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
             throw new IllegalStateException("Missing spell id");
         }
         return id;
+    }
+
+    private static final class TestHiganbanaKatanaEntity extends HiganbanaKatanaEntity {
+        private TestHiganbanaKatanaEntity(net.minecraft.world.level.Level level, LivingEntity owner) {
+            super(EntityRegistry.HIGANBANA_KATANA.get(), level, owner);
+        }
+
+        private DamageSource createTestDamageSource() {
+            return createCombatDamageSource(DamageTypes.HIGANBANA);
+        }
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/archermultiple/ArcherMultipleBowEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/archermultiple/ArcherMultipleBowEntity.java
@@ -309,7 +309,7 @@ public class ArcherMultipleBowEntity extends PersistentSummonWeaponEntity {
         var soundEvent = isLastBullet ? SoundRegistry.VANILLA_PROJECTILE_SHOOT.get() : SoundEvents.ARROW_SHOOT;
         var sourceType = isLastBullet ? DamageTypes.ARCHER_MULTIPLE_LAST : DamageTypes.ARCHER_MULTIPLE;
 
-        var source = CombatTools.getDamageSource(level, this, getOwner(), sourceType);
+        var source = createCombatDamageSource(sourceType);
         CombatTools.applyDamage(target, damage, source, SpellRegistry.ARCHER_MULTIPLE.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);
         AudioTools.playSoundFromEntity(level, this, soundEvent, SoundSource.PLAYERS, 0.5f);
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/breachingenemy/BreachingEnemyShotgunEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/breachingenemy/BreachingEnemyShotgunEntity.java
@@ -55,7 +55,7 @@ public class BreachingEnemyShotgunEntity extends SummonWeaponEntity {
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
         damage = pCompound.getFloat("Damage");
         range = pCompound.getFloat("Range");
@@ -189,7 +189,7 @@ public class BreachingEnemyShotgunEntity extends SummonWeaponEntity {
             }
 
             var finalDamage = damage * entry.getValue();
-            var source = CombatTools.getDamageSource(level(), this, getOwner(), DamageTypes.BREACHING_ENEMY);
+            var source = createCombatDamageSource(DamageTypes.BREACHING_ENEMY);
             CombatTools.applyDamage(entity, finalDamage, source, SpellRegistry.BREACHING_ENEMY.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);
 
             if (entity instanceof LivingEntity livingEntity){

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/bulletstream/BulletStreamMinigunEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/bulletstream/BulletStreamMinigunEntity.java
@@ -188,7 +188,7 @@ public class BulletStreamMinigunEntity extends SummonWeaponEntity implements Geo
         var hitResult = RaycastTools.raycastFromEye(owner, range, 0.5, e -> CombatTools.isValidCombatTarget(e, this) && e != owner);
         if (hitResult.hitEntity() != null) {
             var target = hitResult.hitEntity();
-            var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.BULLET_STREAM);
+            var source = createCombatDamageSource(DamageTypes.BULLET_STREAM);
             CombatTools.applyDamage(target, resolveCurrentDamage(owner), source, SpellRegistry.BULLET_STREAM.get().getSchoolType(), CombatTools.KnockbackTypes.NO_KNOCKBACK);
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/commencefire/CommenceFireRifleEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/commencefire/CommenceFireRifleEntity.java
@@ -193,7 +193,7 @@ public class CommenceFireRifleEntity extends SummonWeaponEntity {
 
     public void damageTarget(Entity target, boolean isHeadShot, Level level) {
         var resoluteTarget = CombatTools.resolutePartEntity(target);
-        var source = CombatTools.getDamageSource(level, getOwner(), DamageTypes.COMMENCE_FIRE);
+        var source = createOwnerDirectCombatDamageSource(DamageTypes.COMMENCE_FIRE);
         var headshotRate = headshotPercent / 100.0f;
         var finalDamage = damage * (isHeadShot ? headshotRate : 1);
         CombatTools.applyDamage(resoluteTarget, finalDamage, source, SpellRegistry.COMMENCE_FIRE.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/dualacrobat/DualAcrobatSmgEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/dualacrobat/DualAcrobatSmgEntity.java
@@ -82,7 +82,7 @@ public class DualAcrobatSmgEntity extends SummonWeaponEntity {
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag tag) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag tag) {
         super.readAdditionalSaveData(tag);
         damage = tag.getFloat("Damage");
         range = tag.getFloat("Range");
@@ -294,7 +294,7 @@ public class DualAcrobatSmgEntity extends SummonWeaponEntity {
 
         if (aimResult.hitEntity() != null) {
             var target = CombatTools.resolutePartEntity(aimResult.hitEntity());
-            var source = CombatTools.getDamageSource(level(), this, getOwner(), DamageTypes.DUAL_ACROBAT);
+            var source = createCombatDamageSource(DamageTypes.DUAL_ACROBAT);
             CombatTools.applyDamage(target, damage, source, SpellRegistry.DUAL_ACROBAT.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/gracedrain/GracedRainCloudEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/gracedrain/GracedRainCloudEntity.java
@@ -320,7 +320,7 @@ public class GracedRainCloudEntity extends SummonWeaponEntity {
                 center.x - halfExtent, center.y - HEIGHT_OFFSET, center.z - halfExtent,
                 center.x + halfExtent, center.y, center.z + halfExtent
         );
-        var source = CombatTools.getDamageSource(level, this, getOwner(), DamageTypes.GRACED_RAIN);
+        var source = createCombatDamageSource(DamageTypes.GRACED_RAIN);
         var school = SpellRegistry.GRACED_RAIN.get().getSchoolType();
         var targets = level.getEntitiesOfClass(LivingEntity.class, box, LivingEntity::isAlive);
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/grindrunner/GrindRunnerWheelEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/grindrunner/GrindRunnerWheelEntity.java
@@ -1011,7 +1011,7 @@ public class GrindRunnerWheelEntity extends SummonWeaponEntity implements GeoEnt
         }
 
         var level = level();
-        var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.GRIND_RUNNER);
+        var source = createCombatDamageSource(DamageTypes.GRIND_RUNNER);
         var includeOwner = state == WheelState.LAUNCHED;
         for (var target : resolveDamageTargets(owner, includeOwner)) {
             CombatTools.applyDamage(target, damageAmount, source, SpellRegistry.GRIND_RUNNER.get().getSchoolType(), knockbackType);

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/higanbana/HiganbanaKatanaEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/higanbana/HiganbanaKatanaEntity.java
@@ -154,7 +154,7 @@ public class HiganbanaKatanaEntity extends SummonWeaponEntity implements GeoEnti
 
         if (getOwner() instanceof LivingEntity owner) {
             var point = getLookAngle().normalize().scale(0.75);
-            var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.HIGANBANA);
+            var source = createCombatDamageSource(DamageTypes.HIGANBANA);
             var hitResult = RaycastTools.hitsSphere(
                     level,
                     position().add(point),
@@ -247,7 +247,7 @@ public class HiganbanaKatanaEntity extends SummonWeaponEntity implements GeoEnti
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
         damage = pCompound.getFloat("Damage");
         slashStandbyTick = pCompound.getInt("SlashStandbyTick");

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/lethalassault/LethalAssaultRifleEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/lethalassault/LethalAssaultRifleEntity.java
@@ -62,7 +62,7 @@ public class LethalAssaultRifleEntity extends SummonWeaponEntity implements Anti
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag tag) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag tag) {
         super.readAdditionalSaveData(tag);
         damage = tag.getFloat("Damage");
         recoilTick = tag.getInt("RecoilTick");
@@ -187,7 +187,7 @@ public class LethalAssaultRifleEntity extends SummonWeaponEntity implements Anti
 
         if (aimResult.hitEntity() != null) {
             var target = CombatTools.resolutePartEntity(aimResult.hitEntity());
-            var source = CombatTools.getDamageSource(level(), this, getOwner(), DamageTypes.LETHAL_ASSAULT);
+            var source = createCombatDamageSource(DamageTypes.LETHAL_ASSAULT);
             CombatTools.applyDamage(target, damage, source, SpellRegistry.LETHAL_ASSAULT.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mantisleap/MantisLeapBladeEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mantisleap/MantisLeapBladeEntity.java
@@ -124,7 +124,7 @@ public class MantisLeapBladeEntity extends SummonWeaponEntity implements GeoEnti
 
         if (getOwner() instanceof LivingEntity owner) {
             var point = getLookAngle().normalize().scale(1.5);
-            var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.MANTIS_LEAP);
+            var source = createCombatDamageSource(DamageTypes.MANTIS_LEAP);
             var hitResult = RaycastTools.hitsSphere(
                     level,
                     position().add(point),
@@ -166,7 +166,7 @@ public class MantisLeapBladeEntity extends SummonWeaponEntity implements GeoEnti
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
         damage = pCompound.getFloat("Damage");
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLightChargeCutEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLightChargeCutEntity.java
@@ -4,6 +4,8 @@ import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import jp.aquafactory.apprenticecodex.utility.AudioTools;
+import jp.aquafactory.apprenticecodex.utility.CombatOwnerResolver;
+import jp.aquafactory.apprenticecodex.utility.CombatOwnerUuidHolder;
 import jp.aquafactory.apprenticecodex.utility.CombatTools;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
@@ -20,12 +22,13 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-public class MoonLightChargeCutEntity extends Entity implements TraceableEntity {
+public class MoonLightChargeCutEntity extends Entity implements TraceableEntity, CombatOwnerUuidHolder {
     public static final int PROCESS_START_DELAY_TICKS = 2;
     public static final int PROCESS_DURATION_TICKS = 15;
     public static final float START_OFFSET_BLOCKS = 2.0f;
@@ -50,6 +53,7 @@ public class MoonLightChargeCutEntity extends Entity implements TraceableEntity 
             SynchedEntityData.defineId(MoonLightChargeCutEntity.class, EntityDataSerializers.FLOAT);
 
     private Entity owner;
+    private UUID combatOwnerUuid;
     private float damage;
     private float previousProcessedDistance;
     private final Set<UUID> damagedEntityIds = new HashSet<>();
@@ -62,6 +66,7 @@ public class MoonLightChargeCutEntity extends Entity implements TraceableEntity 
     public MoonLightChargeCutEntity(EntityType<? extends MoonLightChargeCutEntity> entityType, Level level, Entity owner) {
         this(entityType, level);
         this.owner = owner;
+        combatOwnerUuid = CombatOwnerResolver.captureCombatOwnerUuid(owner);
     }
 
     @Override
@@ -142,7 +147,13 @@ public class MoonLightChargeCutEntity extends Entity implements TraceableEntity 
         var right = calculateRightDirection(forward);
         var up = calculateUpDirection(forward, right);
 
-        var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.MOON_LIGHT);
+        var source = CombatOwnerResolver.createDamageSourcePreservingCurrentOwner(
+                level,
+                this,
+                owner,
+                combatOwnerUuid,
+                DamageTypes.MOON_LIGHT
+        );
         var school = SpellRegistry.MOON_LIGHT.get().getSchoolType();
         var candidates = level.getEntitiesOfClass(
                 LivingEntity.class,
@@ -281,6 +292,7 @@ public class MoonLightChargeCutEntity extends Entity implements TraceableEntity 
     @Override
     protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         damage = pCompound.getFloat("Damage");
+        loadCombatOwnerUuid(pCompound);
         entityData.set(DISTANCE_BLOCKS, pCompound.getFloat("DistanceBlocks"));
         var processedDistance = pCompound.getFloat("ProcessedDistance");
         entityData.set(PROCESSED_DISTANCE, processedDistance);
@@ -290,6 +302,7 @@ public class MoonLightChargeCutEntity extends Entity implements TraceableEntity 
     @Override
     protected void addAdditionalSaveData(@NotNull CompoundTag pCompound) {
         pCompound.putFloat("Damage", damage);
+        saveCombatOwnerUuid(pCompound);
         pCompound.putFloat("DistanceBlocks", getDistanceBlocks());
         pCompound.putFloat("ProcessedDistance", getProcessedDistance());
     }
@@ -375,6 +388,16 @@ public class MoonLightChargeCutEntity extends Entity implements TraceableEntity 
 
     private void setProcessedDistance(float processedDistance) {
         entityData.set(PROCESSED_DISTANCE, Mth.clamp(processedDistance, 0.0f, getDistanceBlocks()));
+    }
+
+    @Override
+    public @Nullable UUID getCombatOwnerUuid() {
+        return combatOwnerUuid;
+    }
+
+    @Override
+    public void setCombatOwnerUuid(@Nullable UUID combatOwnerUuid) {
+        this.combatOwnerUuid = combatOwnerUuid;
     }
 
     private record ProjectionRange(double min, double max) {}

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLightKatanaEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLightKatanaEntity.java
@@ -140,7 +140,7 @@ public class MoonLightKatanaEntity extends SummonWeaponEntity implements GeoEnti
 
         if (getOwner() instanceof LivingEntity owner) {
             var point = getLookAngle().normalize().scale(0.75);
-            var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.MOON_LIGHT);
+            var source = createCombatDamageSource(DamageTypes.MOON_LIGHT);
             var hitResult = RaycastTools.hitsSphere(
                     level,
                     position().add(point),
@@ -186,7 +186,7 @@ public class MoonLightKatanaEntity extends SummonWeaponEntity implements GeoEnti
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
         damage = pCompound.getFloat("Damage");
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxWeaponryEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxWeaponryEntity.java
@@ -16,7 +16,6 @@ import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -277,7 +276,7 @@ public class PhalanxWeaponryEntity extends SummonWeaponEntity implements GeoEnti
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
         damage = pCompound.getFloat("Damage");
         thrustBeamLength = pCompound.getFloat("ThrustBeamLength");
@@ -315,7 +314,6 @@ public class PhalanxWeaponryEntity extends SummonWeaponEntity implements GeoEnti
     @Override
     public void onSyncedDataUpdated(@NotNull EntityDataAccessor<?> key) {
         super.onSyncedDataUpdated(key);
-        //noinspection resource
         if (!level().isClientSide || !GUARD_FLASH_SERIAL.equals(key)) {
             return;
         }
@@ -336,7 +334,6 @@ public class PhalanxWeaponryEntity extends SummonWeaponEntity implements GeoEnti
     }
 
     public float getGuardFlashStrength(float partialTick) {
-        //noinspection resource
         if (!level().isClientSide || clientFlashStartTick < 0.0f) {
             return 0.0f;
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/precisionjack/PrecisionJackKnifeEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/precisionjack/PrecisionJackKnifeEntity.java
@@ -145,7 +145,7 @@ public class PrecisionJackKnifeEntity extends SummonWeaponEntity implements GeoE
         }
 
         var point = getLookAngle().normalize().scale(0.75);
-        var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.PRECISION_JACK);
+        var source = createCombatDamageSource(DamageTypes.PRECISION_JACK);
 
         var hitResult = RaycastTools.hitsSphere(
                 level,

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/quickarms/QuickArmsHandgunEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/quickarms/QuickArmsHandgunEntity.java
@@ -38,7 +38,7 @@ public class QuickArmsHandgunEntity extends SummonWeaponEntity {
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
         range = pCompound.getFloat("Range");
         standbyDamage = pCompound.getFloat("StandbyDamage");
@@ -122,7 +122,7 @@ public class QuickArmsHandgunEntity extends SummonWeaponEntity {
         faceTarget(aimResult.hitPosition());
         if (aimResult.hitEntity() != null) {
             var target = CombatTools.resolutePartEntity(aimResult.hitEntity());
-            var source = CombatTools.getDamageSource(level(), this, getOwner(), DamageTypes.QUICK_ARMS);
+            var source = createCombatDamageSource(DamageTypes.QUICK_ARMS);
             CombatTools.applyDamage(target, damage, source, SpellRegistry.QUICK_ARMS.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/silentassassin/SilentAssassinRifleEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/silentassassin/SilentAssassinRifleEntity.java
@@ -187,7 +187,7 @@ public class SilentAssassinRifleEntity extends SummonWeaponEntity {
     }
 
     public void damageTarget(Entity target, float finalDamage, Level level) {
-        var source = CombatTools.getDamageSource(level, this, getOwner(), DamageTypes.SILENT_ASSASSIN);
+        var source = createCombatDamageSource(DamageTypes.SILENT_ASSASSIN);
         CombatTools.applyDamage(target, finalDamage, source, SpellRegistry.SILENT_ASSASSIN.get().getSchoolType(), CombatTools.KnockbackTypes.DEFAULT);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBladeKatanaEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBladeKatanaEntity.java
@@ -130,7 +130,7 @@ public class SlashBladeKatanaEntity extends SummonWeaponEntity implements GeoEnt
 
         if ((getOwner() instanceof LivingEntity owner)) {
             var point = getLookAngle().normalize().scale(0.75);
-            var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.SLASH_BLADE);
+            var source = createCombatDamageSource(DamageTypes.SLASH_BLADE);
             var hitResult = RaycastTools.hitsSphere(level,
                     position().add(point),
                     2.5,
@@ -159,7 +159,7 @@ public class SlashBladeKatanaEntity extends SummonWeaponEntity implements GeoEnt
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
         damage = pCompound.getFloat("Damage");
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/thermalprocess/ThermalProcessThrowerEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/thermalprocess/ThermalProcessThrowerEntity.java
@@ -219,7 +219,7 @@ public class ThermalProcessThrowerEntity extends SummonWeaponEntity {
         var beamEnd = blockHit.getType() == HitResult.Type.BLOCK
                 ? blockHit.getLocation()
                 : beamStart.add(direction.scale(getEffectiveRange()));
-        var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.THERMAL_PROCESS);
+        var source = createCombatDamageSource(DamageTypes.THERMAL_PROCESS);
         var school = SpellRegistry.THERMAL_PROCESS.get().getSchoolType();
         var currentDamage = resolveCurrentDamage(owner);
         var hits = RaycastTools.sampleBeamHits(

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/tinylumberjack/TinyLumberjackSawEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/tinylumberjack/TinyLumberjackSawEntity.java
@@ -257,7 +257,7 @@ public class TinyLumberjackSawEntity extends SummonWeaponEntity implements GeoEn
         refreshLockedCombatTarget();
 
         if (tickCount % 3 == 0) {
-            var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.TINY_LUMBERJACK);
+            var source = createCombatDamageSource(DamageTypes.TINY_LUMBERJACK);
             var hitResult = RaycastTools.sampleBeamHits(level,
                     position(),
                     position().add(getLookAngle().normalize().scale(1.0)),

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/tirovolley/TiroVolleyMusketEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/tirovolley/TiroVolleyMusketEntity.java
@@ -200,7 +200,7 @@ public class TiroVolleyMusketEntity extends SummonWeaponEntity implements GeoEnt
         faceTarget(hitPosition);
         setFireRotationByVector(hitPosition);
 
-        var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.TIRO_VOLLEY);
+        var source = createCombatDamageSource(DamageTypes.TIRO_VOLLEY);
         CombatTools.applyDamage(
                 target,
                 resolveCurrentDamage(owner),

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/worldflatter/WorldFlatterDrillEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/worldflatter/WorldFlatterDrillEntity.java
@@ -139,7 +139,7 @@ public class WorldFlatterDrillEntity extends SummonWeaponEntity implements GeoEn
     }
 
     @Override
-    protected void readAdditionalSaveData(CompoundTag pCompound) {
+    protected void readAdditionalSaveData(@NotNull CompoundTag pCompound) {
         super.readAdditionalSaveData(pCompound);
     }
 
@@ -207,13 +207,12 @@ public class WorldFlatterDrillEntity extends SummonWeaponEntity implements GeoEn
         var attachPosition = targetCenter.subtract(ownerLook.scale(MOB_ATTACH_DISTANCE));
         moveToEntityTarget(target, attachPosition, owner.getYRot(), owner.getXRot(), ENTITY_REACH_TICKS);
         if (moveTick >= ENTITY_REACH_TICKS) {
-            performMobAttack(owner, target);
+            performMobAttack(target);
         }
     }
 
-    private void performMobAttack(LivingEntity owner, LivingEntity target) {
-        var level = level();
-        var source = CombatTools.getDamageSource(level, this, owner, DamageTypes.WORLD_FLATTER);
+    private void performMobAttack(LivingEntity target) {
+        var source = createCombatDamageSource(DamageTypes.WORLD_FLATTER);
         var damaged = CombatTools.applyDamage(
                 target,
                 damage,

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/CombatOwnerResolver.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/CombatOwnerResolver.java
@@ -53,7 +53,28 @@ public final class CombatOwnerResolver {
         return CombatTools.getDamageSource(level, directEntity, damageType);
     }
 
+    public static DamageSource createDamageSourcePreservingCurrentOwner(
+            Level level,
+            Entity directEntity,
+            @Nullable Entity currentOwner,
+            @Nullable UUID combatOwnerUuid,
+            ResourceKey<DamageType> damageType
+    ) {
+        var combatOwner = resolveCombatOwner(level, currentOwner, combatOwnerUuid);
+        if (combatOwner != null) {
+            return CombatTools.getDamageSource(level, directEntity, combatOwner, damageType);
+        }
+        if (currentOwner != null && !isUnresolvedProxyOwner(currentOwner, combatOwnerUuid)) {
+            return CombatTools.getDamageSource(level, directEntity, currentOwner, damageType);
+        }
+        return CombatTools.getDamageSource(level, directEntity, damageType);
+    }
+
     private static boolean isDirectPlayerOwner(@Nullable Entity owner) {
         return owner instanceof Player && !(owner instanceof net.minecraftforge.common.util.FakePlayer);
+    }
+
+    private static boolean isUnresolvedProxyOwner(Entity owner, @Nullable UUID combatOwnerUuid) {
+        return combatOwnerUuid != null && owner instanceof CombatOwnerUuidSource;
     }
 }


### PR DESCRIPTION
- PR #625 のローカルレビュー時に指摘された事項に関して、武器召喚魔法関連に横断的に対応
- あくまでもDamageSourceのみにフォーカスして対応
- `runClient`、`runGameTestServer`確認済み