### PR TITLE
PR #630 を 1.21.1-main へ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -1613,6 +1613,16 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE, batch = MINING_SPELL_ISOLATED_BATCH)
+    public static void craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(GameTestHelper helper) {
+        EquipmentSpellBehaviorBridgeGameTestScenarios.craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = MINING_SPELL_ISOLATED_BATCH)
+    public static void strongestLimitedBaseCooldownSelectionIgnoresStacking(GameTestHelper helper) {
+        EquipmentSpellBehaviorBridgeGameTestScenarios.strongestLimitedBaseCooldownSelectionIgnoresStacking(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = MINING_SPELL_ISOLATED_BATCH)
     public static void craftsmansDelightExtendsTouchDigRange(GameTestHelper helper) {
         EquipmentSpellBehaviorBridgeGameTestScenarios.craftsmansDelightExtendsTouchDigRange(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellBehaviorBridgeGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellBehaviorBridgeGameTestScenarios.java
@@ -108,6 +108,7 @@ import jp.aquafactory.apprenticecodex.item.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.item.SpellcasterRoundItem;
 import jp.aquafactory.apprenticecodex.item.ScrollcasterGauntlet;
 import jp.aquafactory.apprenticecodex.item.ScrollcasterGauntletCastEvent;
+import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmulet;
 import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmuletAutoCastEvent;
 import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmuletSpellListManager;
@@ -590,6 +591,72 @@ final class EquipmentSpellBehaviorBridgeGameTestScenarios extends ApprenticeCode
 
             assertCraftsmansDelightBasicDiscountOnly(helper, player, SpellRegistry.HARVEST_MOON.get(), 60, "Harvest Moon");
             assertCraftsmansDelightBasicDiscountOnly(helper, player, SpellRegistry.EARTH_FORGE.get(), 20, "Earth Forge");
+        });
+    }
+
+    static void craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "craftsmans_scrollcaster_cooldown_policy_test");
+            equipRingCurio(player, new ItemStack(ItemRegistry.CRAFTSMANS_DELIGHT.get()));
+            var spell = SpellRegistry.HARVEST_MOON.get();
+            var gauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
+            ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(spell));
+            ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
+            var magicData = MagicData.getPlayerMagicData(player);
+            helper.assertTrue(magicData != null,
+                    "CraftsmansDelight Scrollcaster Gauntlet cooldown test could not resolve player magic data");
+            magicData.setPlayerCastingItem(gauntlet.copy());
+
+            var expectedCooldown = WeaponImbueCooldownHelper.getEffectiveSpellCooldown(
+                    spell,
+                    player,
+                    CastSource.SWORD,
+                    gauntlet
+            );
+            helper.assertTrue(expectedCooldown < io.redspace.ironsspellbooks.capabilities.magic.MagicManager.getEffectiveSpellCooldown(
+                            spell,
+                            player,
+                            CastSource.SWORD
+                    ),
+                    "CraftsmansDelight Scrollcaster Gauntlet cooldown should be reduced from the normal sword cooldown");
+
+            var craftsmansFirstEvent = new SpellCooldownAddedEvent.Pre(
+                    io.redspace.ironsspellbooks.capabilities.magic.MagicManager.getEffectiveSpellCooldown(spell, player, CastSource.SWORD),
+                    spell,
+                    player,
+                    CastSource.SWORD
+            );
+            CraftsmansDelightCooldownReductionEvent.onSpellCooldownAdded(craftsmansFirstEvent);
+            ScrollcasterGauntletCastEvent.onSpellCooldownAdded(craftsmansFirstEvent);
+            helper.assertTrue(craftsmansFirstEvent.getEffectiveCooldown() == expectedCooldown,
+                    "CraftsmansDelight -> Scrollcaster Gauntlet cooldown order should keep the reduced gauntlet cooldown but got "
+                            + craftsmansFirstEvent.getEffectiveCooldown() + " / expected " + expectedCooldown);
+
+            var scrollcasterFirstEvent = new SpellCooldownAddedEvent.Pre(
+                    io.redspace.ironsspellbooks.capabilities.magic.MagicManager.getEffectiveSpellCooldown(spell, player, CastSource.SWORD),
+                    spell,
+                    player,
+                    CastSource.SWORD
+            );
+            ScrollcasterGauntletCastEvent.onSpellCooldownAdded(scrollcasterFirstEvent);
+            CraftsmansDelightCooldownReductionEvent.onSpellCooldownAdded(scrollcasterFirstEvent);
+            helper.assertTrue(scrollcasterFirstEvent.getEffectiveCooldown() == expectedCooldown,
+                    "Scrollcaster Gauntlet -> CraftsmansDelight cooldown order should keep the reduced gauntlet cooldown but got "
+                            + scrollcasterFirstEvent.getEffectiveCooldown() + " / expected " + expectedCooldown);
+        });
+    }
+
+    static void strongestLimitedBaseCooldownSelectionIgnoresStacking(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(90) == 90,
+                    "No limited cooldown candidate should keep the base cooldown");
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(90, 45, 30) == 30,
+                    "Limited cooldown candidates should choose only the strongest reduction");
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(90, 0, -1, 60) == 60,
+                    "Invalid limited cooldown candidates should be ignored");
+            helper.assertTrue(WeaponImbueCooldownHelper.selectStrongestLimitedBaseCooldown(0, 1) == 0,
+                    "Zero base cooldown should stay zero");
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/WeaponImbueCooldownHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/WeaponImbueCooldownHelper.java
@@ -1,12 +1,14 @@
 package jp.aquafactory.apprenticecodex.item;
 
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
+import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.util.Utils;
-import io.redspace.ironsspellbooks.capabilities.magic.MagicManager;
 import io.redspace.ironsspellbooks.compat.Curios;
