### PR TITLE
[codex] PR #672 指摘修正の1.20.1 backport

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
@@ -7,6 +7,7 @@ import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.capabilities.magic.MagicManager;
+import io.redspace.ironsspellbooks.capabilities.magic.RecastInstance;
 import io.redspace.ironsspellbooks.capabilities.magic.RecastResult;
 import io.redspace.ironsspellbooks.gui.overlays.SpellSelection;
 import io.redspace.ironsspellbooks.item.SpellSlotUpgradeItem;
@@ -557,6 +558,50 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
                     grimoire,
                     SpellRegistry.BOUND_BOW.get()
             ).isEmpty(), "Mithril Freecast Staff should clear retained pending cooldown source without relying on current casting item");
+            var timeoutPlayer = createEquipmentTestPlayer(helper, new BlockPos(2, 2, 0),
+                    "mithril_freecast_recast_timeout_cleanup_test");
+            var timeoutMagicData = MagicData.getPlayerMagicData(timeoutPlayer);
+            helper.assertTrue(timeoutMagicData != null,
+                    "Mithril Freecast Staff timeout cleanup test could not resolve player magic data");
+            var timeoutStaff = new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get());
+            equipNecklaceCurio(timeoutPlayer, new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.GREATER_CONJURERS_TALISMAN.get()));
+            MithrilFreecastStaffCastContext.retainUntilCooldown(
+                    timeoutPlayer.getUUID(),
+                    timeoutStaff,
+                    SpellRegistry.BOUND_BOW.get(),
+                    CastSource.SPELLBOOK
+            );
+            var timeoutBoundBowRecast = new RecastInstance(
+                    SpellRegistry.BOUND_BOW.get().getSpellId(),
+                    1,
+                    2,
+                    20,
+                    CastSource.SWORD,
+                    null
+            );
+            timeoutMagicData.getPlayerRecasts().forceAddRecast(timeoutBoundBowRecast);
+            timeoutMagicData.getPlayerRecasts().removeRecast(timeoutBoundBowRecast, RecastResult.TIMEOUT);
+            helper.assertFalse(timeoutMagicData.getPlayerCooldowns().isOnCooldown(SpellRegistry.BOUND_BOW.get()),
+                    "Mithril Freecast Staff timeout cleanup test should exercise a cooldown-suppressed timeout path");
+            var swordBoundBowCooldown = MagicManager.getEffectiveSpellCooldown(SpellRegistry.BOUND_BOW.get(), timeoutPlayer, CastSource.SWORD);
+            var timeoutExpectedBoundBowCooldown = staffItem.resolveSwingTriggeredCooldownTicks(
+                    timeoutPlayer,
+                    SpellRegistry.BOUND_BOW.get(),
+                    CastSource.SPELLBOOK
+            );
+            helper.assertTrue(timeoutExpectedBoundBowCooldown != swordBoundBowCooldown,
+                    "Mithril Freecast Staff timeout cleanup test needs SPELLBOOK and SWORD cooldowns to differ");
+            timeoutMagicData.setPlayerCastingItem(new ItemStack(Items.STICK));
+            var staleTimeoutCooldownEvent = new SpellCooldownAddedEvent.Pre(
+                    swordBoundBowCooldown,
+                    SpellRegistry.BOUND_BOW.get(),
+                    timeoutPlayer,
+                    CastSource.SWORD
+            );
+            MinecraftForge.EVENT_BUS.post(staleTimeoutCooldownEvent);
+            helper.assertTrue(staleTimeoutCooldownEvent.getEffectiveCooldown() == swordBoundBowCooldown,
+                    "Mithril Freecast Staff should clear retained source after recast timeout but got "
+                            + staleTimeoutCooldownEvent.getEffectiveCooldown() + " / expected " + swordBoundBowCooldown);
 
             var spellbookMagicMissileCooldown = WeaponImbueCooldownHelper.getEffectiveSpellCooldown(
                     magicMissile,

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/PlayerRecastsMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/PlayerRecastsMixin.java
@@ -1,8 +1,11 @@
 package jp.aquafactory.apprenticecodex.mixin;
 
+import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
 import io.redspace.ironsspellbooks.capabilities.magic.PlayerRecasts;
 import io.redspace.ironsspellbooks.capabilities.magic.RecastInstance;
+import io.redspace.ironsspellbooks.capabilities.magic.RecastResult;
 import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbowCastManager;
+import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaffCastContext;
 import net.minecraft.server.level.ServerPlayer;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
@@ -46,6 +49,26 @@ public abstract class PlayerRecastsMixin {
             var preservedTicks = Math.min(Integer.MAX_VALUE, (long) recastInstance.getTicksRemaining() + actualTicks);
             ((RecastInstanceAccessor) recastInstance).apprenticecodex$setRemainingTicks((int) preservedTicks);
         });
+    }
+
+    @Inject(
+            method = "removeRecast(Lio/redspace/ironsspellbooks/capabilities/magic/RecastInstance;Lio/redspace/ironsspellbooks/capabilities/magic/RecastResult;Z)V",
+            at = @At("RETURN")
+    )
+    private void apprenticecodex$clearMithrilFreecastCooldownSource(
+            RecastInstance recastInstance,
+            RecastResult recastResult,
+            boolean doSync,
+            CallbackInfo ci
+    ) {
+        if (serverPlayer == null) {
+            return;
+        }
+
+        MithrilFreecastStaffCastContext.clearPendingCooldownSource(
+                serverPlayer.getUUID(),
+                SpellRegistry.getSpell(recastInstance.getSpellId())
+        );
     }
 
 }


### PR DESCRIPTION
## 概要
- PR #672 の Codex Review 指摘で判明した Mithril Freecast Staff の pending cooldown source 残留修正を 1.20.1 に backport
- `PlayerRecasts#removeRecast` 後に、該当プレイヤー/魔法の Mithril Freecast Staff 用 cooldown source を破棄
- Recast timeout 後に古い selected source が通常詠唱の cooldown へ漏れないことを GameTest に追加

## Backport
- cherry-picked from `729aa6768139eded98065d86e590802453c205bb`
- 1.20.1 Forge 側に合わせて GameTest のイベント投稿は `MinecraftForge.EVENT_BUS` を使用

## 確認
- `./gradlew.bat build`
- `./gradlew.bat runGameTestServer`（719 required tests passed）