### PR TITLE
PR #659 の1.21.1対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -40,6 +40,7 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     private static final String HEAVENLY_FIST_CREATE_COMPACTING_DENYLIST_BATCH =
             "apprenticecodex.heavenly_fist_create_compacting_denylist";
     private static final String GRIND_RUNNER_ISOLATED_BATCH = "apprenticecodex.grind_runner_isolated";
+    private static final String SUMMON_WEAPON_ANIMATION_BATCH = "apprenticecodex.summon_weapon_animation";
 
     private ApprenticeCodexSpellBehaviorGameTests() {
     }
@@ -787,5 +788,15 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     @GameTest(template = TEMPLATE, batch = MIST_FORM_ISOLATED_BATCH)
     public static void mistFormMovementRestrictionIgnoreKeepsBlockEffects(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.mistFormMovementRestrictionIgnoreKeepsBlockEffects(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = SUMMON_WEAPON_ANIMATION_BATCH)
+    public static void slashBladeStandbyAnimationSpeedTracksReducedCastTime(GameTestHelper helper) {
+        SummonWeaponAnimationGameTestScenarios.slashBladeStandbyAnimationSpeedTracksReducedCastTime(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = SUMMON_WEAPON_ANIMATION_BATCH)
+    public static void moonLightStandbyAnimationSpeedAndDelayTrackReducedCastTime(GameTestHelper helper) {
+        SummonWeaponAnimationGameTestScenarios.moonLightStandbyAnimationSpeedAndDelayTrackReducedCastTime(helper);
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SummonWeaponAnimationGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SummonWeaponAnimationGameTestScenarios.java
@@ -1,0 +1,134 @@
+package jp.aquafactory.apprenticecodex.gametest;
+
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
+import io.redspace.ironsspellbooks.api.spells.CastSource;
+import io.redspace.ironsspellbooks.api.spells.CastType;
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.mixin.MagicDataAccessor;
+import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
+import jp.aquafactory.apprenticecodex.spell.moonlight.MoonLight;
+import jp.aquafactory.apprenticecodex.spell.slashblade.SlashBlade;
+import net.minecraft.core.BlockPos;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+
+import static jp.aquafactory.apprenticecodex.gametest.BowGameTestSupport.createEquipmentTestPlayer;
+
+final class SummonWeaponAnimationGameTestScenarios {
+    private static final ResourceLocation CAST_TIME_REDUCTION_TEST_MODIFIER_ID =
+            ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "summon_weapon_animation_test");
+
+    private SummonWeaponAnimationGameTestScenarios() {
+    }
+
+    static void slashBladeStandbyAnimationSpeedTracksReducedCastTime(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "slash_blade_standby_speed_test");
+            var spell = (SlashBlade) SpellRegistry.SLASH_BLADE.get();
+            applyCastTimeReduction(helper, player);
+
+            var baseCastTime = spell.getCastTime(1);
+            var effectiveCastTime = spell.getEffectiveCastTime(1, player);
+            helper.assertTrue(effectiveCastTime > 0 && effectiveCastTime < baseCastTime,
+                    "Slash Blade test should have reduced cast time. base=" + baseCastTime
+                            + ", effective=" + effectiveCastTime);
+
+            var magicData = MagicData.getPlayerMagicData(player);
+            prepareLongCast(magicData, effectiveCastTime);
+            var weapon = spell.onCastNoWeapon(helper.getLevel(), 1, player, magicData);
+
+            spell.onCastTickWithWeapon(helper.getLevel(), 1, player, magicData, weapon);
+            assertFloatClose(
+                    helper,
+                    weapon.getAnimationSpeedForGameTest(),
+                    1.5f * baseCastTime / effectiveCastTime,
+                    "Slash Blade standby animation speed should track cast-time reduction"
+            );
+
+            spell.onCastCompleteWithWeapon(helper.getLevel(), 1, player, magicData, false, weapon);
+            assertFloatClose(
+                    helper,
+                    weapon.getAnimationSpeedForGameTest(),
+                    5.0f,
+                    "Slash Blade quickdraw animation speed should keep its existing value"
+            );
+        });
+    }
+
+    static void moonLightStandbyAnimationSpeedAndDelayTrackReducedCastTime(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "moon_light_standby_speed_test");
+            var spell = (MoonLight) SpellRegistry.MOON_LIGHT.get();
+            applyCastTimeReduction(helper, player);
+
+            var baseCastTime = spell.getCastTime(1);
+            var effectiveCastTime = spell.getEffectiveCastTime(1, player);
+            helper.assertTrue(effectiveCastTime > 0 && effectiveCastTime < baseCastTime,
+                    "MoonLight test should have reduced cast time. base=" + baseCastTime
+                            + ", effective=" + effectiveCastTime);
+
+            var speedScale = baseCastTime / (float) effectiveCastTime;
+            var expectedDelay = Mth.ceil(10 / speedScale);
+            var magicData = MagicData.getPlayerMagicData(player);
+            prepareLongCast(magicData, effectiveCastTime);
+            var weapon = spell.onCastNoWeapon(helper.getLevel(), 1, player, magicData);
+
+            weapon.tickCount = Math.max(0, expectedDelay - 1);
+            spell.onCastTickWithWeapon(helper.getLevel(), 1, player, magicData, weapon);
+            helper.assertFalse(weapon.isStandby(),
+                    "MoonLight should not enter standby before the reduced standby delay");
+
+            weapon.tickCount = expectedDelay;
+            spell.onCastTickWithWeapon(helper.getLevel(), 1, player, magicData, weapon);
+            helper.assertTrue(weapon.isStandby(),
+                    "MoonLight should enter standby once the reduced standby delay is reached");
+            assertFloatClose(
+                    helper,
+                    weapon.getAnimationSpeedForGameTest(),
+                    1.5f * speedScale,
+                    "MoonLight standby animation speed should track cast-time reduction"
+            );
+
+            spell.onCastCompleteWithWeapon(helper.getLevel(), 1, player, magicData, false, weapon);
+            assertFloatClose(
+                    helper,
+                    weapon.getAnimationSpeedForGameTest(),
+                    4.0f,
+                    "MoonLight quickdraw animation speed should keep its existing value"
+            );
+        });
+    }
+
+    private static void applyCastTimeReduction(GameTestHelper helper, net.minecraft.world.entity.LivingEntity player) {
+        var castTimeReductionAttribute = player.getAttribute(AttributeRegistry.CAST_TIME_REDUCTION);
+        helper.assertTrue(castTimeReductionAttribute != null,
+                "Summon weapon animation test could not resolve cast-time reduction attribute");
+        if (castTimeReductionAttribute == null) {
+            return;
+        }
+
+        castTimeReductionAttribute.removeModifier(CAST_TIME_REDUCTION_TEST_MODIFIER_ID);
+        castTimeReductionAttribute.addTransientModifier(new AttributeModifier(
+                CAST_TIME_REDUCTION_TEST_MODIFIER_ID,
+                0.5D,
+                AttributeModifier.Operation.ADD_MULTIPLIED_BASE
+        ));
+    }
+
+    private static void prepareLongCast(MagicData magicData, int castDuration) {
+        var accessor = (MagicDataAccessor) magicData;
+        accessor.apprenticecodex$setCastingSpellLevel(1);
+        accessor.apprenticecodex$setCastDuration(castDuration);
+        accessor.apprenticecodex$setCastDurationRemaining(castDuration);
+        accessor.apprenticecodex$setCastSource(CastSource.SPELLBOOK);
+        accessor.apprenticecodex$setCastType(CastType.LONG);
+    }
+
+    private static void assertFloatClose(GameTestHelper helper, float actual, float expected, String message) {
+        helper.assertTrue(Math.abs(actual - expected) < 1.0E-4f,
+                message + ". expected=" + expected + ", actual=" + actual);
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLight.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLight.java
@@ -18,6 +18,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
+import net.minecraft.util.Mth;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
@@ -116,12 +117,27 @@ public class MoonLight extends AbstractSummonWeaponSpell<MoonLightKatanaEntity> 
 
     @Override
     public void onCastTickWithWeapon(Level level, int spellLevel, LivingEntity entity, MagicData playerMagicData, @NotNull MoonLightKatanaEntity weapon) {
-        if (!weapon.isStandby() && weapon.tickCount >= STANDBY_START_DELAY_TICK) {
-            weapon.setStandby();
+        var castTimeSpeedScale = getCastTimeSpeedScale(spellLevel, playerMagicData);
+        if (!weapon.isStandby() && weapon.tickCount >= getStandbyStartDelayTick(castTimeSpeedScale)) {
+            weapon.setStandby(castTimeSpeedScale);
         }
 
         weapon.setChargingEffectActive(true);
         weapon.setFullyChargedEffect(false);
+    }
+
+    private int getStandbyStartDelayTick(float castTimeSpeedScale) {
+        return Math.max(0, Mth.ceil(STANDBY_START_DELAY_TICK / Math.max(1.0f, castTimeSpeedScale)));
+    }
+
+    private float getCastTimeSpeedScale(int spellLevel, @Nullable MagicData playerMagicData) {
+        var baseCastTime = Math.max(0, getCastTime(spellLevel));
+        if (baseCastTime <= 0 || playerMagicData == null) {
+            return 1.0f;
+        }
+
+        var actualCastTime = Math.max(1, playerMagicData.getCastDuration());
+        return Math.max(1.0f, baseCastTime / (float) actualCastTime);
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLightKatanaEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/moonlight/MoonLightKatanaEntity.java
@@ -119,14 +119,22 @@ public class MoonLightKatanaEntity extends SummonWeaponEntity implements GeoEnti
     }
 
     public void setStandby() {
+        setStandby(1.0f);
+    }
+
+    public void setStandby(float castTimeSpeedScale) {
         triggerAnim("main", "standby");
-        entityData.set(ANIMATION_SPEED, 1.5f);
+        entityData.set(ANIMATION_SPEED, 1.5f * Math.max(1.0f, castTimeSpeedScale));
         entityData.set(SHOW_TRAIL, false);
         isStandby = true;
     }
 
     public boolean isStandby() {
         return isStandby;
+    }
+
+    public float getAnimationSpeedForGameTest() {
+        return entityData.get(ANIMATION_SPEED);
     }
 
     public void slash(Level level) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBlade.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBlade.java
@@ -18,7 +18,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvent;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
@@ -112,8 +111,18 @@ public class SlashBlade extends AbstractSummonWeaponSpell<SlashBladeKatanaEntity
     @Override
     public void onCastTickWithWeapon(Level level, int spellLevel, LivingEntity entity, MagicData playerMagicData, @NotNull SlashBladeKatanaEntity weapon) {
         if (!weapon.isStandby()){
-            weapon.setStandby();
+            weapon.setStandby(getCastTimeSpeedScale(spellLevel, playerMagicData));
         }
+    }
+
+    private float getCastTimeSpeedScale(int spellLevel, @Nullable MagicData playerMagicData) {
+        var baseCastTime = Math.max(0, getCastTime(spellLevel));
+        if (baseCastTime <= 0 || playerMagicData == null) {
+            return 1.0f;
+        }
+
+        var actualCastTime = Math.max(1, playerMagicData.getCastDuration());
+        return Math.max(1.0f, baseCastTime / (float) actualCastTime);
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBladeKatanaEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/slashblade/SlashBladeKatanaEntity.java
@@ -111,14 +111,22 @@ public class SlashBladeKatanaEntity extends SummonWeaponEntity implements GeoEnt
     }
 
     public void setStandby(){
+        setStandby(1.0f);
+    }
+
+    public void setStandby(float castTimeSpeedScale){
         triggerAnim("main", "standby");
-        entityData.set(ANIMATION_SPEED, 1.5f);
+        entityData.set(ANIMATION_SPEED, 1.5f * Math.max(1.0f, castTimeSpeedScale));
         entityData.set(SHOW_TRAIL, false);
         isStandby = true;
     }
 
     public boolean isStandby(){
         return isStandby;
+    }
+
+    public float getAnimationSpeedForGameTest() {
+        return entityData.get(ANIMATION_SPEED);
     }
 
     public void slash(Level level){


### PR DESCRIPTION
## 概要
- #659 を `1.21.1-main` 向けに forward-port
- 一閃 / 月光の構えモーション速度を、詠唱時間短縮に合わせて高速化
- 月光の構え開始ディレイも実効詠唱時間に合わせて短縮
- 1.21.1 API に合わせて追加 GameTest の `AttributeModifier` ID を `ResourceLocation` 形式へ調整

## 確認
- `./gradlew.bat runGameTestServer` 成功（721 tests passed）
- `./gradlew.bat build` 成功
- `runClient` 問題なし（ローカル確認済み）

## 備考
- cherry-pick 元: 169f53353160c9d34a79173804a308ba39fcfa67