### PR TITLE
PR #645 の1.21.1対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
@@ -218,6 +218,18 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
             ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, 2.0D * bonus,
                     "Chromatic Magia Dress leggings should record a new Remote Owner CONTINUOUS session after finish");
             RemoteOwnerCastRunner.finishContinuousCast(owner.serverLevel(), owner, secondSession, false);
+
+            magicData.setMana(1000.0F);
+            var concurrentFirstSession = startRemoteOwnerContinuousCast(helper, owner, spellData);
+            var concurrentSecondSession = startRemoteOwnerContinuousCast(helper, owner, spellData);
+            tickRemoteOwnerContinuousCast(owner, concurrentFirstSession, 12);
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, 3.0D * bonus,
+                    "Chromatic Magia Dress leggings should record the first concurrent Remote Owner CONTINUOUS session");
+            tickRemoteOwnerContinuousCast(owner, concurrentSecondSession, 12);
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, 4.0D * bonus,
+                    "Chromatic Magia Dress leggings should record same-owner concurrent Remote Owner CONTINUOUS sessions separately");
+            RemoteOwnerCastRunner.finishContinuousCast(owner.serverLevel(), owner, concurrentFirstSession, false);
+            RemoteOwnerCastRunner.finishContinuousCast(owner.serverLevel(), owner, concurrentSecondSession, false);
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
@@ -5,6 +5,7 @@ import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.SchoolRegistry;
 import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
+import io.redspace.ironsspellbooks.api.spells.SpellData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.datagen.spell.RemoteOwnerCastSpellProfileDataGenerator;
@@ -20,6 +21,7 @@ import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastMode;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastOrigin;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastProfile;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastProfileManager;
+import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastRunner;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerDirectionMode;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerOriginMode;
 import jp.aquafactory.apprenticecodex.spell.AbstractSummonWeaponSpell;
@@ -37,7 +39,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.util.FakePlayer;
@@ -55,6 +59,16 @@ import java.util.UUID;
 public final class ApprenticeCodexRemoteOwnerCastGameTests {
     private static final String TEMPLATE = "gametest/basic_floor";
     private static final String CONFIG_BATCH = "apprenticecodex.remote_owner_cast_config";
+    private static final String INSCRIBE_ICE_ISOLATED_BATCH =
+            "apprenticecodex.remote_owner_cast_inscribe_ice_isolated";
+    private static final String CHROMATIC_RECORD_CASTING_SLOT = "chromatic_magia_dress_remote_owner_test";
+    private static final RemoteOwnerCastProfile CHROMATIC_RECORD_PROFILE = new RemoteOwnerCastProfile(
+            RemoteOwnerCastMode.PLAYER_SELF,
+            RemoteOwnerOriginMode.PLAYER_SELF,
+            RemoteOwnerDirectionMode.PLAYER_LOOK,
+            Optional.empty(),
+            true
+    );
 
     private ApprenticeCodexRemoteOwnerCastGameTests() {
     }
@@ -132,6 +146,75 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
         helper.assertFalse(amulet.canImbueSpell(SpellRegistry.RAISE_DEAD_SPELL.get(), 1),
                 "Satellite Followcast Amulet should keep rejecting recast spells.");
         helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void remoteOwnerCastRecordsChromaticMagiaDressInstantLongAndInitialRecast(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createChromaticRecordTestOwner(helper, "chromatic_remote_owner_cast_test");
+            var magicData = requireMagicData(helper, owner);
+            magicData.setMana(1000.0F);
+
+            var helmet = new ItemStack(ItemRegistry.CHROMATIC_MAGIA_DRESS_HAT.get());
+            var chestplate = new ItemStack(ItemRegistry.CHROMATIC_MAGIA_DRESS_COAT.get());
+            var boots = new ItemStack(ItemRegistry.CHROMATIC_MAGIA_DRESS_BOOTS.get());
+            owner.setItemSlot(EquipmentSlot.HEAD, helmet);
+            owner.setItemSlot(EquipmentSlot.CHEST, chestplate);
+            owner.setItemSlot(EquipmentSlot.FEET, boots);
+
+            var bonus = ApprenticeCodexServerConfig.chromaticMagiaDressSchoolSpellPowerBonusPerHistory();
+            var instantSpell = jp.aquafactory.apprenticecodex.registry.SpellRegistry.MANA_SLASH.get();
+            assertRemoteOwnerCastSucceeds(helper, owner, new SpellData(instantSpell, 1),
+                    "Remote Owner INSTANT Chromatic Magia Dress test cast failed");
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, boots, EquipmentSlot.FEET, instantSpell, bonus,
+                    "Chromatic Magia Dress boots should record Remote Owner INSTANT casts");
+
+            var longSpell = jp.aquafactory.apprenticecodex.registry.SpellRegistry.COMPOUND_PHIAL.get();
+            assertRemoteOwnerCastSucceeds(helper, owner, new SpellData(longSpell, 1),
+                    "Remote Owner LONG Chromatic Magia Dress test cast failed");
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, helmet, EquipmentSlot.HEAD, longSpell, bonus,
+                    "Chromatic Magia Dress helmet should record Remote Owner LONG casts");
+
+            var recastSpell = SpellRegistry.RAISE_DEAD_SPELL.get();
+            assertRemoteOwnerCastSucceeds(helper, owner, new SpellData(recastSpell, 1),
+                    "Remote Owner initial recast Chromatic Magia Dress test cast failed");
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, chestplate, EquipmentSlot.CHEST, recastSpell, bonus,
+                    "Chromatic Magia Dress chestplate should record Remote Owner initial recast-capable casts");
+
+            var activeRecastResult = tryRemoteOwnerCast(owner, new SpellData(recastSpell, 1));
+            helper.assertTrue(activeRecastResult.handled() && !activeRecastResult.succeeded(),
+                    "Remote Owner active recast test should fail before recording a second history");
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, chestplate, EquipmentSlot.CHEST, recastSpell, bonus,
+                    "Chromatic Magia Dress chestplate should not record Remote Owner active recasts");
+        });
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void remoteOwnerContinuousCastRecordsChromaticMagiaDressOncePerSession(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createChromaticRecordTestOwner(helper, "chromatic_remote_owner_continuous_test");
+            var magicData = requireMagicData(helper, owner);
+            magicData.setMana(1000.0F);
+
+            var leggings = new ItemStack(ItemRegistry.CHROMATIC_MAGIA_DRESS_LEGGINGS.get());
+            owner.setItemSlot(EquipmentSlot.LEGS, leggings);
+
+            var bonus = ApprenticeCodexServerConfig.chromaticMagiaDressSchoolSpellPowerBonusPerHistory();
+            var continuousSpell = jp.aquafactory.apprenticecodex.registry.SpellRegistry.FORCE_FIELD.get();
+            var spellData = new SpellData(continuousSpell, 1);
+            var firstSession = startRemoteOwnerContinuousCast(helper, owner, spellData);
+            tickRemoteOwnerContinuousCast(owner, firstSession, 12);
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, bonus,
+                    "Chromatic Magia Dress leggings should record the first Remote Owner CONTINUOUS onCast only once");
+            RemoteOwnerCastRunner.finishContinuousCast(owner.serverLevel(), owner, firstSession, false);
+
+            magicData.setMana(1000.0F);
+            var secondSession = startRemoteOwnerContinuousCast(helper, owner, spellData);
+            tickRemoteOwnerContinuousCast(owner, secondSession, 1);
+            ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, 2.0D * bonus,
+                    "Chromatic Magia Dress leggings should record a new Remote Owner CONTINUOUS session after finish");
+            RemoteOwnerCastRunner.finishContinuousCast(owner.serverLevel(), owner, secondSession, false);
+        });
     }
 
     @GameTest(template = TEMPLATE)
