### PR TITLE
PR #674 の1.21.1対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -146,6 +146,7 @@ import jp.aquafactory.apprenticecodex.spell.demicreatorwings.DemicreatorWings;
 import jp.aquafactory.apprenticecodex.spell.demicreatorwings.DemicreatorWingsManager;
 import jp.aquafactory.apprenticecodex.spell.divinepossession.DivinePossessionPowerHelper;
 import jp.aquafactory.apprenticecodex.spell.archermultiple.ArcherMultipleBowEntity;
+import jp.aquafactory.apprenticecodex.spell.arcanebeam.ArcaneBeamEntity;
 import jp.aquafactory.apprenticecodex.spell.assistwings.AssistWingsWingEntity;
 import jp.aquafactory.apprenticecodex.spell.automagnet.AutoMagnetCollectionMode;
 import jp.aquafactory.apprenticecodex.spell.automagnet.AutoMagnetFamiliarEntity;
@@ -179,6 +180,7 @@ import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShieldProjectileE
 import jp.aquafactory.apprenticecodex.spell.mysticshield.MysticShieldShieldEntity;
 import jp.aquafactory.apprenticecodex.spell.personalshelf.PersonalShelf;
 import jp.aquafactory.apprenticecodex.spell.personalshelf.PersonalShelfChestBlockEntity;
+import jp.aquafactory.apprenticecodex.spell.phalanxcharge.PhalanxChargeBeamEntity;
 import jp.aquafactory.apprenticecodex.spell.phalanxcharge.PhalanxCounterSpellEvent;
 import jp.aquafactory.apprenticecodex.spell.precisionjack.PrecisionJackKnifeEntity;
 import jp.aquafactory.apprenticecodex.spell.senseevil.SenseEvil;
@@ -8730,6 +8732,27 @@ public class ApprenticeCodexGameTestScenarios {
     static void assertHealthUnchanged(GameTestHelper helper, net.minecraft.world.entity.LivingEntity target, float expectedHealth, String message) {
         helper.assertTrue(Math.abs(target.getHealth() - expectedHealth) < 0.001F,
                 message + ": expected=" + expectedHealth + ", actual=" + target.getHealth());
+    }
+
+    static void beamLengthIgnoresNoCollisionGrass(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            helper.setBlock(new BlockPos(2, 3, 1), Blocks.SHORT_GRASS);
+            helper.setBlock(new BlockPos(4, 3, 1), Blocks.STONE);
+
+            var start = helper.absoluteVec(new Vec3(0.5D, 3.5D, 1.5D));
+            var arcaneBeam = new ArcaneBeamEntity(EntityRegistry.ARCANE_BEAM.get(), level);
+            arcaneBeam.moveTo(start.x, start.y, start.z, -90.0F, 0.0F);
+            arcaneBeam.updateLength(8.0F, level);
+            helper.assertTrue(Math.abs(arcaneBeam.getLength() - 3.5D) < 0.01D,
+                    "Arcane Beam should ignore grass collision and stop at stone: " + arcaneBeam.getLength());
+
+            var phalanxBeam = new PhalanxChargeBeamEntity(EntityRegistry.PHALANX_CHARGE_BEAM.get(), level);
+            phalanxBeam.moveTo(start.x, start.y, start.z, -90.0F, 0.0F);
+            phalanxBeam.setup(level, 8.0F, 0.15F, 1.0F);
+            helper.assertTrue(Math.abs(phalanxBeam.getLength() - 3.5D) < 0.01D,
+                    "Phalanx Charge beam should ignore grass collision and stop at stone: " + phalanxBeam.getLength());
+        });
     }
 
     static void spawnCounterspellTestEntity(GameTestHelper helper, net.minecraft.world.entity.Entity entity, Vec3 localPos) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -40,6 +40,7 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     private static final String HEAVENLY_FIST_CREATE_COMPACTING_DENYLIST_BATCH =
             "apprenticecodex.heavenly_fist_create_compacting_denylist";
     private static final String GRIND_RUNNER_ISOLATED_BATCH = "apprenticecodex.grind_runner_isolated";
+    private static final String BEAM_OCCLUSION_ISOLATED_BATCH = "apprenticecodex.beam_occlusion_isolated";
     private static final String SUMMON_WEAPON_ANIMATION_BATCH = "apprenticecodex.summon_weapon_animation";
 
     private ApprenticeCodexSpellBehaviorGameTests() {
@@ -738,6 +739,11 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     @GameTest(template = TEMPLATE, batch = HEAVENLY_FIST_ISOLATED_BATCH, timeoutTicks = 40)
     public static void gravityBoundPullsAirborneTargetsDown(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.gravityBoundPullsAirborneTargetsDown(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = BEAM_OCCLUSION_ISOLATED_BATCH)
+    public static void beamLengthIgnoresNoCollisionGrass(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.beamLengthIgnoresNoCollisionGrass(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = MIST_FORM_ISOLATED_BATCH)

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/arcanebeam/ArcaneBeamEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/arcanebeam/ArcaneBeamEntity.java
@@ -146,7 +146,7 @@ public class ArcaneBeamEntity extends Entity implements TraceableEntity {
         var blockHit = level.clip(new ClipContext(
                 position(),
                 position().add(getLookAngle().scale(maxLength)),
-                ClipContext.Block.OUTLINE,
+                ClipContext.Block.COLLIDER,
                 ClipContext.Fluid.NONE,
                 this
         ));

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxChargeBeamEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/phalanxcharge/PhalanxChargeBeamEntity.java
@@ -111,7 +111,7 @@ public class PhalanxChargeBeamEntity extends Entity implements TraceableEntity {
         var blockHit = level.clip(new ClipContext(
                 position(),
                 position().add(getLookAngle().scale(maxLength)),
-                ClipContext.Block.OUTLINE,
+                ClipContext.Block.COLLIDER,
                 ClipContext.Fluid.NONE,
                 this
         ));


### PR DESCRIPTION
## 概要
- PR #674 の `main` 向け修正を `1.21.1-main` に forward-port しました。
- Arcane Beam / Phalanx Charge Beam の長さ計算を collision なしブロックで止まらないようにし、草を無視して石で止まる GameTest を追加しました。
- 1.21.1 側 API に合わせて GameTest は `Blocks.SHORT_GRASS` と既存の `helper.assertTrue` 形式へ調整しています。

## 検証
- `./gradlew.bat runGameTestServer` 成功（730 required tests passed）
- `./gradlew.bat build` 成功
- `src/generated/resources` 差分なし

## 移植元
- #674
- `ff4d0b49be8ebf8ee40814155a45f95b79c94fef`