### PR TITLE
PR #663 の1.21.1対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -273,6 +273,14 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.craftsmansDelightFortuneLevel();
     }
 
+    public static boolean isCraftsmansDelightGracedRainGrowthDenied(ResourceLocation entityTypeId) {
+        return ITEMS_CONFIG.isCraftsmansDelightGracedRainGrowthDenied(entityTypeId);
+    }
+
+    public static boolean isCraftsmansDelightGracedRainBreedingCooldownDenied(ResourceLocation entityTypeId) {
+        return ITEMS_CONFIG.isCraftsmansDelightGracedRainBreedingCooldownDenied(entityTypeId);
+    }
+
     public static double apprenticeMageRobeSpellPowerBonusPerPiece() {
         return ITEMS_CONFIG.apprenticeMageRobeSpellPowerBonusPerPiece();
     }
@@ -761,6 +769,23 @@ public final class ApprenticeCodexServerConfig {
         var previousSpellDenylist = ITEMS_CONFIG.multipurposeStaffrifleSpellDenylist();
         ITEMS_CONFIG.setMultipurposeStaffrifleSpellDenylistForGameTest(spellDenylist);
         return () -> ITEMS_CONFIG.setMultipurposeStaffrifleSpellDenylistForGameTest(previousSpellDenylist);
+    }
+
+    public static GameTestConfigOverride useCraftsmansDelightGracedRainDenylistOverrideForGameTest(
+            List<String> gracedRainGrowthDenylist,
+            List<String> gracedRainBreedingCooldownDenylist
+    ) {
+        var previousGrowthDenylist = ITEMS_CONFIG.craftsmansDelightGracedRainGrowthDenylist();
+        var previousBreedingCooldownDenylist = ITEMS_CONFIG.craftsmansDelightGracedRainBreedingCooldownDenylist();
+
+        ITEMS_CONFIG.setCraftsmansDelightGracedRainDenylistsForGameTest(
+                gracedRainGrowthDenylist,
+                gracedRainBreedingCooldownDenylist
+        );
+        return () -> ITEMS_CONFIG.setCraftsmansDelightGracedRainDenylistsForGameTest(
+                previousGrowthDenylist,
+                previousBreedingCooldownDenylist
+        );
     }
 
     public static GameTestConfigOverride useSpellgunConfigOverrideForGameTest(SpellgunServerConfig.Values values) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -226,6 +226,22 @@ final class ItemsServerConfig {
         return craftsmansDelightConfig.fortuneLevel();
     }
 
+    boolean isCraftsmansDelightGracedRainGrowthDenied(ResourceLocation entityTypeId) {
+        return craftsmansDelightConfig.isGracedRainGrowthDenied(entityTypeId);
+    }
+
+    boolean isCraftsmansDelightGracedRainBreedingCooldownDenied(ResourceLocation entityTypeId) {
+        return craftsmansDelightConfig.isGracedRainBreedingCooldownDenied(entityTypeId);
+    }
+
+    List<String> craftsmansDelightGracedRainGrowthDenylist() {
+        return craftsmansDelightConfig.gracedRainGrowthDenylist();
+    }
+
+    List<String> craftsmansDelightGracedRainBreedingCooldownDenylist() {
+        return craftsmansDelightConfig.gracedRainBreedingCooldownDenylist();
+    }
+
     double apprenticeMageRobeSpellPowerBonusPerPiece() {
         return magicArmorConfig.apprenticeMageRobeSpellPowerBonusPerPiece();
     }
