### PR TITLE
[codex] 職人の歓喜の限定クールダウン短縮を共通化

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -1072,6 +1072,16 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
         EquipmentSpellBehaviorBridgeGameTestScenarios.craftsmansDelightAppliesToHarvestMoonAndEarthForgeManaAndCooldown(helper);
     }
 
+    @GameTest(template = TEMPLATE)
+    public static void craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(GameTestHelper helper) {
+        EquipmentSpellBehaviorBridgeGameTestScenarios.craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void strongestLimitedBaseCooldownSelectionIgnoresStacking(GameTestHelper helper) {
+        EquipmentSpellBehaviorBridgeGameTestScenarios.strongestLimitedBaseCooldownSelectionIgnoresStacking(helper);
+    }
+
     @GameTest(template = TEMPLATE, batch = MINING_SPELL_ISOLATED_BATCH)
     public static void craftsmansDelightExtendsTouchDigRange(GameTestHelper helper) {
         EquipmentSpellBehaviorBridgeGameTestScenarios.craftsmansDelightExtendsTouchDigRange(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellBehaviorBridgeGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellBehaviorBridgeGameTestScenarios.java
@@ -12,6 +12,9 @@ import java.util.List;
 import jp.aquafactory.apprenticecodex.compat.malum.MalumHauntedCompat;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.datagen.DamageTypeTagGenerator;
+import jp.aquafactory.apprenticecodex.item.ScrollcasterGauntlet;
+import jp.aquafactory.apprenticecodex.item.ScrollcasterGauntletCastEvent;
+import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelight;
 import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightCooldownReductionEvent;
 import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightManaCostDiscountEvent;
@@ -271,6 +274,73 @@ final class EquipmentSpellBehaviorBridgeGameTestScenarios extends ApprenticeCode
             assertCraftsmansDelightBasicDiscountOnly(helper, player, SpellRegistry.EARTH_FORGE.get(), 20, "Earth Forge");
         });
     }