-import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
+import io.redspace.ironsspellbooks.config.ServerConfigs;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelight;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightSpellSupport;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -23,12 +25,39 @@ public final class WeaponImbueCooldownHelper {
             CastSource castSource,
             @Nullable ItemStack castingStack
     ) {
-        if (!shouldIgnoreWeaponImbueCooldownMultiplier(castingStack, spell, castSource)) {
-            return MagicManager.getEffectiveSpellCooldown(spell, player, castSource);
+        var baseCooldown = resolveLimitedBaseCooldown(spell, player);
+        var playerCooldownModifier = player.getAttributeValue(AttributeRegistry.COOLDOWN_REDUCTION);
+        var itemCooldownModifier = castSource == CastSource.SWORD
+                && !shouldIgnoreWeaponImbueCooldownMultiplier(castingStack, spell, castSource)
+                ? ServerConfigs.SWORDS_CD_MULTIPLIER.get().floatValue()
+                : 1.0f;
+        return (int) (baseCooldown * (2 - Utils.softCapFormula(playerCooldownModifier)) * itemCooldownModifier);
+    }
+
+    private static int resolveLimitedBaseCooldown(AbstractSpell spell, Player player) {
+        var baseCooldown = Math.max(0, spell.getSpellCooldown());
+        if (baseCooldown == 0) {
+            return 0;
         }
 
-        var playerCooldownModifier = player.getAttributeValue(AttributeRegistry.COOLDOWN_REDUCTION);
-        return (int) (spell.getSpellCooldown() * (2 - Utils.softCapFormula(playerCooldownModifier)));
+        var craftsmansDelightCooldown = CraftsmansDelightSpellSupport.isCooldownReductionTarget(spell)
+                ? CraftsmansDelight.applyCooldownDiscount(baseCooldown, player)
+                : baseCooldown;
+        return selectStrongestLimitedBaseCooldown(baseCooldown, craftsmansDelightCooldown);
+    }
+
+    public static int selectStrongestLimitedBaseCooldown(int baseCooldown, int... candidateCooldowns) {
+        var selectedCooldown = Math.max(0, baseCooldown);
+        if (selectedCooldown == 0) {
+            return 0;
+        }
+
+        for (var candidateCooldown : candidateCooldowns) {
+            if (candidateCooldown > 0 && candidateCooldown < selectedCooldown) {
+                selectedCooldown = candidateCooldown;
+            }
+        }
+        return selectedCooldown;
     }
 
     public static int getEffectiveSpellCooldown(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
@@ -4,11 +4,10 @@ import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
-import io.redspace.ironsspellbooks.api.util.Utils;
 import io.redspace.ironsspellbooks.compat.Curios;
-import io.redspace.ironsspellbooks.config.ServerConfigs;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
@@ -234,7 +233,7 @@ public class CraftsmansDelight extends Item implements ICurioItem, IJeiInfoItem 
             return spell.getSpellCooldown();
         }
 
-        return applyCooldownModifiers(applyCooldownDiscount(spell.getSpellCooldown(), player), player, castSource);
+        return WeaponImbueCooldownHelper.getEffectiveSpellCooldown(spell, player, castSource, ItemStack.EMPTY);
     }
 
     public static void applyCastingMobility(@Nullable LivingEntity entity) {
@@ -387,14 +386,6 @@ public class CraftsmansDelight extends Item implements ICurioItem, IJeiInfoItem 
                                 .map(slotResult -> slotResult.stack().copy())
                                 .orElse(ItemStack.EMPTY)))
                 .orElse(ItemStack.EMPTY);