@@ -457,6 +540,74 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
         helper.assertTrue(instance != null, message + ": missing attribute");
         helper.assertTrue(Math.abs(instance.getValue() - expected) < 1.0E-6D,
                 message + ": " + instance.getValue() + " / expected " + expected);
+    }
+
+    private static FakePlayer createChromaticRecordTestOwner(GameTestHelper helper, String profileName) {
+        var owner = ApprenticeCodexGameTestScenarios.createEquipmentTestPlayer(helper, new net.minecraft.core.BlockPos(0, 2, 0),
+                profileName);
+        helper.getLevel().addFreshEntity(owner);
+        return owner;
+    }
+
+    private static MagicData requireMagicData(GameTestHelper helper, FakePlayer owner) {
+        var magicData = MagicData.getPlayerMagicData(owner);
+        helper.assertTrue(magicData != null, "Remote Owner Chromatic Magia Dress test could not resolve player mana data");
+        return magicData;
+    }
+
+    private static void assertRemoteOwnerCastSucceeds(GameTestHelper helper, FakePlayer owner, SpellData spellData, String message) {
+        var result = tryRemoteOwnerCast(owner, spellData);
+        helper.assertTrue(result.handled() && result.succeeded(), message);
+    }
+
+    private static RemoteOwnerCastRunner.CastResult tryRemoteOwnerCast(FakePlayer owner, SpellData spellData) {
+        return RemoteOwnerCastRunner.tryCast(
+                owner.serverLevel(),
+                owner,
+                ItemStack.EMPTY,
+                spellData,
+                CHROMATIC_RECORD_PROFILE,
+                RemoteOwnerCastOrigin.SATELLITE_FOLLOWCAST,
+                owner.getEyePosition(),
+                owner.getLookAngle(),
+                CastSource.SWORD,
+                CHROMATIC_RECORD_CASTING_SLOT,
+                false
+        );
+    }
+
+    private static RemoteOwnerCastRunner.ContinuousCastSession startRemoteOwnerContinuousCast(
+            GameTestHelper helper,
+            FakePlayer owner,
+            SpellData spellData
+    ) {
+        var result = RemoteOwnerCastRunner.tryStartContinuousCast(
+                owner.serverLevel(),
+                owner,
+                ItemStack.EMPTY,
+                spellData,
+                CHROMATIC_RECORD_PROFILE,
+                RemoteOwnerCastOrigin.SATELLITE_FOLLOWCAST,
+                owner.getEyePosition(),
+                owner.getLookAngle(),
+                CastSource.SWORD,
+                CHROMATIC_RECORD_CASTING_SLOT,
+                40,
+                false
+        );
+        helper.assertTrue(result.handled() && result.succeeded() && result.session() != null,
+                "Remote Owner CONTINUOUS Chromatic Magia Dress test cast failed");
+        return result.session();
+    }
+
+    private static void tickRemoteOwnerContinuousCast(
+            FakePlayer owner,
+            RemoteOwnerCastRunner.ContinuousCastSession session,
+            int ticks
+    ) {
+        for (var i = 0; i < ticks && !session.isFinished(); ++i) {
+            RemoteOwnerCastRunner.tickContinuousCast(owner.serverLevel(), owner, session);
+        }
     }
 
     private static void assertVecClose(GameTestHelper helper, Vec3 actual, Vec3 expected, String message) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
@@ -11,6 +11,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.datagen.spell.RemoteOwnerCastSpellProfileDataGenerator;
 import jp.aquafactory.apprenticecodex.datagen.spell.SpellDispenserSpellProfileDataGenerator;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
+import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressCastEvent;
 import jp.aquafactory.apprenticecodex.item.curios.satellitefollowcastamulet.SatelliteFollowcastAmulet;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
@@ -45,6 +46,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.common.util.FakePlayer;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.neoforge.gametest.GameTestHolder;
 import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
 
@@ -203,6 +205,8 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
             var continuousSpell = jp.aquafactory.apprenticecodex.registry.SpellRegistry.FORCE_FIELD.get();
             var spellData = new SpellData(continuousSpell, 1);
             var firstSession = startRemoteOwnerContinuousCast(helper, owner, spellData);
+            helper.assertFalse(magicData.isCasting(),
+                    "Remote Owner CONTINUOUS should not mark owner MagicData as active casting");
             tickRemoteOwnerContinuousCast(owner, firstSession, 12);
             ApprenticeCodexGameTestScenarios.assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, bonus,
                     "Chromatic Magia Dress leggings should record the first Remote Owner CONTINUOUS onCast only once");