+
+    static void craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "craftsmans_scrollcaster_cooldown_policy_test");
+            equipRingCurio(player, new ItemStack(ItemRegistry.CRAFTSMANS_DELIGHT.get()));
+            var spell = SpellRegistry.HARVEST_MOON.get();
+            var gauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
+            ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(spell));
+            ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
+            var magicData = MagicData.getPlayerMagicData(player);
+            helper.assertTrue(magicData != null,
+                    "CraftsmansDelight Scrollcaster Gauntlet cooldown test could not resolve player magic data");
+            magicData.setPlayerCastingItem(gauntlet.copy());
+
+            var expectedCooldown = WeaponImbueCooldownHelper.getEffectiveSpellCooldown(
+                    spell,
+                    player,
+                    CastSource.SWORD,
+                    gauntlet
+            );
+            helper.assertTrue(expectedCooldown < io.redspace.ironsspellbooks.capabilities.magic.MagicManager.getEffectiveSpellCooldown(
+                            spell,
+                            player,
+                            CastSource.SWORD
+                    ),
+                    "CraftsmansDelight Scrollcaster Gauntlet cooldown should be reduced from the normal sword cooldown");
+
+            var craftsmansFirstEvent = new SpellCooldownAddedEvent.Pre(
+                    io.redspace.ironsspellbooks.capabilities.magic.MagicManager.getEffectiveSpellCooldown(spell, player, CastSource.SWORD),
+                    spell,
+                    player,
+                    CastSource.SWORD
+            );
+            CraftsmansDelightCooldownReductionEvent.onSpellCooldownAdded(craftsmansFirstEvent);
+            ScrollcasterGauntletCastEvent.onSpellCooldownAdded(craftsmansFirstEvent);
+            helper.assertTrue(craftsmansFirstEvent.getEffectiveCooldown() == expectedCooldown,
+                    "CraftsmansDelight -> Scrollcaster Gauntlet cooldown order should keep the reduced gauntlet cooldown but got "
+                            + craftsmansFirstEvent.getEffectiveCooldown() + " / expected " + expectedCooldown);
+
+            var scrollcasterFirstEvent = new SpellCooldownAddedEvent.Pre(
+                    io.redspace.ironsspellbooks.capabilities.magic.MagicManager.getEffectiveSpellCooldown(spell, player, CastSource.SWORD),
+                    spell,
+                    player,
+                    CastSource.SWORD
+            );
+            ScrollcasterGauntletCastEvent.onSpellCooldownAdded(scrollcasterFirstEvent);
+            CraftsmansDelightCooldownReductionEvent.onSpellCooldownAdded(scrollcasterFirstEvent);
+            helper.assertTrue(scrollcasterFirstEvent.getEffectiveCooldown() == expectedCooldown,
+                    "Scrollcaster Gauntlet -> CraftsmansDelight cooldown order should keep the reduced gauntlet cooldown but got "
+                            + scrollcasterFirstEvent.getEffectiveCooldown() + " / expected " + expectedCooldown);
+        });
+    }
+
+    static void strongestLimitedBaseCooldownSelectionIgnoresStacking(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(90) == 90,
+                    "No limited cooldown candidate should keep the base cooldown");
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(90, 45, 30) == 30,
+                    "Limited cooldown candidates should choose only the strongest reduction");
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(90, 0, -1, 60) == 60,
+                    "Invalid limited cooldown candidates should be ignored");
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(0, 1) == 0,
+                    "Zero base cooldown should stay zero");
+        });
+    }
+
     static void craftsmansDelightExtendsTouchDigRange(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var spell = new TouchDigSpell();

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/WeaponImbueCooldownHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/WeaponImbueCooldownHelper.java
@@ -4,7 +4,9 @@ import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.util.Utils;
-import io.redspace.ironsspellbooks.capabilities.magic.MagicManager;
+import io.redspace.ironsspellbooks.config.ServerConfigs;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelight;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightSpellSupport;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
@@ -19,12 +21,39 @@ public final class WeaponImbueCooldownHelper {
             CastSource castSource,
             @Nullable ItemStack castingStack
     ) {
-        if (!shouldIgnoreWeaponImbueCooldownMultiplier(castingStack, spell, castSource)) {
-            return MagicManager.getEffectiveSpellCooldown(spell, player, castSource);
+        var baseCooldown = resolveLimitedBaseCooldown(spell, player);
+        var playerCooldownModifier = player.getAttributeValue(AttributeRegistry.COOLDOWN_REDUCTION.get());
+        var itemCooldownModifier = castSource == CastSource.SWORD
+                && !shouldIgnoreWeaponImbueCooldownMultiplier(castingStack, spell, castSource)
+                ? ServerConfigs.SWORDS_CD_MULTIPLIER.get().floatValue()
+                : 1.0f;
+        return (int) (baseCooldown * (2 - Utils.softCapFormula(playerCooldownModifier)) * itemCooldownModifier);
+    }
+
+    private static int resolveLimitedBaseCooldown(AbstractSpell spell, Player player) {
+        var baseCooldown = Math.max(0, spell.getSpellCooldown());
+        if (baseCooldown == 0) {
+            return 0;
         }
 
-        var playerCooldownModifier = player.getAttributeValue(AttributeRegistry.COOLDOWN_REDUCTION.get());
-        return (int) (spell.getSpellCooldown() * (2 - Utils.softCapFormula(playerCooldownModifier)));
+        var craftsmansDelightCooldown = CraftsmansDelightSpellSupport.isCooldownReductionTarget(spell)
+                ? CraftsmansDelight.applyCooldownDiscount(baseCooldown, player)
+                : baseCooldown;
+        return selectStrongestLimitedBaseCooldown(baseCooldown, craftsmansDelightCooldown);
+    }
+
+    public static int selectStrongestLimitedBaseCooldown(int baseCooldown, int... candidateCooldowns) {
+        var selectedCooldown = Math.max(0, baseCooldown);
+        if (selectedCooldown == 0) {
+            return 0;
+        }
+
+        for (var candidateCooldown : candidateCooldowns) {
+            if (candidateCooldown > 0 && candidateCooldown < selectedCooldown) {
+                selectedCooldown = candidateCooldown;
+            }
+        }
+        return selectedCooldown;
     }
 
     public static boolean shouldIgnoreWeaponImbueCooldownMultiplier(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
@@ -4,11 +4,10 @@ import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
-import io.redspace.ironsspellbooks.api.util.Utils;
 import io.redspace.ironsspellbooks.compat.Curios;
-import io.redspace.ironsspellbooks.config.ServerConfigs;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
@@ -230,7 +229,7 @@ public class CraftsmansDelight extends Item implements ICurioItem, IJeiInfoItem 
             return spell.getSpellCooldown();
         }
 
-        return applyCooldownModifiers(applyCooldownDiscount(spell.getSpellCooldown(), player), player, castSource);
+        return WeaponImbueCooldownHelper.getEffectiveSpellCooldown(spell, player, castSource, ItemStack.EMPTY);
     }
 
     public static void applyCastingMobility(@Nullable LivingEntity entity) {
@@ -349,14 +348,6 @@ public class CraftsmansDelight extends Item implements ICurioItem, IJeiInfoItem 
                         .map(slotResult -> slotResult.stack().copy())
                         .orElse(ItemStack.EMPTY))
                 .orElse(ItemStack.EMPTY);
-    }
-
-    private static int applyCooldownModifiers(int baseCooldown, Player player, CastSource castSource) {
-        var playerCooldownModifier = player.getAttributeValue(AttributeRegistry.COOLDOWN_REDUCTION.get());
-        var itemCooldownModifier = castSource == CastSource.SWORD
-                ? ServerConfigs.SWORDS_CD_MULTIPLIER.get().floatValue()
-                : 1.0f;
-        return (int) (baseCooldown * (2 - Utils.softCapFormula(playerCooldownModifier)) * itemCooldownModifier);
     }
 
     private static boolean consumeManaForSneakUse(Player player, ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelightCooldownReductionEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelightCooldownReductionEvent.java
@@ -1,8 +1,12 @@
 package jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight;
 
 import io.redspace.ironsspellbooks.api.events.SpellCooldownAddedEvent;
+import io.redspace.ironsspellbooks.api.magic.MagicData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
@@ -11,7 +15,7 @@ public final class CraftsmansDelightCooldownReductionEvent {
     private CraftsmansDelightCooldownReductionEvent() {
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onSpellCooldownAdded(SpellCooldownAddedEvent.Pre event) {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
@@ -24,6 +28,13 @@ public final class CraftsmansDelightCooldownReductionEvent {
         }
 
         // GUI プレビュー系は entity == null で魔法情報を読むことがあるため、実際にクールダウンを付与する経路だけで反映する。
-        event.setEffectiveCooldown(CraftsmansDelight.getReducedEffectiveCooldown(event.getSpell(), player, event.getCastSource()));
+        var magicData = MagicData.getPlayerMagicData(player);
+        var castingItem = magicData == null ? ItemStack.EMPTY : magicData.getPlayerCastingItem();
+        event.setEffectiveCooldown(WeaponImbueCooldownHelper.getEffectiveSpellCooldown(
+                event.getSpell(),
+                player,
+                event.getCastSource(),
+                castingItem
+        ));
     }
 }


### PR DESCRIPTION
## 概要

- `WeaponImbueCooldownHelper` に限定クールダウン短縮の基礎クールダウン解決を集約
- Craftsman's Delight のクールダウン短縮を共通ヘルパー経由に変更し、Scrollcaster Gauntlet の武器付与クールダウン方針を維持
- 今後同種の限定クールダウン短縮が増えた場合に、重複時は最も強い短縮のみを採用する選択処理を追加
- Harvest Moon + Scrollcaster Gauntlet + Craftsman's Delight の回帰 GameTest と、重複候補選択の GameTest を追加

## 背景

Scrollcaster Gauntlet の右クリック詠唱では `CastSource.SWORD` としてクールダウンが付与されますが、Craftsman's Delight 側のイベントが `castingStack` を見ずにクールダウンを再計算していたため、Scrollcaster Gauntlet が持つ武器付与クールダウン倍率の無視ポリシーが落ちる経路がありました。

## 影響

- Craftsman's Delight 対象魔法の限定クールダウン短縮は、共通ヘルパー経由で他の装備クールダウン方針と合成されます。
- 既存の `CraftsmansDelight.getReducedEffectiveCooldown` は互換用ラッパーとして残しています。
- 重複短縮は乗算せず、最終的に最も短い基礎クールダウン候補だけを採用します。

## 検証

- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`（621 required tests passed）
- ローカルレビュー済み
- `runClient` はローカル確認済み