@@ -680,6 +696,16 @@ final class ItemsServerConfig {
 
     void setSpellgunConfigForGameTest(SpellgunServerConfig.Values values) {
         spellgunConfig.setForGameTest(values);
+    }
+
+    void setCraftsmansDelightGracedRainDenylistsForGameTest(
+            List<String> gracedRainGrowthDenylist,
+            List<String> gracedRainBreedingCooldownDenylist
+    ) {
+        craftsmansDelightConfig.setGracedRainDenylistsForGameTest(
+                gracedRainGrowthDenylist,
+                gracedRainBreedingCooldownDenylist
+        );
     }
 
     void setMultipurposeStaffrifleSpellDenylistForGameTest(List<String> spellDenylist) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/CraftsmansDelightServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/CraftsmansDelightServerConfig.java
@@ -1,20 +1,32 @@
 package jp.aquafactory.apprenticecodex.config.item;
 
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.common.ModConfigSpec;
+
+import java.util.List;
+import java.util.Objects;
 
 public final class CraftsmansDelightServerConfig {
     private final ModConfigSpec.BooleanValue canImbueEnchantment;
     private final ModConfigSpec.DoubleValue requiredMana;
     private final ModConfigSpec.IntValue fortuneLevel;
+    private final ModConfigSpec.ConfigValue<List<? extends String>> gracedRainGrowthDenylist;
+    private final ModConfigSpec.ConfigValue<List<? extends String>> gracedRainBreedingCooldownDenylist;
+    private List<String> gracedRainGrowthDenylistOverride;
+    private List<String> gracedRainBreedingCooldownDenylistOverride;
 
     private CraftsmansDelightServerConfig(
             ModConfigSpec.BooleanValue canImbueEnchantment,
             ModConfigSpec.DoubleValue requiredMana,
-            ModConfigSpec.IntValue fortuneLevel
+            ModConfigSpec.IntValue fortuneLevel,
+            ModConfigSpec.ConfigValue<List<? extends String>> gracedRainGrowthDenylist,
+            ModConfigSpec.ConfigValue<List<? extends String>> gracedRainBreedingCooldownDenylist
     ) {
         this.canImbueEnchantment = canImbueEnchantment;
         this.requiredMana = requiredMana;
         this.fortuneLevel = fortuneLevel;
+        this.gracedRainGrowthDenylist = gracedRainGrowthDenylist;
+        this.gracedRainBreedingCooldownDenylist = gracedRainBreedingCooldownDenylist;
     }
 
     public static CraftsmansDelightServerConfig define(ModConfigSpec.Builder builder) {
@@ -23,12 +35,20 @@ public final class CraftsmansDelightServerConfig {
         var canImbueEnchantment = builder.define("canImbueEnchantment", true);
         var requiredMana = builder.defineInRange("requiredMana", 500.0d, 0.0d, 10000.0d);
         var fortuneLevel = builder.defineInRange("fortuneLevel", 3, 1, 10);
+        var gracedRainGrowthDenylist = builder
+                .comment("Entity type IDs blocked from Craftsman's Delight Graced Rain baby growth acceleration. Entries use \"modid:path\".")
+                .defineListAllowEmpty("gracedRainGrowthDenylist", List.<String>of(), CraftsmansDelightServerConfig::isEntityTypeId);
+        var gracedRainBreedingCooldownDenylist = builder
+                .comment("Entity type IDs blocked from Craftsman's Delight Graced Rain breeding cooldown reduction. Entries use \"modid:path\".")
+                .defineListAllowEmpty("gracedRainBreedingCooldownDenylist", List.<String>of(), CraftsmansDelightServerConfig::isEntityTypeId);
 
         builder.pop();
         return new CraftsmansDelightServerConfig(
                 canImbueEnchantment,
                 requiredMana,
-                fortuneLevel
+                fortuneLevel,
+                gracedRainGrowthDenylist,
+                gracedRainBreedingCooldownDenylist
         );
     }
 
@@ -42,6 +62,54 @@ public final class CraftsmansDelightServerConfig {
 
     public int fortuneLevel() {
         return fortuneLevel.get();
+    }
+
+    public boolean isGracedRainGrowthDenied(ResourceLocation entityTypeId) {
+        return containsEntityTypeId(gracedRainGrowthDenylist(), entityTypeId);
+    }
+
+    public boolean isGracedRainBreedingCooldownDenied(ResourceLocation entityTypeId) {
+        return containsEntityTypeId(gracedRainBreedingCooldownDenylist(), entityTypeId);
+    }
+
+    public List<String> gracedRainGrowthDenylist() {
+        return Objects.requireNonNullElseGet(gracedRainGrowthDenylistOverride,
+                () -> stringList(gracedRainGrowthDenylist));
+    }
+
+    public List<String> gracedRainBreedingCooldownDenylist() {
+        return Objects.requireNonNullElseGet(gracedRainBreedingCooldownDenylistOverride,
+                () -> stringList(gracedRainBreedingCooldownDenylist));
+    }
+
+    public void setGracedRainDenylistsForGameTest(
+            List<String> gracedRainGrowthDenylist,
+            List<String> gracedRainBreedingCooldownDenylist
+    ) {
+        this.gracedRainGrowthDenylistOverride = List.copyOf(gracedRainGrowthDenylist);
+        this.gracedRainBreedingCooldownDenylistOverride = List.copyOf(gracedRainBreedingCooldownDenylist);
+    }
+
+    private static boolean containsEntityTypeId(List<String> configuredIds, ResourceLocation entityTypeId) {
+        if (entityTypeId == null) {
+            return false;
+        }
+        for (var configuredId : configuredIds) {
+            if (entityTypeId.equals(ResourceLocation.tryParse(String.valueOf(configuredId)))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static List<String> stringList(ModConfigSpec.ConfigValue<List<? extends String>> configValue) {
+        return configValue.get().stream()
+                .map(String::valueOf)
+                .toList();
+    }
+
+    private static boolean isEntityTypeId(Object value) {
+        return value instanceof String text && text.contains(":") && ResourceLocation.tryParse(text) != null;
     }
 }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -11,6 +11,8 @@ import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
 public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     private static final String TEMPLATE = "gametest/basic_floor";
     private static final String MINING_SPELL_ISOLATED_BATCH = "apprenticecodex.mining_spell_isolated";
+    private static final String CRAFTSMANS_DELIGHT_GRACED_RAIN_DENYLIST_CONFIG_BATCH =
+            "apprenticecodex.craftsmans_delight_graced_rain_denylist_config";
     private static final String FOCUS_STAFFBOW_CONTINUOUS_BATCH = "apprenticecodex.focus_staffbow_continuous";
     private static final String FOCUS_STAFFBOW_ARROW_CONFIG_BATCH =
             "apprenticecodex.focus_staffbow_arrow_config";
@@ -1397,6 +1399,41 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     @GameTest(template = TEMPLATE)
     public static void craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(GameTestHelper helper) {
         EquipmentSpellBehaviorBridgeGameTestScenarios.craftsmansDelightScrollcasterGauntletCooldownKeepsItemPolicy(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void craftsmansDelightGracedRainAcceleratesBabyGrowth(GameTestHelper helper) {
+        CraftsmansDelightGracedRainGameTestScenarios.craftsmansDelightGracedRainAcceleratesBabyGrowth(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void craftsmansDelightGracedRainReducesBreedingCooldown(GameTestHelper helper) {
+        CraftsmansDelightGracedRainGameTestScenarios.craftsmansDelightGracedRainReducesBreedingCooldown(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void gracedRainWithoutCraftsmansDelightLeavesMobAgeUnchanged(GameTestHelper helper) {
+        CraftsmansDelightGracedRainGameTestScenarios.gracedRainWithoutCraftsmansDelightLeavesMobAgeUnchanged(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void gracedRainUndeadTargetsKeepDamageBehavior(GameTestHelper helper) {
+        CraftsmansDelightGracedRainGameTestScenarios.gracedRainUndeadTargetsKeepDamageBehavior(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = CRAFTSMANS_DELIGHT_GRACED_RAIN_DENYLIST_CONFIG_BATCH)
+    public static void craftsmansDelightGracedRainGrowthDenylistBlocksOnlyGrowth(GameTestHelper helper) {
+        CraftsmansDelightGracedRainGameTestScenarios.craftsmansDelightGracedRainGrowthDenylistBlocksOnlyGrowth(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = CRAFTSMANS_DELIGHT_GRACED_RAIN_DENYLIST_CONFIG_BATCH)
+    public static void craftsmansDelightGracedRainBreedingCooldownDenylistBlocksOnlyCooldown(GameTestHelper helper) {
+        CraftsmansDelightGracedRainGameTestScenarios.craftsmansDelightGracedRainBreedingCooldownDenylistBlocksOnlyCooldown(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void craftsmansDelightGracedRainDoesNotReduceAllayDuplicationCooldown(GameTestHelper helper) {
+        CraftsmansDelightGracedRainGameTestScenarios.craftsmansDelightGracedRainDoesNotReduceAllayDuplicationCooldown(helper);
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/CraftsmansDelightGracedRainGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/CraftsmansDelightGracedRainGameTestScenarios.java
@@ -1,0 +1,206 @@
+package jp.aquafactory.apprenticecodex.gametest;
+
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
+import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
+import jp.aquafactory.apprenticecodex.spell.gracedrain.GracedRainCloudEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.entity.AgeableMob;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.allay.Allay;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.common.util.FakePlayer;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+final class CraftsmansDelightGracedRainGameTestScenarios extends ApprenticeCodexGameTestScenarios {
+    private static final int STARTING_AGE = -1000;
+    private static final int STARTING_BREEDING_COOLDOWN = 1000;
+    private static final int EXPECTED_REDUCED_AGE = -900;
+    private static final int EXPECTED_REDUCED_BREEDING_COOLDOWN = 900;
+    private static final int DUPLICATION_COOLDOWN = 1000;
+
+    private CraftsmansDelightGracedRainGameTestScenarios() {
+    }
+
+    static void craftsmansDelightGracedRainAcceleratesBabyGrowth(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createGracedRainOwner(helper, "graced_rain_baby_growth_owner", true);
+            var cow = spawnAgeableTarget(helper, EntityType.COW, STARTING_AGE);
+
+            processGracedRainEntityEffect(helper, owner, cow);
+
+            helper.assertTrue(cow.getAge() == EXPECTED_REDUCED_AGE,
+                    "Craftsman's Delight Graced Rain should reduce remaining baby growth age from "
+                            + STARTING_AGE + " to " + EXPECTED_REDUCED_AGE + " but got " + cow.getAge());
+        });
+    }
+
+    static void craftsmansDelightGracedRainReducesBreedingCooldown(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createGracedRainOwner(helper, "graced_rain_breeding_cooldown_owner", true);
+            var cow = spawnAgeableTarget(helper, EntityType.COW, STARTING_BREEDING_COOLDOWN);
+
+            processGracedRainEntityEffect(helper, owner, cow);
+
+            helper.assertTrue(cow.getAge() == EXPECTED_REDUCED_BREEDING_COOLDOWN,
+                    "Craftsman's Delight Graced Rain should reduce breeding cooldown from "
+                            + STARTING_BREEDING_COOLDOWN + " to " + EXPECTED_REDUCED_BREEDING_COOLDOWN
+                            + " but got " + cow.getAge());
+        });
+    }
+
+    static void gracedRainWithoutCraftsmansDelightLeavesMobAgeUnchanged(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createGracedRainOwner(helper, "graced_rain_no_ring_owner", false);
+            var cow = spawnAgeableTarget(helper, EntityType.COW, STARTING_AGE);
+
+            processGracedRainEntityEffect(helper, owner, cow);
+
+            helper.assertTrue(cow.getAge() == STARTING_AGE,
+                    "Graced Rain without Craftsman's Delight should not change age but got " + cow.getAge());
+        });
+    }
+
+    static void gracedRainUndeadTargetsKeepDamageBehavior(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createGracedRainOwner(helper, "graced_rain_undead_owner", true);
+            var zombie = helper.spawn(EntityType.ZOMBIE, new BlockPos(0, 2, 0));
+            zombie.setNoAi(true);
+            var startingHealth = zombie.getHealth();
+
+            processGracedRainEntityEffect(helper, owner, zombie);
+
+            helper.assertTrue(zombie.getHealth() < startingHealth,
+                    "Graced Rain should keep damaging undead targets while Craftsman's Delight is equipped");
+        });
+    }
+
+    static void craftsmansDelightGracedRainGrowthDenylistBlocksOnlyGrowth(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            try (var ignored = ApprenticeCodexServerConfig.useCraftsmansDelightGracedRainDenylistOverrideForGameTest(
+                    List.of(cowId()),
+                    List.of()
+            )) {
+                var owner = createGracedRainOwner(helper, "graced_rain_growth_denylist_owner", true);
+                var babyCow = spawnAgeableTarget(helper, EntityType.COW, STARTING_AGE, new BlockPos(0, 2, 0));
+                var cooldownCow = spawnAgeableTarget(helper, EntityType.COW, STARTING_BREEDING_COOLDOWN, new BlockPos(2, 2, 0));
+
+                processGracedRainEntityEffect(helper, owner, babyCow);
+                processGracedRainEntityEffect(helper, owner, cooldownCow);
+
+                helper.assertTrue(babyCow.getAge() == STARTING_AGE,
+                        "Graced Rain growth denylist should leave baby age unchanged but got " + babyCow.getAge());
+                helper.assertTrue(cooldownCow.getAge() == EXPECTED_REDUCED_BREEDING_COOLDOWN,
+                        "Graced Rain growth denylist should not block breeding cooldown reduction but got "
+                                + cooldownCow.getAge());
+            }
+        });
+    }
+
+    static void craftsmansDelightGracedRainBreedingCooldownDenylistBlocksOnlyCooldown(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            try (var ignored = ApprenticeCodexServerConfig.useCraftsmansDelightGracedRainDenylistOverrideForGameTest(
+                    List.of(),
+                    List.of(cowId())
+            )) {
+                var owner = createGracedRainOwner(helper, "graced_rain_breeding_denylist_owner", true);
+                var babyCow = spawnAgeableTarget(helper, EntityType.COW, STARTING_AGE, new BlockPos(0, 2, 0));
+                var cooldownCow = spawnAgeableTarget(helper, EntityType.COW, STARTING_BREEDING_COOLDOWN, new BlockPos(2, 2, 0));
+
+                processGracedRainEntityEffect(helper, owner, babyCow);
+                processGracedRainEntityEffect(helper, owner, cooldownCow);
+
+                helper.assertTrue(babyCow.getAge() == EXPECTED_REDUCED_AGE,
+                        "Graced Rain breeding cooldown denylist should not block baby growth but got "
+                                + babyCow.getAge());
+                helper.assertTrue(cooldownCow.getAge() == STARTING_BREEDING_COOLDOWN,
+                        "Graced Rain breeding cooldown denylist should leave cooldown unchanged but got "
+                                + cooldownCow.getAge());
+            }
+        });
+    }
+
+    static void craftsmansDelightGracedRainDoesNotReduceAllayDuplicationCooldown(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var owner = createGracedRainOwner(helper, "graced_rain_allay_owner", true);
+            var allay = helper.spawn(EntityType.ALLAY, new BlockPos(0, 2, 0));
+            allay.setNoAi(true);
+            setAllayDuplicationCooldown(allay, DUPLICATION_COOLDOWN);
+
+            processGracedRainEntityEffect(helper, owner, allay);
+
+            var actualCooldown = getAllayDuplicationCooldown(allay);
+            helper.assertTrue(actualCooldown == DUPLICATION_COOLDOWN,
+                    "Craftsman's Delight Graced Rain should not reduce Allay duplication cooldown but got "
+                            + actualCooldown);
+        });
+    }
+
+    private static FakePlayer createGracedRainOwner(GameTestHelper helper, String profileName, boolean equipCraftsmansDelight) {
+        var owner = createTrackedEquipmentTestPlayer(helper, new BlockPos(4, 2, 0), profileName);
+        if (equipCraftsmansDelight) {
+            equipRingCurio(owner, new ItemStack(ItemRegistry.CRAFTSMANS_DELIGHT.get()));
+        }
+        return owner;
+    }
+
+    private static <T extends AgeableMob> T spawnAgeableTarget(GameTestHelper helper, EntityType<T> entityType, int age) {
+        return spawnAgeableTarget(helper, entityType, age, new BlockPos(0, 2, 0));
+    }
+
+    private static <T extends AgeableMob> T spawnAgeableTarget(
+            GameTestHelper helper,
+            EntityType<T> entityType,
+            int age,
+            BlockPos position
+    ) {
+        var target = helper.spawn(entityType, position);
+        target.setNoAi(true);
+        target.setAge(age);
+        return target;
+    }
+
+    private static void processGracedRainEntityEffect(GameTestHelper helper, FakePlayer owner, LivingEntity target) {
+        var level = helper.getLevel();
+        var cloud = new GracedRainCloudEntity(EntityRegistry.GRACED_RAIN_CLOUD.get(), level, owner);
+        cloud.setEffectRadiusBlocks(1);
+        cloud.setHealAmount(2.0F);
+        cloud.setAnchorPosition(target.position().add(0.0D, GracedRainCloudEntity.HEIGHT_OFFSET, 0.0D));
+        for (var tick = 0; tick < 10; ++tick) {
+            cloud.tickOnServer(level);
+        }
+    }
+
+    private static String cowId() {
+        return BuiltInRegistries.ENTITY_TYPE.getKey(EntityType.COW).toString();
+    }
+
+    private static void setAllayDuplicationCooldown(Allay allay, long cooldown) {
+        try {
+            var field = allayDuplicationCooldownField();
+            field.setLong(allay, cooldown);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Could not set Allay duplication cooldown for GameTest", exception);
+        }
+    }
+
+    private static long getAllayDuplicationCooldown(Allay allay) {
+        try {
+            var field = allayDuplicationCooldownField();
+            return field.getLong(allay);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Could not read Allay duplication cooldown for GameTest", exception);
+        }
+    }
+
+    private static Field allayDuplicationCooldownField() throws NoSuchFieldException {
+        var field = Allay.class.getDeclaredField("duplicationCooldown");
+        field.setAccessible(true);
+        return field;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/gracedrain/GracedRainCloudEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/gracedrain/GracedRainCloudEntity.java
@@ -1,8 +1,10 @@
 package jp.aquafactory.apprenticecodex.spell.gracedrain;
 
 import io.redspace.ironsspellbooks.api.spells.SchoolType;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.damage.DamageTypes;
 import jp.aquafactory.apprenticecodex.entity.SummonWeaponEntity;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelight;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import jp.aquafactory.apprenticecodex.registry.TagRegistry;
@@ -10,6 +12,7 @@ import jp.aquafactory.apprenticecodex.utility.AudioTools;
 import jp.aquafactory.apprenticecodex.utility.CombatTools;
 import jp.aquafactory.apprenticecodex.utility.RaycastTools;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
@@ -19,6 +22,7 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.util.Mth;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.AgeableMob;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -39,6 +43,7 @@ public class GracedRainCloudEntity extends SummonWeaponEntity {
     private static final float VISUAL_OVERFLOW_BLOCKS = 0.35f;
     private static final int FOLLOW_EFFECT_INTERVAL_TICKS = 10;
     private static final int SOUND_INTERVAL_TICKS = 55;
+    private static final double CRAFTSMANS_DELIGHT_AGE_REDUCTION_RATIO = 0.10D;
 
     private static final EntityDataAccessor<Integer> EFFECT_RADIUS_BLOCKS =
             SynchedEntityData.defineId(GracedRainCloudEntity.class, EntityDataSerializers.INT);
@@ -323,25 +328,64 @@ public class GracedRainCloudEntity extends SummonWeaponEntity {
         var source = createCombatDamageSource(DamageTypes.GRACED_RAIN);
         var school = SpellRegistry.GRACED_RAIN.get().getSchoolType();
         var targets = level.getEntitiesOfClass(LivingEntity.class, box, LivingEntity::isAlive);
+        var owner = getOwner();
+        var ownerLiving = owner instanceof LivingEntity living ? living : null;
+        var craftsmansDelightAgeEffectEnabled = CraftsmansDelight.isEquippedBy(ownerLiving);
 
         for (var target : targets) {
-            applyHealingEffect(target, source, school);
+            applyHealingEffect(target, source, school, craftsmansDelightAgeEffectEnabled);
         }
 
-        var owner = getOwner();
-        if (owner instanceof LivingEntity ownerLiving && ownerLiving.isAlive()
+        if (ownerLiving != null && ownerLiving.isAlive()
                 && box.intersects(ownerLiving.getBoundingBox())
                 && !targets.contains(ownerLiving)) {
-            applyHealingEffect(ownerLiving, source, school);
+            applyHealingEffect(ownerLiving, source, school, craftsmansDelightAgeEffectEnabled);
         }
     }
 
-    private void applyHealingEffect(LivingEntity target, DamageSource source, SchoolType school) {
+    private void applyHealingEffect(
+            LivingEntity target,
+            DamageSource source,
+            SchoolType school,
+            boolean craftsmansDelightAgeEffectEnabled
+    ) {
         if (target.isInvertedHealAndHarm()) {
             CombatTools.applyDamage(target, healAmount, source, school, CombatTools.KnockbackTypes.NO_KNOCKBACK);
         } else {
             target.heal(healAmount);
+            if (craftsmansDelightAgeEffectEnabled) {
+                applyCraftsmansDelightAgeEffect(target);
+            }
         }
+    }
+
+    private void applyCraftsmansDelightAgeEffect(LivingEntity target) {
+        if (target.getType() == EntityType.ALLAY || !(target instanceof AgeableMob ageable)) {
+            return;
+        }
+
+        var age = ageable.getAge();
+        if (age < 0 && !isCraftsmansDelightGracedRainGrowthDenied(ageable)) {
+            ageable.setAge(Math.min(0, age + getCraftsmansDelightAgeReductionTicks(age)));
+        } else if (age > 0 && !isCraftsmansDelightGracedRainBreedingCooldownDenied(ageable)) {
+            ageable.setAge(Math.max(0, age - getCraftsmansDelightAgeReductionTicks(age)));
+        }
+    }
+
+    private int getCraftsmansDelightAgeReductionTicks(int age) {
+        return Math.max(1, Mth.ceil(Math.abs(age) * CRAFTSMANS_DELIGHT_AGE_REDUCTION_RATIO));
+    }
+
+    private boolean isCraftsmansDelightGracedRainGrowthDenied(AgeableMob target) {
+        return ApprenticeCodexServerConfig.isCraftsmansDelightGracedRainGrowthDenied(
+                BuiltInRegistries.ENTITY_TYPE.getKey(target.getType())
+        );
+    }
+
+    private boolean isCraftsmansDelightGracedRainBreedingCooldownDenied(AgeableMob target) {
+        return ApprenticeCodexServerConfig.isCraftsmansDelightGracedRainBreedingCooldownDenied(
+                BuiltInRegistries.ENTITY_TYPE.getKey(target.getType())
+        );
     }
 
     public void setGrowthIntervalTicks(int ticks) {

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -339,6 +339,7 @@
   "jei.apprenticecodex.craftsmans_delight.desc_10": "- Touch Dig: Range is doubled.",
   "jei.apprenticecodex.craftsmans_delight.desc_11": "- Heavenly Fist: Harvests mature crystals growing from nearby budding blocks.",
   "jei.apprenticecodex.craftsmans_delight.desc_12": "- Mana Mending: Resets the item's cumulative anvil work count when repair completes.",
+  "jei.apprenticecodex.craftsmans_delight.desc_13": "- Graced Rain: Growth acceleration also affects creatures and helps them breed again sooner.",
   "jei.apprenticecodex.protection_spell_supporter.desc_1": "Modifies the spells below and reduces their mana cost while they are active.",
   "jei.apprenticecodex.protection_spell_supporter.desc_2": "- Force Field: Can block attacks that a shield cannot.",
   "jei.apprenticecodex.protection_spell_supporter.desc_3": "- Phalanx Charge: Increases movement speed while guarding with the shield, and can neutralize Counterspell from the front.",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -340,6 +340,7 @@
   "jei.apprenticecodex.craftsmans_delight.desc_10": "- タッチディグ：射程が2倍に伸びる。",
   "jei.apprenticecodex.craftsmans_delight.desc_11": "- 天からの鉄拳：近くの芽生えブロックから生えた最大成長の結晶を採掘する。",
   "jei.apprenticecodex.craftsmans_delight.desc_12": "- マナ修繕：修繕が完了した時にそのアイテムの累計作業量をリセットする。",
+  "jei.apprenticecodex.craftsmans_delight.desc_13": "- 恵みの雨：成長の加速が生き物にも有効になり、連続した繁殖も促す。",
   "jei.apprenticecodex.protection_spell_supporter.desc_1": "下記の魔法の性能を変化させ、使用中のマナ消費量も減少させる。",
   "jei.apprenticecodex.protection_spell_supporter.desc_2": "- フォースフィールド：盾で防げない攻撃も防げるようになる。",
   "jei.apprenticecodex.protection_spell_supporter.desc_3": "- ファランクスチャージ：盾を構えた時の移動速度が上昇し、前方からのカウンタースペルを無力化できる。",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -339,6 +339,7 @@
   "jei.apprenticecodex.craftsmans_delight.desc_10": "- 触控挖掘：范围翻倍",
   "jei.apprenticecodex.craftsmans_delight.desc_11": "- 天堂铁拳：采掘附近从芽生方块上长出的最大结晶",
   "jei.apprenticecodex.craftsmans_delight.desc_12": "- 魔力修复：修复完成时重置该物品的累计铁砧作业次数",
+  "jei.apprenticecodex.craftsmans_delight.desc_13": "- 恩泽之雨：成长加速也会作用于生物，并促使其更快再次繁殖",
   "jei.apprenticecodex.protection_spell_supporter.desc_1": "修改以下法术，并在法术生效期间降低其法力值消耗：",
   "jei.apprenticecodex.protection_spell_supporter.desc_2": "- 力场：可抵挡盾牌无法防御的攻击",
   "jei.apprenticecodex.protection_spell_supporter.desc_3": "- 方阵冲锋：持盾格挡时提升移动速度，并可无效化来自前方的反制法术",


### PR DESCRIPTION
## 概要
- main 向け PR #663「恵みの雨の強化対応」を 1.21.1-main へ forward-port
- Craftsman's Delight 装備時の恵みの雨による生物の成長加速・繁殖クールダウン短縮を追加
- 1.21.1 / NeoForge 向けに `ModConfigSpec`、`FakePlayer`、entity registry 参照を調整

## 確認
- `./gradlew.bat compileJava`
- `./gradlew.bat runData`
- `git diff --name-status -- src/generated/resources` 差分なし
- `./gradlew.bat runGameTestServer`（728 tests passed）
- `./gradlew.bat build`
- ローカル `runClient` 確認済み