@@ -607,6 +611,7 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
     ) {
         for (var i = 0; i < ticks && !session.isFinished(); ++i) {
             RemoteOwnerCastRunner.tickContinuousCast(owner.serverLevel(), owner, session);
+            ChromaticMagiaDressCastEvent.onPlayerTick(new PlayerTickEvent.Post(owner));
         }
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
@@ -174,6 +174,7 @@ import jp.aquafactory.apprenticecodex.spell.tinylumberjack.TinyLumberjackJob;
 import jp.aquafactory.apprenticecodex.spell.uniteluna.UniteLunaMoonEntity;
 import jp.aquafactory.apprenticecodex.spell.worldflatter.WorldFlatterDrillEntity;
 import jp.aquafactory.apprenticecodex.item.armor.ApprenticeMageRobeItem;
+import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressCastEvent;
 import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressItem;
 import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressStats;
 import jp.aquafactory.apprenticecodex.item.armor.ElementMaidenRobeItem;
@@ -1316,6 +1317,26 @@ final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodex
             postSpellOnCast(player, continuousSpell, 1);
             assertSchoolSpellPowerBonus(helper, leggings, EquipmentSlot.LEGS, continuousSpell, schoolSpellPowerBonusPerHistory,
                     "Chromatic Magia Dress leggings should record CONTINUOUS spells");
+
+            var heldContinuousLeggings = new ItemStack(ItemRegistry.CHROMATIC_MAGIA_DRESS_LEGGINGS.get());
+            player.setItemSlot(EquipmentSlot.LEGS, heldContinuousLeggings);
+            magicData.initiateCast(continuousSpell, 1, 60, CastSource.SPELLBOOK, "gametest");
+            postSpellOnCast(player, continuousSpell, 1);
+            postSpellOnCast(player, continuousSpell, 1);
+            postSpellOnCast(player, continuousSpell, 1);
+            assertSchoolSpellPowerBonus(helper, heldContinuousLeggings, EquipmentSlot.LEGS, continuousSpell,
+                    schoolSpellPowerBonusPerHistory,
+                    "Chromatic Magia Dress leggings should record only once during one CONTINUOUS hold");
+
+            magicData.resetCastingState();
+            ChromaticMagiaDressCastEvent.onPlayerTick(new PlayerTickEvent.Post(player));
+            magicData.initiateCast(continuousSpell, 1, 60, CastSource.SPELLBOOK, "gametest");
+            postSpellOnCast(player, continuousSpell, 1);
+            assertSchoolSpellPowerBonus(helper, heldContinuousLeggings, EquipmentSlot.LEGS, continuousSpell,
+                    2.0D * schoolSpellPowerBonusPerHistory,
+                    "Chromatic Magia Dress leggings should record a new CONTINUOUS hold after the previous cast ends");
+            magicData.resetCastingState();
+            ChromaticMagiaDressCastEvent.onPlayerTick(new PlayerTickEvent.Post(player));
 
             var instantSpell = SpellRegistry.MANA_SLASH.get();
             postSpellOnCast(player, instantSpell, 1);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
@@ -17,13 +17,15 @@ import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @EventBusSubscriber(modid = ApprenticeCodex.MODID)
 public final class ChromaticMagiaDressCastEvent {
     private static final Map<UUID, ContinuousCastSessionKey> RECORDED_LOCAL_CONTINUOUS_CASTS = new HashMap<>();
-    private static final Map<UUID, ContinuousCastSessionKey> RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS = new HashMap<>();
+    private static final Map<UUID, Set<ContinuousCastSessionKey>> RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS = new HashMap<>();
 
     private ChromaticMagiaDressCastEvent() {
     }
@@ -41,7 +43,7 @@ public final class ChromaticMagiaDressCastEvent {
 
         var spell = SpellRegistry.getSpell(event.getSpellId());
         recordCast(player, spell, event.getSpellLevel(), magicData, magicData, event.getCastSource(),
-                magicData.getCastingEquipmentSlot(), RECORDED_LOCAL_CONTINUOUS_CASTS);
+                magicData.getCastingEquipmentSlot(), ChromaticMagiaDressCastEvent::recordLocalContinuousCast);
     }
 
     public static void recordRemoteOwnerCast(
@@ -56,7 +58,7 @@ public final class ChromaticMagiaDressCastEvent {
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
         recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, ownerMagicData, castSource,
-                castingSlot, RECORDED_LOCAL_CONTINUOUS_CASTS);
+                castingSlot, ChromaticMagiaDressCastEvent::recordLocalContinuousCast);
     }
 
     public static void recordRemoteOwnerContinuousCast(
@@ -72,7 +74,7 @@ public final class ChromaticMagiaDressCastEvent {
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
         recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, sessionMagicData, castSource,
-                castingSlot, RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS);
+                castingSlot, ChromaticMagiaDressCastEvent::recordRemoteOwnerContinuousCastKey);
     }
 
     public static void clearRemoteOwnerContinuousCast(
@@ -86,7 +88,15 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var key = ContinuousCastSessionKey.from(ownerId, spellData, castSource, castingSlot);
-        RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS.remove(ownerId, key);
+        var recordedKeys = RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS.get(ownerId);
+        if (recordedKeys == null) {
+            return;
+        }
+
+        recordedKeys.remove(key);
+        if (recordedKeys.isEmpty()) {
+            RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS.remove(ownerId);
+        }
     }
 
     @SubscribeEvent
