### PR TITLE
デュアルアクロバットのflakyテスト修正をbackport

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -6595,6 +6595,7 @@ public class ApprenticeCodexGameTestScenarios {
     static void dualAcrobatReleaseFiresLoadedAmmoAndExpires(GameTestHelper helper) {
         helper.runAtTickTime(1, () -> {
             var level = helper.getLevel();
+            prepareDualAcrobatShootingLane(helper);
             var player = createTrackedEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "dual_acrobat_release_test");
             player.setYRot(0.0f);
             player.setYBodyRot(0.0f);
@@ -6627,6 +6628,7 @@ public class ApprenticeCodexGameTestScenarios {
     static void dualAcrobatCancelledInterruptionStillFiresLoadedAmmoAndExpires(GameTestHelper helper) {
         helper.runAtTickTime(1, () -> {
             var level = helper.getLevel();
+            prepareDualAcrobatShootingLane(helper);
             var player = createTrackedEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "dual_acrobat_cancelled_release_test");
             player.setYRot(0.0f);
             player.setYBodyRot(0.0f);
@@ -6654,6 +6656,17 @@ public class ApprenticeCodexGameTestScenarios {
                         "Normally cancelled Dual Acrobat SMG pair should discard after firing all loaded ammo");
             });
         });
+    }
+
+    static void prepareDualAcrobatShootingLane(GameTestHelper helper) {
+        for (var x = -1; x <= 1; ++x) {
+            for (var z = 0; z <= 8; ++z) {
+                helper.setBlock(new BlockPos(x, 1, z), Blocks.STONE);
+                helper.setBlock(new BlockPos(x, 2, z), Blocks.AIR);
+                helper.setBlock(new BlockPos(x, 3, z), Blocks.AIR);
+                helper.setBlock(new BlockPos(x, 4, z), Blocks.AIR);
+            }
+        }
     }
 
     static void dualAcrobatCounterspellInterruptDiscardsWithoutShooting(GameTestHelper helper) {


### PR DESCRIPTION
## 概要
- #637 のデュアルアクロバット GameTest flaky 修正を 1.20.1 `main` 系へ backport
- 射撃対象のゾンビに足場と射線を用意し、テスト環境依存の失敗を避ける

## 検証
- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`（659 tests passed）