### PR TITLE
PR #658 の1.21.1対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ImbueTooltipClientHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ImbueTooltipClientHelper.java
@@ -8,8 +8,8 @@ final class ImbueTooltipClientHelper {
     private ImbueTooltipClientHelper() {
     }
 
-    static boolean hasShiftDown() {
-        return Screen.hasShiftDown();
+    static boolean hasDetailsKeyDown() {
+        return Screen.hasShiftDown() || Screen.hasAltDown();
     }
 
     static Component getAttackKeyName() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ImbueTooltipHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ImbueTooltipHelper.java
@@ -27,7 +27,7 @@ public final class ImbueTooltipHelper {
     }
 
     public static boolean appendHintIfDetailsHidden(List<Component> lines) {
-        if (hasShiftDown()) {
+        if (hasDetailsKeyDown()) {
             return false;
         }
 
@@ -131,7 +131,7 @@ public final class ImbueTooltipHelper {
                 .toPlainString();
     }
 
-    public static boolean hasShiftDown() {
-        return FMLEnvironment.dist == Dist.CLIENT && ImbueTooltipClientHelper.hasShiftDown();
+    public static boolean hasDetailsKeyDown() {
+        return FMLEnvironment.dist == Dist.CLIENT && ImbueTooltipClientHelper.hasDetailsKeyDown();
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/MagiAgentSuitItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/MagiAgentSuitItem.java
@@ -248,7 +248,7 @@ public class MagiAgentSuitItem extends ArmorItem implements GeoItem, IPresetSpel
             return;
         }
 
-        if (!ImbueTooltipHelper.hasShiftDown()) {
+        if (!ImbueTooltipHelper.hasDetailsKeyDown()) {
             lines.add(Component.translatable(descriptionKey).withStyle(ChatFormatting.GRAY));
             lines.add(Component.translatable(SPELL_HINT_KEY).withStyle(ChatFormatting.DARK_GRAY));
             return;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
@@ -103,7 +103,7 @@ public class CraftsmansDelight extends Item implements ICurioItem, IJeiInfoItem 
     }
 
     private static void appendTargetSpellHintOrTooltips(List<Component> tooltips) {
-        if (!ImbueTooltipHelper.hasShiftDown()) {
+        if (!ImbueTooltipHelper.hasDetailsKeyDown()) {
             tooltips.add(Component.translatable(SPELL_HINT_KEY).withStyle(ChatFormatting.DARK_GRAY));
             return;
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/protectionspellsupporter/ProtectionSpellSupporter.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/protectionspellsupporter/ProtectionSpellSupporter.java
@@ -64,7 +64,7 @@ public class ProtectionSpellSupporter extends Item implements ICurioItem, IJeiIn
     }
 
     private static void appendTargetSpellHintOrTooltips(List<Component> tooltips) {
-        if (!ImbueTooltipHelper.hasShiftDown()) {
+        if (!ImbueTooltipHelper.hasDetailsKeyDown()) {
             tooltips.add(Component.translatable(SPELL_HINT_KEY).withStyle(ChatFormatting.DARK_GRAY));
             return;
         }

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -132,9 +132,9 @@
   "item.apprenticecodex.magi_agent_suit_leggings": "Magi-Agent's Slacks",
   "item.apprenticecodex.magi_agent_suit_boots": "Magi-Agent's Shoes",
 
-  "item.apprenticecodex.common.desc.spell_hint": "Hold Shift to show affected spells.",
+  "item.apprenticecodex.common.desc.spell_hint": "Hold Shift or Alt to show affected spells.",
   "item.apprenticecodex.common.desc.spell_hint_open": "Affected spells:",
-  "item.apprenticecodex.spellgun.tooltip.hint": "Hold Shift for details.",
+  "item.apprenticecodex.spellgun.tooltip.hint": "Hold Shift or Alt for details.",
   "item.apprenticecodex.spellgun.tooltip.ability_title": "Effects of imbued spell:",
   "item.apprenticecodex.spellgun.tooltip.ability_swingcast_title": "Effects when casting imbued spell with swing:",
   "item.apprenticecodex.spellgun.tooltip.ability_smashcast_title": "Effects when casting imbued spell with smash:",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -132,7 +132,7 @@
   "item.apprenticecodex.magi_agent_suit_leggings": "マギ・エージェントのスラックス",
   "item.apprenticecodex.magi_agent_suit_boots": "マギ・エージェントの革靴",
 
-  "item.apprenticecodex.spellgun.tooltip.hint": "Shiftキーで詳細を表示",
+  "item.apprenticecodex.spellgun.tooltip.hint": "ShiftまたはAltキーで詳細を表示",
   "item.apprenticecodex.spellgun.tooltip.ability_title": "注入した魔法への特殊効果:",
   "item.apprenticecodex.spellgun.tooltip.ability_swingcast_title": "注入した魔法を振って詠唱した時:",
   "item.apprenticecodex.spellgun.tooltip.ability_smashcast_title": "注入した魔法で強打詠唱した時:",
@@ -162,7 +162,7 @@
   "item.apprenticecodex.spellgun.tooltip.ammo_condition_below_rare": "レア以下",
   "item.apprenticecodex.spellgun.tooltip.ammo_condition_above_epic": "エピック以上",
 
-  "item.apprenticecodex.common.desc.spell_hint": "Shiftキーで対象の魔法を表示",
+  "item.apprenticecodex.common.desc.spell_hint": "ShiftまたはAltキーで対象の魔法を表示",
   "item.apprenticecodex.common.desc.spell_hint_open": "対象魔法:",
   "item.apprenticecodex.apprentice_desk.disabled_tooltip": "使い走り魔術師の職業ブロックとしてのみ機能する。",
   "item.apprenticecodex.spell_dispenser.creative_tooltip": "クリエイティブバージョン",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -131,7 +131,7 @@
   "item.apprenticecodex.magi_agent_suit_leggings": "魔导特工西裤",
   "item.apprenticecodex.magi_agent_suit_boots": "魔导特工皮鞋",
 
-  "item.apprenticecodex.spellgun.tooltip.hint": "按住Shift查看详情。",
+  "item.apprenticecodex.spellgun.tooltip.hint": "按住 Shift 或 Alt 查看详情。",
   "item.apprenticecodex.spellgun.tooltip.ability_title": "注入法术效果：",
   "item.apprenticecodex.spellgun.tooltip.ability_swingcast_title": "挥击释放注入法术时的效果：",
   "item.apprenticecodex.spellgun.tooltip.ability_smashcast_title": "以强打释放注入法术时：",
@@ -161,7 +161,7 @@
   "item.apprenticecodex.spellgun.tooltip.ammo_condition_below_rare": "稀有及以下品质",
   "item.apprenticecodex.spellgun.tooltip.ammo_condition_above_epic": "史诗以上品质",
 
-  "item.apprenticecodex.common.desc.spell_hint": "按住 Shift 显示适用法术",
+  "item.apprenticecodex.common.desc.spell_hint": "按住 Shift 或 Alt 显示适用法术",
   "item.apprenticecodex.common.desc.spell_hint_open": "适用法术：",
   "item.apprenticecodex.apprentice_desk.disabled_tooltip": "仅作为跑腿法师的工作站点方块时生效。",
   "item.apprenticecodex.spell_dispenser.creative_tooltip": "创造版",

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_boots.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_boots.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.3,
+    "weight":1.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_leggings.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_leggings.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.5,
+    "weight":2.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_scarf.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_scarf.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.1,
+    "weight":0.5
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_torso.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/apprentice_mage_torso.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.75,
+    "weight":3.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_boots.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_boots.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.3,
+    "weight":1.5
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_coat.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_coat.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":1.2,
+    "weight":8.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_hat.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_hat.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.5,
+    "weight":2.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_leggings.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/chromatic_magia_dress_leggings.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.8,
+    "weight":5.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_boots.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_boots.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.3,
+    "weight":1.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_leggings.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_leggings.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.3,
+    "weight":1.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_ribbon.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_ribbon.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.1,
+    "weight":0.5
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_robe.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/element_maiden_robe_robe.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.5,
+    "weight":2.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_boots.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_boots.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.3,
+    "weight":1.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_hat.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_hat.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.5,
+    "weight":3.5
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_leggings.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_leggings.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.5,
+    "weight":3.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_robe.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/enchantress_robe.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":1.0,
+    "weight":9.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_boots.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_boots.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.2,
+    "weight":0.8
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_coat.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_coat.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":2.0,
+    "weight":9.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_hood.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_hood.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.5,
+    "weight":3.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_leggings.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/magi_agent_suit_leggings.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":2.0,
+    "weight":10.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_body.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_body.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.0,
+    "weight":0.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_foot.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_foot.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.0,
+    "weight":0.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_head.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_head.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.0,
+    "weight":0.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_leg.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/armors/stealth_rune_armor_leg.json
@@ -1,0 +1,7 @@
+{
+  "attributes":
+  {
+    "stun_armor":0.0,
+    "weight":0.0
+  }
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/charged_twin_blade_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/charged_twin_blade_staff.json
@@ -1,3 +1,10 @@
 {
-  "type": "apprenticecodex:charged_twin_blade_staff"
+  "type": "apprenticecodex:charged_twin_blade_staff",
+  "attributes": {
+    "common": {
+      "armor_negation": 20.0,
+      "impact": 3.0,
+      "max_strikes": 3
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/copper_swingcast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/copper_swingcast_staff.json
@@ -2,5 +2,11 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "impact": 0.8,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/crystal_bladed_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/crystal_bladed_staff.json
@@ -1,3 +1,10 @@
 {
-  "type": "epicfight:sword"
+  "type": "epicfight:sword",
+  "attributes": {
+    "common": {
+      "armor_negation":5.0,
+      "impact":1.1,
+      "max_strikes":2
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/diamond_swingcast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/diamond_swingcast_staff.json
@@ -2,5 +2,11 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "impact": 1.1,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/gold_swingcast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/gold_swingcast_staff.json
@@ -2,5 +2,11 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "impact": 0.2,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/illuminate_stellar_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/illuminate_stellar_staff.json
@@ -2,5 +2,17 @@
   "type": "epicfight:spear",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "one_hand": {
+      "armor_negation": 10.0,
+      "impact": 2.5,
+      "max_strikes": 1
+    },
+    "two_hand": {
+      "armor_negation": 10.0,
+      "impact": 1.8,
+      "max_strikes": 3
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/iron_swingcast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/iron_swingcast_staff.json
@@ -2,5 +2,11 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "impact": 1.0,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/mana_force_blade.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/mana_force_blade.json
@@ -2,8 +2,9 @@
   "type": "epicfight:uchigatana",
   "attributes": {
     "common": {
-      "impact": 1.1,
-      "max_strikes": 1
+      "armor_negation": 5.0,
+      "impact": 1.2,
+      "max_strikes": 2
     }
   }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/mithril_freecast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/mithril_freecast_staff.json
@@ -2,5 +2,11 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "impact": 0.9,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/multipurpose_staffrifle.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/multipurpose_staffrifle.json
@@ -1,8 +1,3 @@
 {
-  "attributes": {
-    "common": {
-      "impact": 0.5
-    }
-  },
   "type": "apprenticecodex:multipurpose_staffrifle"
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/netherite_swingcast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/netherite_swingcast_staff.json
@@ -2,5 +2,12 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "armor_negation": 10.0,
+      "impact": 1.3,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/revolvercast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/revolvercast_staff.json
@@ -2,5 +2,11 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "impact": 1.0,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/scrollcaster_gauntlet.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/scrollcaster_gauntlet.json
@@ -5,7 +5,7 @@
   "swing_sound": "epicfight:entity.weapon.whoosh",
   "attributes": {
     "common": {
-      "impact": 0.7
+      "impact": 1.0
     }
   }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/silver_swingcast_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/silver_swingcast_staff.json
@@ -2,5 +2,11 @@
   "type": "epicfight:sword",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "impact": 0.9,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/smashcast_scepter.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/smashcast_scepter.json
@@ -2,5 +2,12 @@
   "type": "apprenticecodex:smashcast_scepter",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "common": {
+      "armor_negation": 50.0,
+      "impact": 4.0,
+      "max_strikes": 0
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/spell_side_edge.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/spell_side_edge.json
@@ -1,3 +1,10 @@
 {
-  "type": "epicfight:dagger"
+  "type": "epicfight:dagger",
+  "attributes": {
+    "common": {
+      "armor_negation": 10.0,
+      "impact": 0.8,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/spell_side_edge_mirror.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/spell_side_edge_mirror.json
@@ -1,3 +1,10 @@
 {
-  "type": "epicfight:dagger"
+  "type": "epicfight:dagger",
+  "attributes": {
+    "common": {
+      "armor_negation": 10.0,
+      "impact": 0.8,
+      "max_strikes": 1
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/spellcharged_greatsword.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/spellcharged_greatsword.json
@@ -1,3 +1,10 @@
 {
-  "type": "apprenticecodex:spellcharged_greatsword"
+  "type": "apprenticecodex:spellcharged_greatsword",
+  "attributes": {
+    "common": {
+      "armor_negation": 30.0,
+      "impact": 5.0,
+      "max_strikes": 5
+    }
+  }
 }

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/unite_luna_staff.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/unite_luna_staff.json
@@ -2,5 +2,17 @@
   "type": "epicfight:spear",
   "hit_particle": "epicfight:hit_blunt",
   "hit_sound": "epicfight:entity.hit.blunt",
-  "swing_sound": "epicfight:entity.weapon.whoosh_rod"
+  "swing_sound": "epicfight:entity.weapon.whoosh_rod",
+  "attributes": {
+    "one_hand": {
+      "armor_negation": 40.0,
+      "impact": 3.5,
+      "max_strikes": 1
+    },
+    "two_hand": {
+      "armor_negation": 20.0,
+      "impact": 3.0,
+      "max_strikes": 3
+    }
+  }
 }


### PR DESCRIPTION
## 概要
- PR #658「EpicFight向けの数値設定とUI対応」を `1.21.1-main` へ forward-port
- Epic Fight capability JSON に防具の `stun_armor` / `weight`、武器の attribute 調整を反映
- Epic Fight 環境で Shift と競合する詳細表示操作に Alt キーを追加

## 対応メモ
- merge commit は取り込まず、PR #658 の非 merge コミット4件を `git cherry-pick -x` で取り込み
- `ImbueTooltipHelper` の衝突は 1.21.1 側の `FMLEnvironment.dist == Dist.CLIENT` 方式を維持して解決
- PR 作成前のローカル確認では `runClientEpicFight` も問題なし

## 確認
- `./gradlew.bat runGameTestServer` 成功（719 tests passed）
- `./gradlew.bat runGameTestServerEpicFight` 成功（719 tests passed）
- `./gradlew.bat build` 成功（`checkTextEncodingHygiene` 含む）