### PR TITLE
マナ障壁の護符のエンチャントがつかない不具合を修正

### DIFF
--- a/src/generated/resources/data/minecraft/tags/enchantment/in_enchanting_table.json
+++ b/src/generated/resources/data/minecraft/tags/enchantment/in_enchanting_table.json
@@ -12,6 +12,9 @@
     "apprenticecodex:large_mug",
     "apprenticecodex:red_energy",
     "apprenticecodex:glow_energy",
-    "apprenticecodex:synthesis"
+    "apprenticecodex:synthesis",
+    "apprenticecodex:shell",
+    "apprenticecodex:synchronization",
+    "apprenticecodex:neutralization"
   ]
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/EnchantmentTagGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/EnchantmentTagGenerator.java
@@ -67,7 +67,10 @@ public final class EnchantmentTagGenerator extends EnchantmentTagsProvider {
                         Enchantments.LARGE_MUG,
                         Enchantments.RED_ENERGY,
                         Enchantments.GLOW_ENERGY,
-                        Enchantments.SYNTHESIS
+                        Enchantments.SYNTHESIS,
+                        Enchantments.SHELL,
+                        Enchantments.SYNCHRONIZATION,
+                        Enchantments.NEUTRALIZATION
                 );
 
         tag(EnchantmentTags.TRADEABLE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
@@ -525,9 +525,9 @@ final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodex
             assertApprenticeEnchantmentFlags(helper, Enchantments.RED_ENERGY, false, true, false, false);
             assertApprenticeEnchantmentFlags(helper, Enchantments.GLOW_ENERGY, false, true, false, false);
             assertApprenticeEnchantmentFlags(helper, Enchantments.SYNTHESIS, false, true, false, false);
-            assertApprenticeEnchantmentFlags(helper, Enchantments.SHELL, false, false, false, false);
-            assertApprenticeEnchantmentFlags(helper, Enchantments.SYNCHRONIZATION, false, false, false, false);
-            assertApprenticeEnchantmentFlags(helper, Enchantments.NEUTRALIZATION, false, false, false, false);
+            assertApprenticeEnchantmentFlags(helper, Enchantments.SHELL, false, true, false, false);
+            assertApprenticeEnchantmentFlags(helper, Enchantments.SYNCHRONIZATION, false, true, false, false);
+            assertApprenticeEnchantmentFlags(helper, Enchantments.NEUTRALIZATION, false, true, false, false);
         });
     }
     static void randomApplicableBookEnchantmentsExcludeFlaskEnchantments(GameTestHelper helper) {


### PR DESCRIPTION
- 1.21.1限定の不具合
- `runGameTestServer`、`runGameTestServerEasyMagic`確認済み