@@ -128,7 +138,7 @@ public final class ChromaticMagiaDressCastEvent {
             MagicData castingMagicData,
             CastSource castSource,
             String castingSlot,
-            Map<UUID, ContinuousCastSessionKey> recordedContinuousCasts
+            ContinuousCastRecorder continuousCastRecorder
     ) {
         if (ownerMagicData == null || spell == null || spell == SpellRegistry.none()
                 || ownerMagicData.getPlayerRecasts().hasRecastForSpell(spell.getSpellId())) {
@@ -137,7 +147,7 @@ public final class ChromaticMagiaDressCastEvent {
 
         var castType = spell.getCastType();
         if (!shouldRecordContinuousCast(player, castingMagicData, spell, spellLevel, castType, castSource, castingSlot,
-                recordedContinuousCasts)) {
+                continuousCastRecorder)) {
             return;
         }
 
@@ -169,7 +179,7 @@ public final class ChromaticMagiaDressCastEvent {
             CastType castType,
             CastSource castSource,
             String castingSlot,
-            Map<UUID, ContinuousCastSessionKey> recordedContinuousCasts
+            ContinuousCastRecorder continuousCastRecorder
     ) {
         if (castType != CastType.CONTINUOUS
                 || !matchesActiveContinuousCast(magicData, spell, spellLevel, castSource, castingSlot)) {
@@ -177,14 +187,24 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var key = ContinuousCastSessionKey.from(player, magicData);
-        var previousKey = recordedContinuousCasts.get(player.getUUID());
+        return continuousCastRecorder.record(player, key);
+    }
+
+    private static boolean recordLocalContinuousCast(ServerPlayer player, ContinuousCastSessionKey key) {
+        var previousKey = RECORDED_LOCAL_CONTINUOUS_CASTS.get(player.getUUID());
         if (key.equals(previousKey)) {
             return false;
         }
 
         // Iron's 1.20.1 Forge は CONTINUOUS の効果 tick ごとに SpellOnCastEvent を出すため、同じ詠唱中は初回だけ記録する。
-        recordedContinuousCasts.put(player.getUUID(), key);
+        RECORDED_LOCAL_CONTINUOUS_CASTS.put(player.getUUID(), key);
         return true;
+    }
+
+    private static boolean recordRemoteOwnerContinuousCastKey(ServerPlayer player, ContinuousCastSessionKey key) {
+        return RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS
+                .computeIfAbsent(player.getUUID(), ignored -> new HashSet<>())
+                .add(key);
     }
 
     private static boolean matchesActiveContinuousCast(
@@ -203,6 +223,11 @@ public final class ChromaticMagiaDressCastEvent {
 
     private static boolean isActiveContinuousCast(MagicData magicData) {
         return magicData != null && magicData.isCasting() && magicData.getCastType() == CastType.CONTINUOUS;
+    }
+
+    @FunctionalInterface
+    private interface ContinuousCastRecorder {
+        boolean record(ServerPlayer player, ContinuousCastSessionKey key);
     }
 
     private record ContinuousCastSessionKey(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
@@ -42,7 +42,8 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var spell = SpellRegistry.getSpell(event.getSpellId());
-        recordCast(player, spell, event.getSpellLevel(), magicData, magicData, null, event.getCastSource(),
+        recordCast(player, spell, event.getSpellLevel(), magicData, magicData,
+                hasActiveRecast(magicData, spell), null, event.getCastSource(),
                 magicData.getCastingEquipmentSlot(), ChromaticMagiaDressCastEvent::recordLocalContinuousCast);
     }
 
@@ -57,7 +58,24 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
-        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, ownerMagicData, null, castSource,
+        recordRemoteOwnerCast(owner, spellData, castSource, castingSlot,
+                hasActiveRecast(ownerMagicData, spellData.getSpell()));
+    }
+
+    public static void recordRemoteOwnerCast(
+            ServerPlayer owner,
+            SpellData spellData,
+            CastSource castSource,
+            String castingSlot,
+            boolean activeRecastBeforeCast
+    ) {
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return;
+        }
+
+        var ownerMagicData = MagicData.getPlayerMagicData(owner);
+        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, ownerMagicData,
+                activeRecastBeforeCast, null, castSource,
                 castingSlot, ChromaticMagiaDressCastEvent::recordLocalContinuousCast);
     }
 
@@ -67,14 +85,16 @@ public final class ChromaticMagiaDressCastEvent {
             MagicData sessionMagicData,
             CastSource castSource,
             String castingSlot,
-            UUID sessionId
+            UUID sessionId,
+            boolean activeRecastBeforeCast
     ) {
         if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
             return;
         }
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
-        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, sessionMagicData, sessionId, castSource,
+        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, sessionMagicData,
+                activeRecastBeforeCast, sessionId, castSource,
                 castingSlot, ChromaticMagiaDressCastEvent::recordRemoteOwnerContinuousCastKey);
     }
 
@@ -138,13 +158,14 @@ public final class ChromaticMagiaDressCastEvent {
             int spellLevel,
             MagicData ownerMagicData,
             MagicData castingMagicData,
+            boolean activeRecastBeforeCast,
             UUID continuousSessionId,
             CastSource castSource,
             String castingSlot,
             ContinuousCastRecorder continuousCastRecorder
     ) {
         if (ownerMagicData == null || spell == null || spell == SpellRegistry.none()
-                || ownerMagicData.getPlayerRecasts().hasRecastForSpell(spell.getSpellId())) {
+                || activeRecastBeforeCast) {
             return;
         }
 
@@ -227,6 +248,10 @@ public final class ChromaticMagiaDressCastEvent {
 
     private static boolean isActiveContinuousCast(MagicData magicData) {
         return magicData != null && magicData.isCasting() && magicData.getCastType() == CastType.CONTINUOUS;
+    }
+
+    private static boolean hasActiveRecast(MagicData magicData, AbstractSpell spell) {
+        return magicData != null && spell != null && magicData.getPlayerRecasts().hasRecastForSpell(spell.getSpellId());
     }
 
     @FunctionalInterface

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
@@ -22,7 +22,8 @@ import java.util.UUID;
 
 @EventBusSubscriber(modid = ApprenticeCodex.MODID)
 public final class ChromaticMagiaDressCastEvent {
-    private static final Map<UUID, ContinuousCastSessionKey> RECORDED_CONTINUOUS_CASTS = new HashMap<>();
+    private static final Map<UUID, ContinuousCastSessionKey> RECORDED_LOCAL_CONTINUOUS_CASTS = new HashMap<>();
+    private static final Map<UUID, ContinuousCastSessionKey> RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS = new HashMap<>();
 
     private ChromaticMagiaDressCastEvent() {
     }
@@ -40,7 +41,7 @@ public final class ChromaticMagiaDressCastEvent {
 
         var spell = SpellRegistry.getSpell(event.getSpellId());
         recordCast(player, spell, event.getSpellLevel(), magicData, magicData, event.getCastSource(),
-                magicData.getCastingEquipmentSlot());
+                magicData.getCastingEquipmentSlot(), RECORDED_LOCAL_CONTINUOUS_CASTS);
     }
 
     public static void recordRemoteOwnerCast(
@@ -55,7 +56,7 @@ public final class ChromaticMagiaDressCastEvent {
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
         recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, ownerMagicData, castSource,
-                castingSlot);
+                castingSlot, RECORDED_LOCAL_CONTINUOUS_CASTS);
     }
 
     public static void recordRemoteOwnerContinuousCast(
@@ -71,7 +72,7 @@ public final class ChromaticMagiaDressCastEvent {
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
         recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, sessionMagicData, castSource,
-                castingSlot);
+                castingSlot, RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS);
     }
 
     public static void clearRemoteOwnerContinuousCast(
@@ -85,7 +86,7 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var key = ContinuousCastSessionKey.from(ownerId, spellData, castSource, castingSlot);
-        RECORDED_CONTINUOUS_CASTS.remove(ownerId, key);
+        RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS.remove(ownerId, key);
     }
 
     @SubscribeEvent
@@ -96,25 +97,27 @@ public final class ChromaticMagiaDressCastEvent {
 
         var magicData = MagicData.getPlayerMagicData(player);
         if (!isActiveContinuousCast(magicData)) {
-            RECORDED_CONTINUOUS_CASTS.remove(player.getUUID());
+            RECORDED_LOCAL_CONTINUOUS_CASTS.remove(player.getUUID());
             return;
         }
 
         var activeKey = ContinuousCastSessionKey.from(player, magicData);
-        var previousKey = RECORDED_CONTINUOUS_CASTS.get(player.getUUID());
+        var previousKey = RECORDED_LOCAL_CONTINUOUS_CASTS.get(player.getUUID());
         if (previousKey != null && !previousKey.equals(activeKey)) {
-            RECORDED_CONTINUOUS_CASTS.remove(player.getUUID());
+            RECORDED_LOCAL_CONTINUOUS_CASTS.remove(player.getUUID());
         }
     }
 
     @SubscribeEvent
     public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
-        RECORDED_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
+        RECORDED_LOCAL_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
+        RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
     }
 
     @SubscribeEvent
     public static void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