-    }
-
-    private static int applyCooldownModifiers(int baseCooldown, Player player, CastSource castSource) {
-        var playerCooldownModifier = player.getAttributeValue(AttributeRegistry.COOLDOWN_REDUCTION);
-        var itemCooldownModifier = castSource == CastSource.SWORD
-                ? ServerConfigs.SWORDS_CD_MULTIPLIER.get().floatValue()
-                : 1.0f;
-        return (int) (baseCooldown * (2 - Utils.softCapFormula(playerCooldownModifier)) * itemCooldownModifier);
     }
 
     private static boolean consumeManaForSneakUse(Player player, ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelightCooldownReductionEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelightCooldownReductionEvent.java
@@ -1,8 +1,12 @@
 package jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight;
 
 import io.redspace.ironsspellbooks.api.events.SpellCooldownAddedEvent;
+import io.redspace.ironsspellbooks.api.magic.MagicData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 
@@ -11,7 +15,7 @@ public final class CraftsmansDelightCooldownReductionEvent {
     private CraftsmansDelightCooldownReductionEvent() {
     }
 
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onSpellCooldownAdded(SpellCooldownAddedEvent.Pre event) {
         if (!(event.getEntity() instanceof ServerPlayer player)) {
             return;
@@ -24,6 +28,13 @@ public final class CraftsmansDelightCooldownReductionEvent {
         }
 
         // GUI プレビュー系は entity == null で魔法情報を読むことがあるため、実際にクールダウンを付与する経路だけで反映する。
-        event.setEffectiveCooldown(CraftsmansDelight.getReducedEffectiveCooldown(event.getSpell(), player, event.getCastSource()));
+        var magicData = MagicData.getPlayerMagicData(player);
+        var castingItem = magicData == null ? ItemStack.EMPTY : magicData.getPlayerCastingItem();
+        event.setEffectiveCooldown(WeaponImbueCooldownHelper.getEffectiveSpellCooldown(
+                event.getSpell(),
+                player,
+                event.getCastSource(),
+                castingItem
+        ));
     }
 }


### PR DESCRIPTION
## 概要

- PR #630 の Craftsman's Delight 限定クールダウン短縮共通化を `1.21.1-main` へ forward-port
- `WeaponImbueCooldownHelper` に限定クールダウン短縮の基礎クールダウン解決を集約
- Craftsman's Delight のクールダウン短縮イベントで実際の casting item を参照し、Scrollcaster Gauntlet の武器付与クールダウン方針を維持
- 1.21.1 側 API に合わせて NeoForge event/import と `AttributeRegistry` 参照を調整

## 元 PR / コミット

- 元 PR: #630
- cherry-pick 元: `769a5cd0a1f2baa9e0ebbc87e8a869fb8dd7d2e3`
- port コミット: `52907696f4b238e512bf5b24f3f263cd4c73779f`

## 検証

- `./gradlew.bat runGameTestServer` 成功（631 required tests passed）
- `./gradlew.bat build` 成功（`checkTextEncodingHygiene` 含む）
- `runClient` はローカル確認済み（ユーザー確認）
- ローカルレビュー済み