-        RECORDED_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
+        RECORDED_LOCAL_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
+        RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
     }
 
     private static void recordCast(
@@ -124,7 +127,8 @@ public final class ChromaticMagiaDressCastEvent {
             MagicData ownerMagicData,
             MagicData castingMagicData,
             CastSource castSource,
-            String castingSlot
+            String castingSlot,
+            Map<UUID, ContinuousCastSessionKey> recordedContinuousCasts
     ) {
         if (ownerMagicData == null || spell == null || spell == SpellRegistry.none()
                 || ownerMagicData.getPlayerRecasts().hasRecastForSpell(spell.getSpellId())) {
@@ -132,7 +136,8 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var castType = spell.getCastType();
-        if (!shouldRecordContinuousCast(player, castingMagicData, spell, spellLevel, castType, castSource, castingSlot)) {
+        if (!shouldRecordContinuousCast(player, castingMagicData, spell, spellLevel, castType, castSource, castingSlot,
+                recordedContinuousCasts)) {
             return;
         }
 
@@ -163,7 +168,8 @@ public final class ChromaticMagiaDressCastEvent {
             int spellLevel,
             CastType castType,
             CastSource castSource,
-            String castingSlot
+            String castingSlot,
+            Map<UUID, ContinuousCastSessionKey> recordedContinuousCasts
     ) {
         if (castType != CastType.CONTINUOUS
                 || !matchesActiveContinuousCast(magicData, spell, spellLevel, castSource, castingSlot)) {
@@ -171,13 +177,13 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var key = ContinuousCastSessionKey.from(player, magicData);
-        var previousKey = RECORDED_CONTINUOUS_CASTS.get(player.getUUID());
+        var previousKey = recordedContinuousCasts.get(player.getUUID());
         if (key.equals(previousKey)) {
             return false;
         }
 
         // Iron's 1.20.1 Forge は CONTINUOUS の効果 tick ごとに SpellOnCastEvent を出すため、同じ詠唱中は初回だけ記録する。
-        RECORDED_CONTINUOUS_CASTS.put(player.getUUID(), key);
+        recordedContinuousCasts.put(player.getUUID(), key);
         return true;
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
@@ -42,7 +42,7 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var spell = SpellRegistry.getSpell(event.getSpellId());
-        recordCast(player, spell, event.getSpellLevel(), magicData, magicData, event.getCastSource(),
+        recordCast(player, spell, event.getSpellLevel(), magicData, magicData, null, event.getCastSource(),
                 magicData.getCastingEquipmentSlot(), ChromaticMagiaDressCastEvent::recordLocalContinuousCast);
     }
 
@@ -57,7 +57,7 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
-        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, ownerMagicData, castSource,
+        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, ownerMagicData, null, castSource,
                 castingSlot, ChromaticMagiaDressCastEvent::recordLocalContinuousCast);
     }
 
@@ -66,14 +66,15 @@ public final class ChromaticMagiaDressCastEvent {
             SpellData spellData,
             MagicData sessionMagicData,
             CastSource castSource,
-            String castingSlot
+            String castingSlot,
+            UUID sessionId
     ) {
         if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
             return;
         }
 
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
-        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, sessionMagicData, castSource,
+        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, sessionMagicData, sessionId, castSource,
                 castingSlot, ChromaticMagiaDressCastEvent::recordRemoteOwnerContinuousCastKey);
     }
 
@@ -81,13 +82,14 @@ public final class ChromaticMagiaDressCastEvent {
             UUID ownerId,
             SpellData spellData,
             CastSource castSource,
-            String castingSlot
+            String castingSlot,
+            UUID sessionId
     ) {
         if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
             return;
         }
 
-        var key = ContinuousCastSessionKey.from(ownerId, spellData, castSource, castingSlot);
+        var key = ContinuousCastSessionKey.from(ownerId, spellData, castSource, castingSlot, sessionId);
         var recordedKeys = RECORDED_REMOTE_OWNER_CONTINUOUS_CASTS.get(ownerId);
         if (recordedKeys == null) {
             return;
@@ -136,6 +138,7 @@ public final class ChromaticMagiaDressCastEvent {
             int spellLevel,
             MagicData ownerMagicData,
             MagicData castingMagicData,
+            UUID continuousSessionId,
             CastSource castSource,
             String castingSlot,
             ContinuousCastRecorder continuousCastRecorder
@@ -146,7 +149,7 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var castType = spell.getCastType();
-        if (!shouldRecordContinuousCast(player, castingMagicData, spell, spellLevel, castType, castSource, castingSlot,
+        if (!shouldRecordContinuousCast(player, castingMagicData, continuousSessionId, spell, spellLevel, castType, castSource, castingSlot,
                 continuousCastRecorder)) {
             return;
         }
@@ -174,6 +177,7 @@ public final class ChromaticMagiaDressCastEvent {
     private static boolean shouldRecordContinuousCast(
             ServerPlayer player,
             MagicData magicData,
+            UUID continuousSessionId,
             AbstractSpell spell,
             int spellLevel,
             CastType castType,
@@ -186,7 +190,7 @@ public final class ChromaticMagiaDressCastEvent {
             return true;
         }
 
-        var key = ContinuousCastSessionKey.from(player, magicData);
+        var key = ContinuousCastSessionKey.from(player, magicData, continuousSessionId);
         return continuousCastRecorder.record(player, key);
     }
 
@@ -232,14 +236,20 @@ public final class ChromaticMagiaDressCastEvent {
 
     private record ContinuousCastSessionKey(
             UUID playerId,
+            UUID sessionId,
             String spellId,
             int spellLevel,
             CastSource castSource,
             String castingEquipmentSlot
     ) {
         static ContinuousCastSessionKey from(ServerPlayer player, MagicData magicData) {
+            return from(player, magicData, null);
+        }
+
+        static ContinuousCastSessionKey from(ServerPlayer player, MagicData magicData, UUID sessionId) {
             return new ContinuousCastSessionKey(
                     player.getUUID(),
+                    sessionId,
                     magicData.getCastingSpellId(),
                     magicData.getCastingSpellLevel(),
                     magicData.getCastSource(),
@@ -251,10 +261,12 @@ public final class ChromaticMagiaDressCastEvent {
                 UUID ownerId,
                 SpellData spellData,
                 CastSource castSource,
-                String castingEquipmentSlot
+                String castingEquipmentSlot,
+                UUID sessionId
         ) {
             return new ContinuousCastSessionKey(
                     ownerId,
+                    sessionId,
                     spellData.getSpell().getSpellId(),
                     spellData.getLevel(),
                     castSource,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
@@ -3,8 +3,10 @@ package jp.aquafactory.apprenticecodex.item.armor;
 import io.redspace.ironsspellbooks.api.events.SpellOnCastEvent;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
+import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.CastType;
+import io.redspace.ironsspellbooks.api.spells.SpellData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ArmorItem;
@@ -32,25 +34,58 @@ public final class ChromaticMagiaDressCastEvent {
         }
 
         var magicData = MagicData.getPlayerMagicData(player);
-        if (magicData == null || magicData.getPlayerRecasts().hasRecastForSpell(event.getSpellId())) {
+        if (magicData == null) {
             return;
         }
 
         var spell = SpellRegistry.getSpell(event.getSpellId());
-        if (spell == null || spell == SpellRegistry.none()) {
+        recordCast(player, spell, event.getSpellLevel(), magicData, magicData, event.getCastSource(),
+                magicData.getCastingEquipmentSlot());
+    }
+
+    public static void recordRemoteOwnerCast(
+            ServerPlayer owner,
+            SpellData spellData,
+            CastSource castSource,
+            String castingSlot
+    ) {
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
             return;
         }
 
-        var castType = spell.getCastType();
-        for (var armorStack : player.getArmorSlots()) {
-            if (!(armorStack.getItem() instanceof ChromaticMagiaDressItem dressItem)) {
-                continue;
-            }
-            if (shouldRecord(dressItem.getArmorType(), castType, spell.getRecastCount(event.getSpellLevel(), player))
-                    && shouldRecordContinuousCast(player, magicData, event, castType)) {
-                ChromaticMagiaDressHistory.append(armorStack, event.getSchoolType());
-            }
+        var ownerMagicData = MagicData.getPlayerMagicData(owner);
+        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, ownerMagicData, castSource,
+                castingSlot);
+    }
+
+    public static void recordRemoteOwnerContinuousCast(
+            ServerPlayer owner,
+            SpellData spellData,
+            MagicData sessionMagicData,
+            CastSource castSource,
+            String castingSlot
+    ) {
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return;
         }
+
+        var ownerMagicData = MagicData.getPlayerMagicData(owner);
+        recordCast(owner, spellData.getSpell(), spellData.getLevel(), ownerMagicData, sessionMagicData, castSource,
+                castingSlot);
+    }
+
+    public static void clearRemoteOwnerContinuousCast(
+            UUID ownerId,
+            SpellData spellData,
+            CastSource castSource,
+            String castingSlot
+    ) {
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return;
+        }
+
+        var key = ContinuousCastSessionKey.from(ownerId, spellData, castSource, castingSlot);
+        RECORDED_CONTINUOUS_CASTS.remove(ownerId, key);
     }
 
     @SubscribeEvent
@@ -77,6 +112,40 @@ public final class ChromaticMagiaDressCastEvent {
         RECORDED_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
     }
 
+    @SubscribeEvent
+    public static void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+        RECORDED_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
+    }
+
+    private static void recordCast(
+            ServerPlayer player,
+            AbstractSpell spell,
+            int spellLevel,
+            MagicData ownerMagicData,
+            MagicData castingMagicData,
+            CastSource castSource,
+            String castingSlot
+    ) {
+        if (ownerMagicData == null || spell == null || spell == SpellRegistry.none()
+                || ownerMagicData.getPlayerRecasts().hasRecastForSpell(spell.getSpellId())) {
+            return;
+        }
+
+        var castType = spell.getCastType();
+        if (!shouldRecordContinuousCast(player, castingMagicData, spell, spellLevel, castType, castSource, castingSlot)) {
+            return;
+        }
+
+        for (var armorStack : player.getArmorSlots()) {
+            if (!(armorStack.getItem() instanceof ChromaticMagiaDressItem dressItem)) {
+                continue;
+            }
+            if (shouldRecord(dressItem.getArmorType(), castType, spell.getRecastCount(spellLevel, player))) {
+                ChromaticMagiaDressHistory.append(armorStack, spell.getSchoolType());
+            }
+        }
+    }
+
     private static boolean shouldRecord(ArmorItem.Type type, CastType castType, int recastCount) {
         return switch (type) {
             case HELMET -> castType == CastType.LONG;
@@ -90,10 +159,14 @@ public final class ChromaticMagiaDressCastEvent {
     private static boolean shouldRecordContinuousCast(
             ServerPlayer player,
             MagicData magicData,
-            SpellOnCastEvent event,
-            CastType castType
+            AbstractSpell spell,
+            int spellLevel,
+            CastType castType,
+            CastSource castSource,
+            String castingSlot
     ) {
-        if (castType != CastType.CONTINUOUS || !matchesActiveContinuousCast(magicData, event)) {
+        if (castType != CastType.CONTINUOUS
+                || !matchesActiveContinuousCast(magicData, spell, spellLevel, castSource, castingSlot)) {
             return true;
         }
 
@@ -108,11 +181,18 @@ public final class ChromaticMagiaDressCastEvent {
         return true;
     }
 
-    private static boolean matchesActiveContinuousCast(MagicData magicData, SpellOnCastEvent event) {
+    private static boolean matchesActiveContinuousCast(
+            MagicData magicData,
+            AbstractSpell spell,
+            int spellLevel,
+            CastSource castSource,
+            String castingSlot
+    ) {
         return isActiveContinuousCast(magicData)
-                && magicData.getCastingSpellId().equals(event.getSpellId())
-                && magicData.getCastingSpellLevel() == event.getSpellLevel()
-                && magicData.getCastSource() == event.getCastSource();
+                && magicData.getCastingSpellId().equals(spell.getSpellId())
+                && magicData.getCastingSpellLevel() == spellLevel
+                && magicData.getCastSource() == castSource
+                && java.util.Objects.equals(magicData.getCastingEquipmentSlot(), castingSlot);
     }
 
     private static boolean isActiveContinuousCast(MagicData magicData) {
@@ -133,6 +213,21 @@ public final class ChromaticMagiaDressCastEvent {
                     magicData.getCastingSpellLevel(),
                     magicData.getCastSource(),
                     magicData.getCastingEquipmentSlot()
+            );
+        }
+
+        static ContinuousCastSessionKey from(
+                UUID ownerId,
+                SpellData spellData,
+                CastSource castSource,
+                String castingEquipmentSlot
+        ) {
+            return new ContinuousCastSessionKey(
+                    ownerId,
+                    spellData.getSpell().getSpellId(),
+                    spellData.getLevel(),
+                    castSource,
+                    castingEquipmentSlot
             );
         }
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/ChromaticMagiaDressCastEvent.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.item.armor;
 import io.redspace.ironsspellbooks.api.events.SpellOnCastEvent;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
+import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.CastType;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import net.minecraft.server.level.ServerPlayer;
@@ -10,9 +11,17 @@ import net.minecraft.world.item.ArmorItem;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 @EventBusSubscriber(modid = ApprenticeCodex.MODID)
 public final class ChromaticMagiaDressCastEvent {
+    private static final Map<UUID, ContinuousCastSessionKey> RECORDED_CONTINUOUS_CASTS = new HashMap<>();
+
     private ChromaticMagiaDressCastEvent() {
     }
 
@@ -32,14 +41,40 @@ public final class ChromaticMagiaDressCastEvent {
             return;
         }
 
+        var castType = spell.getCastType();
         for (var armorStack : player.getArmorSlots()) {
             if (!(armorStack.getItem() instanceof ChromaticMagiaDressItem dressItem)) {
                 continue;
             }
-            if (shouldRecord(dressItem.getArmorType(), spell.getCastType(), spell.getRecastCount(event.getSpellLevel(), player))) {
+            if (shouldRecord(dressItem.getArmorType(), castType, spell.getRecastCount(event.getSpellLevel(), player))
+                    && shouldRecordContinuousCast(player, magicData, event, castType)) {
                 ChromaticMagiaDressHistory.append(armorStack, event.getSchoolType());
             }
         }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(PlayerTickEvent.Post event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+
+        var magicData = MagicData.getPlayerMagicData(player);
+        if (!isActiveContinuousCast(magicData)) {
+            RECORDED_CONTINUOUS_CASTS.remove(player.getUUID());
+            return;
+        }
+
+        var activeKey = ContinuousCastSessionKey.from(player, magicData);
+        var previousKey = RECORDED_CONTINUOUS_CASTS.get(player.getUUID());
+        if (previousKey != null && !previousKey.equals(activeKey)) {
+            RECORDED_CONTINUOUS_CASTS.remove(player.getUUID());
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        RECORDED_CONTINUOUS_CASTS.remove(event.getEntity().getUUID());
     }
 
     private static boolean shouldRecord(ArmorItem.Type type, CastType castType, int recastCount) {
@@ -50,5 +85,55 @@ public final class ChromaticMagiaDressCastEvent {
             case BOOTS -> castType == CastType.INSTANT;
             case BODY -> false;
         };
+    }
+
+    private static boolean shouldRecordContinuousCast(
+            ServerPlayer player,
+            MagicData magicData,
+            SpellOnCastEvent event,
+            CastType castType
+    ) {
+        if (castType != CastType.CONTINUOUS || !matchesActiveContinuousCast(magicData, event)) {
+            return true;
+        }
+
+        var key = ContinuousCastSessionKey.from(player, magicData);
+        var previousKey = RECORDED_CONTINUOUS_CASTS.get(player.getUUID());
+        if (key.equals(previousKey)) {
+            return false;
+        }
+
+        // Iron's 1.20.1 Forge は CONTINUOUS の効果 tick ごとに SpellOnCastEvent を出すため、同じ詠唱中は初回だけ記録する。
+        RECORDED_CONTINUOUS_CASTS.put(player.getUUID(), key);
+        return true;
+    }
+
+    private static boolean matchesActiveContinuousCast(MagicData magicData, SpellOnCastEvent event) {
+        return isActiveContinuousCast(magicData)
+                && magicData.getCastingSpellId().equals(event.getSpellId())
+                && magicData.getCastingSpellLevel() == event.getSpellLevel()
+                && magicData.getCastSource() == event.getCastSource();
+    }
+
+    private static boolean isActiveContinuousCast(MagicData magicData) {
+        return magicData != null && magicData.isCasting() && magicData.getCastType() == CastType.CONTINUOUS;
+    }
+
+    private record ContinuousCastSessionKey(
+            UUID playerId,
+            String spellId,
+            int spellLevel,
+            CastSource castSource,
+            String castingEquipmentSlot
+    ) {
+        static ContinuousCastSessionKey from(ServerPlayer player, MagicData magicData) {
+            return new ContinuousCastSessionKey(
+                    player.getUUID(),
+                    magicData.getCastingSpellId(),
+                    magicData.getCastingSpellLevel(),
+                    magicData.getCastSource(),
+                    magicData.getCastingEquipmentSlot()
+            );
+        }
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellsideedge/AbstractSpellSideEdgeItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellsideedge/AbstractSpellSideEdgeItem.java
@@ -20,6 +20,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.item.Tiers;
 import net.minecraft.world.item.TooltipFlag;
@@ -66,6 +67,8 @@ public abstract class AbstractSpellSideEdgeItem extends SwordItem implements Geo
         super(Tiers.DIAMOND, new Item.Properties()
                 .stacksTo(1)
                 .durability(DURABILITY)
+                .rarity(Rarity.RARE)
+                .fireResistant()
                 .attributes(SwordItem.createAttributes(Tiers.DIAMOND, 0, (float) ATTACK_SPEED_MODIFIER_AMOUNT)));
         GeoItem.registerSyncedAnimatable(this);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCastRunner.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCastRunner.java
@@ -12,6 +12,7 @@ import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import io.redspace.ironsspellbooks.spells.EntityCastData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.armor.ChromaticMagiaDressCastEvent;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
 import jp.aquafactory.apprenticecodex.spell.AbstractSummonWeaponSpell;
 import jp.aquafactory.apprenticecodex.utility.SpellManaAccessHelper;
@@ -27,6 +28,8 @@ import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
 
 public final class RemoteOwnerCastRunner {
     private static final int CONTINUOUS_CAST_TICK_INTERVAL = 10;
@@ -271,6 +274,7 @@ public final class RemoteOwnerCastRunner {
             syncOwnerManaForCast(manaAccess, sessionMagicData);
 
             return ContinuousCastStartResult.success(new ContinuousCastSession(
+                    owner.getUUID(),
                     spellData,
                     sourceStack.copy(),
                     profile,
@@ -332,6 +336,13 @@ public final class RemoteOwnerCastRunner {
                 session.markReachedOnCast();
                 syncAnchorCasterFromOwner(owner, session);
                 var spellCaster = resolveContinuousSpellCaster(owner, session);
+                ChromaticMagiaDressCastEvent.recordRemoteOwnerContinuousCast(
+                        owner,
+                        spellData,
+                        magicData,
+                        session.castSource(),
+                        session.castingSlot()
+                );
                 runWithContinuousContext(owner, session,
                         () -> spell.onCast(level, spellData.getLevel(), spellCaster, session.castSource(), magicData));
                 syncOwnerManaForCast(session.manaAccess(), magicData);
@@ -395,6 +406,12 @@ public final class RemoteOwnerCastRunner {
                     exception
             );
         } finally {
+            ChromaticMagiaDressCastEvent.clearRemoteOwnerContinuousCast(
+                    owner.getUUID(),
+                    session.spellData(),
+                    session.castSource(),
+                    session.castingSlot()
+            );
             cleanupContinuousSession(session.anchor(), session.magicData(), retainAnchor);
         }
     }
@@ -405,6 +422,12 @@ public final class RemoteOwnerCastRunner {
         }
 
         session.markFinished(0);
+        ChromaticMagiaDressCastEvent.clearRemoteOwnerContinuousCast(
+                session.ownerId(),
+                session.spellData(),
+                session.castSource(),
+                session.castingSlot()
+        );
         cleanupContinuousSession(session.anchor(), session.magicData());
     }
 
@@ -624,6 +647,7 @@ public final class RemoteOwnerCastRunner {
                 }
 
                 syncOwnerManaForCast(manaAccess, castMagicData);
+                ChromaticMagiaDressCastEvent.recordRemoteOwnerCast(owner, spellData, castSource, castingSlot);
                 spell.onCast(level, spellData.getLevel(), spellCaster, castSource, castMagicData);
                 retainAnchor = retainAnchorForSummonWeapon(level, castMagicData.getAdditionalCastData(), spellCasterAnchor);
                 syncOwnerManaForCast(manaAccess, castMagicData);
@@ -761,6 +785,7 @@ public final class RemoteOwnerCastRunner {
     }
 
     public static final class ContinuousCastSession {
+        private final UUID ownerId;
         private final SpellData spellData;
         private final ItemStack sourceStack;
         private final RemoteOwnerCastProfile profile;
@@ -778,6 +803,7 @@ public final class RemoteOwnerCastRunner {
         private int finishedCooldownTicks;
 
         private ContinuousCastSession(
+                UUID ownerId,
                 SpellData spellData,
                 ItemStack sourceStack,
                 RemoteOwnerCastProfile profile,
@@ -790,6 +816,7 @@ public final class RemoteOwnerCastRunner {
                 PlayerManaAccess manaAccess,
                 @Nullable RemoteOwnerCastAnchorEntity anchor
         ) {
+            this.ownerId = ownerId;
             this.spellData = spellData;
             this.sourceStack = sourceStack;
             this.profile = profile;
@@ -801,6 +828,10 @@ public final class RemoteOwnerCastRunner {
             this.magicData = magicData;
             this.manaAccess = manaAccess;
             this.anchor = anchor;
+        }
+
+        public UUID ownerId() {
+            return ownerId;
         }
 
         public SpellData spellData() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCastRunner.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCastRunner.java
@@ -333,21 +333,25 @@ public final class RemoteOwnerCastRunner {
             }
 
             try {
+                var ownerMagicData = MagicData.getPlayerMagicData(owner);
+                var activeRecastBeforeCast = ownerMagicData != null
+                        && ownerMagicData.getPlayerRecasts().hasRecastForSpell(spell.getSpellId());
                 session.markReachedOnCast();
                 syncAnchorCasterFromOwner(owner, session);
                 var spellCaster = resolveContinuousSpellCaster(owner, session);
+                runWithContinuousContext(owner, session,
+                        () -> spell.onCast(level, spellData.getLevel(), spellCaster, session.castSource(), magicData));
+                syncOwnerManaForCast(session.manaAccess(), magicData);
+                bindAnchorIfNeeded(level, owner, session);
                 ChromaticMagiaDressCastEvent.recordRemoteOwnerContinuousCast(
                         owner,
                         spellData,
                         magicData,
                         session.castSource(),
                         session.castingSlot(),
-                        session.sessionId()
+                        session.sessionId(),
+                        activeRecastBeforeCast
                 );
-                runWithContinuousContext(owner, session,
-                        () -> spell.onCast(level, spellData.getLevel(), spellCaster, session.castSource(), magicData));
-                syncOwnerManaForCast(session.manaAccess(), magicData);
-                bindAnchorIfNeeded(level, owner, session);
             } catch (RuntimeException exception) {
                 ApprenticeCodex.LOGGER.warn(
                         "Remote Owner Continuous Cast exception during onCast: spell={}, origin={}",
@@ -621,6 +625,7 @@ public final class RemoteOwnerCastRunner {
         var useIsolatedMagicData = ownerMagicData.isCasting();
         var castMagicData = useIsolatedMagicData ? new MagicData() : ownerMagicData;
         var originalSyncedData = useIsolatedMagicData ? null : ownerMagicData.getSyncedData();
+        var activeRecastBeforeCast = ownerMagicData.getPlayerRecasts().hasRecastForSpell(spell.getSpellId());
         var retainAnchor = false;
         try {
             // Iron's の SpellOnCastEvent 中は元詠唱が owner MagicData に残るため、busy 時だけ実行状態を分離する。
@@ -650,7 +655,6 @@ public final class RemoteOwnerCastRunner {
                 }
 
                 syncOwnerManaForCast(manaAccess, castMagicData);
-                ChromaticMagiaDressCastEvent.recordRemoteOwnerCast(owner, spellData, castSource, castingSlot);
                 spell.onCast(level, spellData.getLevel(), spellCaster, castSource, castMagicData);
                 retainAnchor = retainAnchorForSummonWeapon(level, castMagicData.getAdditionalCastData(), spellCasterAnchor);
                 syncOwnerManaForCast(manaAccess, castMagicData);
@@ -661,6 +665,13 @@ public final class RemoteOwnerCastRunner {
                 if (useIsolatedMagicData) {
                     transferIsolatedRecasts(ownerMagicData, castMagicData);
                 }
+                ChromaticMagiaDressCastEvent.recordRemoteOwnerCast(
+                        owner,
+                        spellData,
+                        castSource,
+                        castingSlot,
+                        activeRecastBeforeCast
+                );
             }
             return CastResult.success();
         } catch (RuntimeException exception) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCastRunner.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCastRunner.java
@@ -341,7 +341,8 @@ public final class RemoteOwnerCastRunner {
                         spellData,
                         magicData,
                         session.castSource(),
-                        session.castingSlot()
+                        session.castingSlot(),
+                        session.sessionId()
                 );
                 runWithContinuousContext(owner, session,
                         () -> spell.onCast(level, spellData.getLevel(), spellCaster, session.castSource(), magicData));
@@ -410,7 +411,8 @@ public final class RemoteOwnerCastRunner {
                     owner.getUUID(),
                     session.spellData(),
                     session.castSource(),
-                    session.castingSlot()
+                    session.castingSlot(),
+                    session.sessionId()
             );
             cleanupContinuousSession(session.anchor(), session.magicData(), retainAnchor);
         }
@@ -426,7 +428,8 @@ public final class RemoteOwnerCastRunner {
                 session.ownerId(),
                 session.spellData(),
                 session.castSource(),
-                session.castingSlot()
+                session.castingSlot(),
+                session.sessionId()
         );
         cleanupContinuousSession(session.anchor(), session.magicData());
     }
@@ -785,6 +788,7 @@ public final class RemoteOwnerCastRunner {
     }
 
     public static final class ContinuousCastSession {
+        private final UUID sessionId = UUID.randomUUID();
         private final UUID ownerId;
         private final SpellData spellData;
         private final ItemStack sourceStack;
@@ -832,6 +836,10 @@ public final class RemoteOwnerCastRunner {
 
         public UUID ownerId() {
             return ownerId;
+        }
+
+        public UUID sessionId() {
+            return sessionId;
         }
 
         public SpellData spellData() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mantisleap/MantisLeap.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mantisleap/MantisLeap.java
@@ -124,12 +124,6 @@ public class MantisLeap extends AbstractSummonWeaponSpell<MantisLeapBladeEntity>
     }
 
     @Override
-    public int getEffectiveCastTime(int spellLevel, LivingEntity entity) {
-        // 詠唱時間短縮は乗らない.
-        return getCastTime(spellLevel);
-    }
-
-    @Override
     public Optional<SoundEvent> getCastStartSound() {
         return Optional.of(SoundRegistry.MANTIS.get());
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLight.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLight.java
@@ -82,11 +82,6 @@ public class MoonLight extends AbstractSummonWeaponSpell<MoonLightKatanaEntity> 
     }
 
     @Override
-    public int getEffectiveCastTime(int spellLevel, LivingEntity entity) {
-        return getCastTime(spellLevel);
-    }
-
-    @Override
     public CastType getCastType() {
         return CastType.LONG;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/precisionjack/PrecisionJack.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/precisionjack/PrecisionJack.java
@@ -85,11 +85,6 @@ public class PrecisionJack extends AbstractSummonWeaponSpell<PrecisionJackKnifeE
     }
 
     @Override
-    public int getEffectiveCastTime(int spellLevel, LivingEntity entity) {
-        return getCastTime(spellLevel);
-    }
-
-    @Override
     public boolean canBeInterrupted(@Nullable net.minecraft.world.entity.player.Player player) {
         return false;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBlade.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBlade.java
@@ -67,12 +67,6 @@ public class SlashBlade extends AbstractSummonWeaponSpell<SlashBladeKatanaEntity
     }
 
     @Override
-    public int getEffectiveCastTime(int spellLevel, LivingEntity entity) {
-        // 詠唱時間短縮は乗らない.
-        return getCastTime(spellLevel);
-    }
-
-    @Override
     public ResourceLocation getSpellResource() {
         return spellId;
     }


### PR DESCRIPTION
## 概要
- #645 を `1.21.1-main` へ forward-port しました。
- merge commit は取り込まず、対象の非 merge コミット 8 本を `git cherry-pick -x` で取り込みました。
- Forge 由来のイベント API 差分は NeoForge 1.21.1 側の `PlayerTickEvent.Post` / `EventBusSubscriber` に合わせています。

## 取り込み元
- #645
- 対象コミット:
  - 5a654d1f945f997b2ad7f73b47157ed2df5c5c03
  - cc04af735472e835baa18fcf09c00114fd793ecf
  - 4d4aeabf837970bd2d5b1ffb12cacf2d218cc397
  - 93d2ada32120e1176ef5c6479f1262a5ecf6cf72
  - e76c38031e4c135caa891f38db7fdbe8a2bb0134
  - 394e46eb36ef6aad3a57e59bce83d29d917da4a8
  - 1413e8b05124cd06f451faf15e8559fbc18f15b8
  - aaeae0a03c1b505432b159606659010582ddf5d4

## 検証
- `./gradlew.bat runData` 成功（generated 差分なし）
- `./gradlew.bat runGameTestServer` 成功（675 required tests passed）
- `./gradlew.bat build` 成功（`checkTextEncodingHygiene` 含む）