### PR TITLE
PR #698 forward-port対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/block/arcanuminajar/ArcanumInAJarBlockEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/arcanuminajar/ArcanumInAJarBlockEntity.java
@@ -5,6 +5,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.registry.BlockEntityRegistry;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import jp.aquafactory.apprenticecodex.utility.AudioTools;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -143,6 +144,7 @@ public class ArcanumInAJarBlockEntity extends BlockEntity {
         super.onLoad();
         if (level != null && !level.isClientSide) {
             migrateLegacyState(level.getGameTime());
+            sanitizePersistentGameTimes(level.getGameTime());
             if (shouldProcess() && progressStartGameTime < 0L) {
                 progressStartGameTime = level.getGameTime();
             }
@@ -198,6 +200,7 @@ public class ArcanumInAJarBlockEntity extends BlockEntity {
         }
 
         blockEntity.migrateLegacyState(serverLevel.getGameTime());
+        blockEntity.sanitizePersistentGameTimes(serverLevel.getGameTime());
         blockEntity.updateProduction(serverLevel.getGameTime());
 
         if (!blockEntity.dispensing) {
@@ -262,6 +265,35 @@ public class ArcanumInAJarBlockEntity extends BlockEntity {
         AudioTools.playSoundFromPosition(level, worldPosition.getCenter(), SoundRegistry.VANILLA_JAR_CLOSE.get(), SoundSource.BLOCKS);
         setChanged();
         syncToClient();
+    }
+
+    private void sanitizePersistentGameTimes(long gameTime) {
+        var changed = false;
+        if (progressStartGameTime >= 0L) {
+            var sanitizedProgressStartGameTime = PersistentGameTimeSanitizer.clampFutureStart(gameTime, progressStartGameTime);
+            if (sanitizedProgressStartGameTime != progressStartGameTime) {
+                progressStartGameTime = sanitizedProgressStartGameTime;
+                changed = true;
+            }
+        }
+
+        if (nextReleaseGameTime >= 0L) {
+            var releaseDelayTicks = Math.max(INITIAL_RELEASE_DELAY_TICKS, REPEAT_RELEASE_DELAY_TICKS);
+            var sanitizedNextReleaseGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                    gameTime,
+                    nextReleaseGameTime,
+                    releaseDelayTicks
+            );
+            if (sanitizedNextReleaseGameTime != nextReleaseGameTime) {
+                nextReleaseGameTime = sanitizedNextReleaseGameTime;
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            setChanged();
+            syncToClient();
+        }
     }
 
     private boolean spawnArcaneEssence(ServerLevel serverLevel, int count) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/atelierstation/AtelierStationBlockEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/atelierstation/AtelierStationBlockEntity.java
@@ -7,6 +7,7 @@ import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.AtelierStationFluidEffectPacket;
 import jp.aquafactory.apprenticecodex.registry.BlockEntityRegistry;
 import jp.aquafactory.apprenticecodex.utility.AlchemistCauldronFluidTools;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
@@ -214,6 +215,7 @@ public final class AtelierStationBlockEntity extends BlockEntity implements Menu
         }
 
         var changed = false;
+        changed |= blockEntity.sanitizeFlaskSupplyCooldown(serverLevel.getGameTime());
         if (blockEntity.shouldRunCollectionTick(serverLevel)
                 && blockEntity.hasAnyFilterConfigured()
                 && blockEntity.storedFluidAmount < MAX_STORED_FLUID_AMOUNT) {
@@ -545,6 +547,20 @@ public final class AtelierStationBlockEntity extends BlockEntity implements Menu
 
     private boolean isFlaskSupplyCoolingDown(long gameTime) {
         return gameTime < flaskSupplyCooldownUntilGameTime;
+    }
+
+    private boolean sanitizeFlaskSupplyCooldown(long gameTime) {
+        var sanitizedCooldownUntil = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                gameTime,
+                flaskSupplyCooldownUntilGameTime,
+                FLASK_SUPPLY_COOLDOWN_TICKS
+        );
+        if (sanitizedCooldownUntil == flaskSupplyCooldownUntilGameTime) {
+            return false;
+        }
+
+        flaskSupplyCooldownUntilGameTime = sanitizedCooldownUntil;
+        return true;
     }
 
     // 搬入直後は中身キューブの表示時間を優先し、全てのフラスコ供給を 20tick 停止する。

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/essencesmoker/EssenceSmokerBlockEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/essencesmoker/EssenceSmokerBlockEntity.java
@@ -4,6 +4,7 @@ import jp.aquafactory.apprenticecodex.recipe.essencesmoker.EssenceSmokerRecipe;
 import jp.aquafactory.apprenticecodex.registry.BlockEntityRegistry;
 import jp.aquafactory.apprenticecodex.registry.RecipeRegistry;
 import jp.aquafactory.apprenticecodex.utility.AudioTools;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import jp.aquafactory.apprenticecodex.utility.ProcessingRecipeDenylist;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -114,6 +115,9 @@ public class EssenceSmokerBlockEntity extends BlockEntity implements WorldlyCont
             return 0L;
         }
 
+        if (!level.isClientSide) {
+            sanitizeProcessFinishGameTime(level.getGameTime());
+        }
         return Math.max(0L, processFinishGameTime - level.getGameTime());
     }
 
@@ -508,6 +512,7 @@ public class EssenceSmokerBlockEntity extends BlockEntity implements WorldlyCont
             return;
         }
 
+        blockEntity.sanitizeProcessFinishGameTime(serverLevel.getGameTime());
         if (serverLevel.getGameTime() < blockEntity.processFinishGameTime) {
             return;
         }
@@ -528,6 +533,22 @@ public class EssenceSmokerBlockEntity extends BlockEntity implements WorldlyCont
         setCatalystInternal(ItemStack.EMPTY);
         playCompletionSound();
         markUpdated();
+    }
+
+    private void sanitizeProcessFinishGameTime(long gameTime) {
+        if (!processing || processFinishGameTime < 0L) {
+            return;
+        }
+
+        var sanitizedFinishGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                gameTime,
+                processFinishGameTime,
+                PROCESS_DURATION_TICKS
+        );
+        if (sanitizedFinishGameTime != processFinishGameTime) {
+            processFinishGameTime = sanitizedFinishGameTime;
+            markUpdated();
+        }
     }
 
     private void transformMaterialsToResults() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/capability/codexspelldata/spellstates/RemoteEyeState.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/capability/codexspelldata/spellstates/RemoteEyeState.java
@@ -5,6 +5,7 @@ import net.minecraft.nbt.CompoundTag;
 
 public class RemoteEyeState implements ICodexSpellState {
     public long activeUntilGameTime;
+    public long activeDurationTicks;
     public double anchorX;
     public double anchorY;
     public double anchorZ;
@@ -13,6 +14,7 @@ public class RemoteEyeState implements ICodexSpellState {
 
     public void reset() {
         activeUntilGameTime = 0L;
+        activeDurationTicks = 0L;
         anchorX = 0.0;
         anchorY = 0.0;
         anchorZ = 0.0;
@@ -24,6 +26,7 @@ public class RemoteEyeState implements ICodexSpellState {
     public CompoundTag save() {
         var tag = new CompoundTag();
         tag.putLong("activeUntilGameTime", activeUntilGameTime);
+        tag.putLong("activeDurationTicks", activeDurationTicks);
         tag.putDouble("anchorX", anchorX);
         tag.putDouble("anchorY", anchorY);
         tag.putDouble("anchorZ", anchorZ);
@@ -35,6 +38,7 @@ public class RemoteEyeState implements ICodexSpellState {
     @Override
     public void load(CompoundTag tag) {
         activeUntilGameTime = tag.getLong("activeUntilGameTime");
+        activeDurationTicks = tag.getLong("activeDurationTicks");
         anchorX = tag.getDouble("anchorX");
         anchorY = tag.getDouble("anchorY");
         anchorZ = tag.getDouble("anchorZ");

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -20,6 +20,7 @@ public final class ApprenticeCodexServerConfig {
     }
 
     public static final ModConfigSpec SPEC;
+    private static final ModConfigSpec.IntValue SAVED_ABSOLUTE_TICK_CLAMP_MAX_TICKS;
     private static final DamageMultiplierServerConfig DAMAGE_MULTIPLIER_CONFIG;
     private static final BlocksServerConfig BLOCKS_CONFIG;
     private static final ItemsServerConfig ITEMS_CONFIG;
@@ -29,6 +30,11 @@ public final class ApprenticeCodexServerConfig {
     private static final ProcessingServerConfig PROCESSING_CONFIG;
     static {
         var builder = new ModConfigSpec.Builder();
+        builder.push("Compatibility");
+        SAVED_ABSOLUTE_TICK_CLAMP_MAX_TICKS = builder
+                .comment("Maximum ticks kept when repairing persisted absolute game-time values that are far in the future.")
+                .defineInRange("savedAbsoluteTickClampMaxTicks", 20 * 60 * 5, 0, Integer.MAX_VALUE);
+        builder.pop();
         DAMAGE_MULTIPLIER_CONFIG = DamageMultiplierServerConfig.define(builder, DamageMultiplierKey.values());
         BLOCKS_CONFIG = BlocksServerConfig.define(builder);
         ITEMS_CONFIG = ItemsServerConfig.define(builder);
@@ -40,6 +46,10 @@ public final class ApprenticeCodexServerConfig {
     }
 
     private ApprenticeCodexServerConfig() {
+    }
+
+    public static int savedAbsoluteTickClampMaxTicks() {
+        return SAVED_ABSOLUTE_TICK_CLAMP_MAX_TICKS.get();
     }
 
     public static float damageMultiplier(DamageMultiplierKey key) {
@@ -243,6 +253,20 @@ public final class ApprenticeCodexServerConfig {
 
     public static float absorptionAmplifyAmuletBaseAbsorptionTarget() {
         return ITEMS_CONFIG.absorptionAmplifyAmuletBaseAbsorptionTarget();
+    }
+
+    public static GameTestConfigOverride useAbsorptionAmplifyAmuletConfigOverrideForGameTest(
+            double baseAbsorptionTarget,
+            int recoveryDelayTicks
+    ) {
+        var previousBaseAbsorptionTarget = ITEMS_CONFIG.absorptionAmplifyAmuletBaseAbsorptionTarget();
+        var previousRecoveryDelayTicks = ITEMS_CONFIG.absorptionAmplifyAmuletRecoveryDelayTicks();
+
+        ITEMS_CONFIG.setAbsorptionAmplifyAmuletConfigForGameTest(baseAbsorptionTarget, recoveryDelayTicks);
+        return () -> ITEMS_CONFIG.setAbsorptionAmplifyAmuletConfigForGameTest(
+                previousBaseAbsorptionTarget,
+                previousRecoveryDelayTicks
+        );
     }
 
     public static float scarletThirstDrainHealth() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -194,6 +194,10 @@ final class ItemsServerConfig {
         return absorptionAmplifyAmuletConfig.baseAbsorptionTarget();
     }
 
+    void setAbsorptionAmplifyAmuletConfigForGameTest(double baseAbsorptionTarget, int recoveryDelayTicks) {
+        absorptionAmplifyAmuletConfig.setForGameTest(baseAbsorptionTarget, recoveryDelayTicks);
+    }
+
     float scarletThirstRequiredHealth() {
         return scarletThirstConfig.requiredHealth();
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/AbsorptionAmplifyAmuletServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/AbsorptionAmplifyAmuletServerConfig.java
@@ -5,6 +5,8 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 public final class AbsorptionAmplifyAmuletServerConfig {
     private final ModConfigSpec.DoubleValue baseAbsorptionTarget;
     private final ModConfigSpec.IntValue recoveryDelayTicks;
+    private Double baseAbsorptionTargetOverride;
+    private Integer recoveryDelayTicksOverride;
 
     private AbsorptionAmplifyAmuletServerConfig(
             ModConfigSpec.DoubleValue baseAbsorptionTarget,
@@ -27,10 +29,17 @@ public final class AbsorptionAmplifyAmuletServerConfig {
     }
 
     public float baseAbsorptionTarget() {
-        return baseAbsorptionTarget.get().floatValue();
+        return (baseAbsorptionTargetOverride == null
+                ? baseAbsorptionTarget.get()
+                : baseAbsorptionTargetOverride).floatValue();
     }
 
     public int recoveryDelayTicks() {
-        return recoveryDelayTicks.get();
+        return recoveryDelayTicksOverride == null ? recoveryDelayTicks.get() : recoveryDelayTicksOverride;
+    }
+
+    public void setForGameTest(double baseAbsorptionTarget, int recoveryDelayTicks) {
+        this.baseAbsorptionTargetOverride = baseAbsorptionTarget;
+        this.recoveryDelayTicksOverride = recoveryDelayTicks;
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -1830,6 +1830,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void multipurposeStaffrifleRateLimitIgnoresLegacyPersistentNbt(GameTestHelper helper) {
+        MultipurposeStaffrifleGameTestScenarios.multipurposeStaffrifleRateLimitIgnoresLegacyPersistentNbt(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void multipurposeStaffrifleUsesDedicatedAmmoAndCasingReturnPolicy(GameTestHelper helper) {
         MultipurposeStaffrifleGameTestScenarios.multipurposeStaffrifleUsesDedicatedAmmoAndCasingReturnPolicy(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -73,6 +73,8 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
             "apprenticecodex.mana_thruster_config";
     private static final String MAGI_COMPRESSOR_GADGET_CONFIG_BATCH =
             "apprenticecodex.magi_compressor_gadget_config";
+    private static final String ABSORPTION_AMPLIFY_AMULET_CONFIG_BATCH =
+            "apprenticecodex.absorption_amplify_amulet_config";
     private static final String JUMPCAST_CHARM_CONFIG_BATCH =
             "apprenticecodex.jumpcast_charm_config";
     private static final String SPELLCHARGED_GREATSWORD_CONFIG_BATCH =
@@ -544,6 +546,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     @GameTest(template = TEMPLATE)
     public static void magiCompressorGadgetRejectsEnchantments(GameTestHelper helper) {
         MagiCompressorGadgetGameTestScenarios.magiCompressorGadgetRejectsEnchantments(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = ABSORPTION_AMPLIFY_AMULET_CONFIG_BATCH)
+    public static void absorptionAmplifyAmuletZeroRecoveryDelayRepairsResumeToCurrentTick(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.absorptionAmplifyAmuletZeroRecoveryDelayRepairsResumeToCurrentTick(helper);
     }
 
     @GameTest(template = TEMPLATE)
@@ -2024,4 +2031,28 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
         SwingcastStaffGameTestScenarios.manaSlashCatalystDamageUsesApplicableSlotGroups(helper);
     }
 
+    @GameTest(template = TEMPLATE)
+    public static void autocastAmuletDeletesPersistedFutureRetryTick(GameTestHelper helper) {
+        AutocastAmuletGameTestScenarios.autocastAmuletDeletesPersistedFutureRetryTick(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void elementalBowClampsPersistedFutureOverheat(GameTestHelper helper) {
+        ElementalBowGameTestScenarios.elementalBowClampsPersistedFutureOverheat(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellchargedGreatswordClampsPersistedFutureOvercharge(GameTestHelper helper) {
+        EquipmentEnchantmentSurfaceGameTestScenarios.spellchargedGreatswordClampsPersistedFutureOvercharge(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void circuitHeatStaffClampsPersistedFutureItemOverheat(GameTestHelper helper) {
+        CircuitHeatStaffGameTestScenarios.circuitHeatStaffClampsPersistedFutureItemOverheat(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void circuitHeatStaffKeepsStoredLongItemOverheatDuration(GameTestHelper helper) {
+        CircuitHeatStaffGameTestScenarios.circuitHeatStaffKeepsStoredLongItemOverheatDuration(helper);
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -7823,6 +7823,7 @@ public class ApprenticeCodexGameTestScenarios {
         magicData.setSyncedData(new SyncedSpellData(player));
         magicData.setMana(1000.0f);
         magicData.getPlayerCooldowns().removeCooldown(spell.getSpellId());
+        magicData.getSyncedData();
         magicData.initiateCast(
                 spell,
                 spellLevel,

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -55,7 +55,6 @@ import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.Mira
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.RemoteEyeState;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.SearchBeaconState;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat;
-import jp.aquafactory.apprenticecodex.compat.malum.MalumHauntedCompat;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArchivistsGrimoireServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.SpellgunServerConfig;
@@ -6951,7 +6950,7 @@ public class ApprenticeCodexGameTestScenarios {
                 state.anchorPitch = player.getXRot();
             }));
 
-            RemoteEyeBodyControlEvent.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player));
+            RemoteEyeBodyControlEvent.onPlayerTick(new PlayerTickEvent.Post(player));
 
             var state = getRemoteEyeState(player);
             helper.assertTrue(state.activeUntilGameTime == activeUntilGameTime,
@@ -6976,7 +6975,7 @@ public class ApprenticeCodexGameTestScenarios {
                 state.anchorPitch = player.getXRot();
             }));
 
-            RemoteEyeBodyControlEvent.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player));
+            RemoteEyeBodyControlEvent.onPlayerTick(new PlayerTickEvent.Post(player));
 
             var state = getRemoteEyeState(player);
             helper.assertTrue(state.activeUntilGameTime == expectedActiveUntilGameTime,
@@ -10386,7 +10385,6 @@ public class ApprenticeCodexGameTestScenarios {
 
     static void tickEquippedAbsorptionAmplifyAmulet(FakePlayer player) {
         var slotResult = top.theillusivec4.curios.api.CuriosApi.getCuriosInventory(player)
-                .resolve()
                 .flatMap(inventory -> inventory.findFirstCurio(ItemRegistry.ABSORPTION_AMPLIFY_AMULET.get()))
                 .orElseThrow(() -> new IllegalStateException("Missing equipped Absorption Amplify Amulet for GameTest"));
         if (slotResult.stack().getItem() instanceof AbsorptionAmplifyAmulet amulet) {
@@ -10426,15 +10424,19 @@ public class ApprenticeCodexGameTestScenarios {
     }
 
     static RemoteEyeState getRemoteEyeState(Player player) {
-        return player.getCapability(Capabilities.SPELL_DATA)
-                .map(data -> data.get(CodexSpellStateTypeRegister.REMOTE_EYE_STATE))
-                .orElseThrow(() -> new IllegalStateException("Missing spell data for RemoteEye GameTest"));
+        var spellData = Capabilities.getSpellDataOrNull(player);
+        if (spellData == null) {
+            throw new IllegalStateException("Missing spell data for RemoteEye GameTest");
+        }
+        return spellData.get(CodexSpellStateTypeRegister.REMOTE_EYE_STATE);
     }
 
     static AbsorptionAmplifyAmuletState getAbsorptionAmplifyAmuletState(Player player) {
-        return player.getCapability(Capabilities.SPELL_DATA)
-                .map(data -> data.get(CodexSpellStateTypeRegister.ABSORPTION_AMPLIFY_AMULET_STATE))
-                .orElseThrow(() -> new IllegalStateException("Missing spell data for Absorption Amplify Amulet GameTest"));
+        var spellData = Capabilities.getSpellDataOrNull(player);
+        if (spellData == null) {
+            throw new IllegalStateException("Missing spell data for Absorption Amplify Amulet GameTest");
+        }
+        return spellData.get(CodexSpellStateTypeRegister.ABSORPTION_AMPLIFY_AMULET_STATE);
     }
 
     static void invokeTouchDigDestroyBlock(TouchDigSpell spell, Level level, BlockPos pos, Player player) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -49,8 +49,13 @@ import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserVariant
 import jp.aquafactory.apprenticecodex.block.spellcasterworkbench.SpellcasterWorkbenchMenu;
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
+import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.AbsorptionAmplifyAmuletState;
+import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.ManaShieldCharmState;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.MirageAvoidanceState;
+import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.RemoteEyeState;
+import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.SearchBeaconState;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat;
+import jp.aquafactory.apprenticecodex.compat.malum.MalumHauntedCompat;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArchivistsGrimoireServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.SpellgunServerConfig;
@@ -85,6 +90,16 @@ import jp.aquafactory.apprenticecodex.item.CircuitHeatStaff;
 import jp.aquafactory.apprenticecodex.item.CircuitHeatStaffCastEvent;
 import jp.aquafactory.apprenticecodex.item.CircuitHeatStaffRightClickItemEvent;
 import jp.aquafactory.apprenticecodex.item.CrystalBladedStaff;
+import jp.aquafactory.apprenticecodex.item.curios.archivistsgrimoire.ArchivistsGrimoire;
+import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmulet;
+import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmuletAutoCastEvent;
+import jp.aquafactory.apprenticecodex.item.curios.absorptionamplifyamulet.AbsorptionAmplifyAmulet;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelight;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightCooldownReductionEvent;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightManaCostDiscountEvent;
+import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightSpellSupport;
+import jp.aquafactory.apprenticecodex.item.curios.CuriosSlotConstants;
+import jp.aquafactory.apprenticecodex.item.curios.spellstainedrunictablet.SpellStainedRunicTablet;
 import jp.aquafactory.apprenticecodex.item.ElementalBow;
 import jp.aquafactory.apprenticecodex.item.FocusStaffbow;
 import jp.aquafactory.apprenticecodex.item.ammo.BowCastAmmoResolver;
@@ -185,6 +200,8 @@ import jp.aquafactory.apprenticecodex.spell.personalshelf.PersonalShelfChestBloc
 import jp.aquafactory.apprenticecodex.spell.phalanxcharge.PhalanxChargeBeamEntity;
 import jp.aquafactory.apprenticecodex.spell.phalanxcharge.PhalanxCounterSpellEvent;
 import jp.aquafactory.apprenticecodex.spell.precisionjack.PrecisionJackKnifeEntity;
+import jp.aquafactory.apprenticecodex.spell.remoteeye.RemoteEye;
+import jp.aquafactory.apprenticecodex.spell.remoteeye.RemoteEyeBodyControlEvent;
 import jp.aquafactory.apprenticecodex.spell.senseevil.SenseEvil;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconSearchService;
 import jp.aquafactory.apprenticecodex.spell.searchbeacon.SearchBeaconTargetList;
@@ -6917,6 +6934,90 @@ public class ApprenticeCodexGameTestScenarios {
         helper.succeed();
     }
 
+    static void remoteEyeSanitizerKeepsStoredLongDuration(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var player = createTrackedEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "remote_eye_long_duration_repair_test");
+            var activeUntilGameTime = level.getGameTime() + 1200L;
+
+            Capabilities.withSpellData(player, data -> data.edit(CodexSpellStateTypeRegister.REMOTE_EYE_STATE, state -> {
+                state.activeUntilGameTime = activeUntilGameTime;
+                state.activeDurationTicks = 1200L;
+                state.anchorX = player.getX();
+                state.anchorY = player.getY();
+                state.anchorZ = player.getZ();
+                state.anchorYaw = player.getYRot();
+                state.anchorPitch = player.getXRot();
+            }));
+
+            RemoteEyeBodyControlEvent.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player));
+
+            var state = getRemoteEyeState(player);
+            helper.assertTrue(state.activeUntilGameTime == activeUntilGameTime,
+                    "RemoteEye sanitizer should not clamp active state below the stored cast duration");
+        });
+    }
+
+    static void remoteEyeSanitizerUsesLegacyFallbackWhenDurationMissing(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var player = createTrackedEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "remote_eye_legacy_duration_repair_test");
+            var expectedActiveUntilGameTime = level.getGameTime() + RemoteEye.PERSISTED_STATE_REPAIR_MAX_ACTIVE_TICKS;
+
+            Capabilities.withSpellData(player, data -> data.edit(CodexSpellStateTypeRegister.REMOTE_EYE_STATE, state -> {
+                state.activeUntilGameTime = expectedActiveUntilGameTime + 1200L;
+                state.activeDurationTicks = 0L;
+                state.anchorX = player.getX();
+                state.anchorY = player.getY();
+                state.anchorZ = player.getZ();
+                state.anchorYaw = player.getYRot();
+                state.anchorPitch = player.getXRot();
+            }));
+
+            RemoteEyeBodyControlEvent.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player));
+
+            var state = getRemoteEyeState(player);
+            helper.assertTrue(state.activeUntilGameTime == expectedActiveUntilGameTime,
+                    "RemoteEye legacy state should still use the 30 second persisted repair fallback");
+        });
+    }
+
+    static void absorptionAmplifyAmuletZeroRecoveryDelayRepairsResumeToCurrentTick(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var player = createTrackedEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "absorption_zero_delay_repair_test");
+
+            try (var ignored = ApprenticeCodexServerConfig.useAbsorptionAmplifyAmuletConfigOverrideForGameTest(8.0D, 0)) {
+                equipNecklaceCurio(player, new ItemStack(ItemRegistry.ABSORPTION_AMPLIFY_AMULET.get()));
+                player.setAbsorptionAmount(0.0F);
+
+                Capabilities.withSpellData(player, data -> data.edit(
+                        CodexSpellStateTypeRegister.ABSORPTION_AMPLIFY_AMULET_STATE,
+                        state -> {
+                            state.initialized = true;
+                            state.recoveryResumeGameTime = level.getGameTime()
+                                    + ApprenticeCodexServerConfig.savedAbsoluteTickClampMaxTicks()
+                                    + 1200L;
+                            state.nextRecoveryGameTime = level.getGameTime();
+                            state.nextProcGameTime = level.getGameTime();
+                            state.lastKnownAbsorption = 0.0F;
+                        }
+                ));
+
+                tickEquippedAbsorptionAmplifyAmulet(player);
+
+                var state = getAbsorptionAmplifyAmuletState(player);
+                helper.assertTrue(state.recoveryResumeGameTime == level.getGameTime(),
+                        "AbsorptionAmplifyAmulet zero recovery delay should repair resume time to the current tick");
+                helper.assertTrue(player.getAbsorptionAmount() == 1.0F,
+                        "AbsorptionAmplifyAmulet should recover immediately after zero-delay repair");
+            }
+        });
+    }
+
     static void mirageAvoidanceUsesFifteenTickInvulnerabilityAndActiveRecastLock(GameTestHelper helper) {
         var level = helper.getLevel();
         var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "mirage_avoidance_window_test");
@@ -10283,6 +10384,16 @@ public class ApprenticeCodexGameTestScenarios {
         equipCurio(player, io.redspace.ironsspellbooks.compat.Curios.NECKLACE_SLOT, necklaceStack);
     }
 
+    static void tickEquippedAbsorptionAmplifyAmulet(FakePlayer player) {
+        var slotResult = top.theillusivec4.curios.api.CuriosApi.getCuriosInventory(player)
+                .resolve()
+                .flatMap(inventory -> inventory.findFirstCurio(ItemRegistry.ABSORPTION_AMPLIFY_AMULET.get()))
+                .orElseThrow(() -> new IllegalStateException("Missing equipped Absorption Amplify Amulet for GameTest"));
+        if (slotResult.stack().getItem() instanceof AbsorptionAmplifyAmulet amulet) {
+            amulet.curioTick(slotResult.slotContext(), slotResult.stack());
+        }
+    }
+
     static FakePlayer createTrackedEquipmentTestPlayer(GameTestHelper helper, BlockPos pos, String profileName) {
         var player = createEquipmentTestPlayer(helper, pos, profileName);
         helper.getLevel().addFreshEntity(player);
@@ -10312,6 +10423,18 @@ public class ApprenticeCodexGameTestScenarios {
             throw new IllegalStateException("Missing spell data for MirageAvoidance GameTest");
         }
         return spellData.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE);
+    }
+
+    static RemoteEyeState getRemoteEyeState(Player player) {
+        return player.getCapability(Capabilities.SPELL_DATA)
+                .map(data -> data.get(CodexSpellStateTypeRegister.REMOTE_EYE_STATE))
+                .orElseThrow(() -> new IllegalStateException("Missing spell data for RemoteEye GameTest"));
+    }
+
+    static AbsorptionAmplifyAmuletState getAbsorptionAmplifyAmuletState(Player player) {
+        return player.getCapability(Capabilities.SPELL_DATA)
+                .map(data -> data.get(CodexSpellStateTypeRegister.ABSORPTION_AMPLIFY_AMULET_STATE))
+                .orElseThrow(() -> new IllegalStateException("Missing spell data for Absorption Amplify Amulet GameTest"));
     }
 
     static void invokeTouchDigDestroyBlock(TouchDigSpell spell, Level level, BlockPos pos, Player player) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -264,6 +264,16 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
         ApprenticeCodexGameTestScenarios.remoteEyeDimensionDenylistOverridesAllowlist(helper);
     }
 
+    @GameTest(template = TEMPLATE, batch = REMOTE_EYE_ISOLATED_BATCH)
+    public static void remoteEyeSanitizerKeepsStoredLongDuration(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.remoteEyeSanitizerKeepsStoredLongDuration(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = REMOTE_EYE_ISOLATED_BATCH)
+    public static void remoteEyeSanitizerUsesLegacyFallbackWhenDurationMissing(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.remoteEyeSanitizerUsesLegacyFallbackWhenDurationMissing(helper);
+    }
+
     @GameTest(template = TEMPLATE, batch = MIRAGE_AVOIDANCE_ISOLATED_BATCH)
     public static void mirageAvoidanceUsesFifteenTickInvulnerabilityAndActiveRecastLock(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.mirageAvoidanceUsesFifteenTickInvulnerabilityAndActiveRecastLock(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/AutocastAmuletGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/AutocastAmuletGameTestScenarios.java
@@ -404,6 +404,23 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
         });
     }
 
+    static void autocastAmuletDeletesPersistedFutureRetryTick(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var stack = ((AutocastAmulet) ItemRegistry.AUTOCAST_AMULET.get()).getDefaultInstance();
+            CustomData.update(DataComponents.CUSTOM_DATA, stack, tag -> {
+                tag.putLong("apprenticecodex:autocast_retry_sequence_tick", 72000L);
+                tag.putInt("apprenticecodex:autocast_retry_skip_slot", 2);
+            });
+
+            helper.assertFalse(AutocastAmulet.isRetrySequenceCoolingDown(stack, 0L),
+                    "Autocast Amulet should delete impossible future retry sequence ticks");
+            helper.assertTrue(AutocastAmulet.getRetrySequenceTick(stack) == -1L,
+                    "Autocast Amulet retry sequence tick should be removed after sanitizing");
+            helper.assertTrue(AutocastAmulet.getRetrySkipSlot(stack) == -1,
+                    "Autocast Amulet retry skip slot should be removed together with the retry tick");
+        });
+    }
+
     static void autocastAmuletWisdomShardIsAdjustmentOnlyProfileGate(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/CircuitHeatStaffGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/CircuitHeatStaffGameTestScenarios.java
@@ -428,6 +428,46 @@ final class CircuitHeatStaffGameTestScenarios extends ApprenticeCodexGameTestSce
         });
     }
 
+    static void circuitHeatStaffClampsPersistedFutureItemOverheat(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var stack = new ItemStack(ItemRegistry.CIRCUIT_HEAT_STAFF.get());
+            CustomData.update(DataComponents.CUSTOM_DATA, stack, tag -> tag.putLong(
+                    "CircuitHeatStaffOverheatExpireGameTime",
+                    level.getGameTime() + 72000L
+            ));
+
+            var remainingTicks = CircuitHeatStaff.getStaffOverheatRemainingTicks(stack, level);
+            var tag = stack.get(DataComponents.CUSTOM_DATA).copyTag();
+
+            helper.assertTrue(remainingTicks <= ApprenticeCodexServerConfig.savedAbsoluteTickClampMaxTicks(),
+                    "Circuit Heat Staff future item overheat should be clamped to the repair limit");
+            helper.assertTrue(tag.getLong("CircuitHeatStaffOverheatExpireGameTime")
+                            <= level.getGameTime() + ApprenticeCodexServerConfig.savedAbsoluteTickClampMaxTicks(),
+                    "Circuit Heat Staff item NBT should be rewritten after clamping");
+        });
+    }
+
+    static void circuitHeatStaffKeepsStoredLongItemOverheatDuration(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var level = helper.getLevel();
+            var stack = new ItemStack(ItemRegistry.CIRCUIT_HEAT_STAFF.get());
+            var longOverheatTicks = (int) Math.min(
+                    (long) ApprenticeCodexServerConfig.savedAbsoluteTickClampMaxTicks() + 1200L,
+                    Integer.MAX_VALUE
+            );
+
+            CircuitHeatStaff.startStaffOverheat(stack, level, longOverheatTicks);
+            var remainingTicks = CircuitHeatStaff.getStaffOverheatRemainingTicks(stack, level);
+
+            helper.assertTrue(remainingTicks == longOverheatTicks,
+                    "Circuit Heat Staff item overheat should keep stored long duration: " + remainingTicks);
+            var tag = stack.get(DataComponents.CUSTOM_DATA).copyTag();
+            helper.assertTrue(tag.getInt("CircuitHeatStaffOverheatDurationTicks") == longOverheatTicks,
+                    "Circuit Heat Staff item overheat should store the applied duration");
+        });
+    }
+
     static void circuitHeatStaffAdditionalManaScalesWithSkippedCooldown(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var baseManaCost = 100;

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ElementalBowGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ElementalBowGameTestScenarios.java
@@ -573,6 +573,34 @@ final class ElementalBowGameTestScenarios {
 
         helper.runAtTickTime(43, helper::succeed);
     }
+
+    static void elementalBowClampsPersistedFutureOverheat(GameTestHelper helper) {
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "elemental_bow_future_overheat_test");
+
+        helper.runAtTickTime(1, () -> {
+            jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBowOverheatManager.applyOverheatAfterCast(
+                    player,
+                    SchoolRegistry.FIRE_RESOURCE,
+                    40
+            );
+            var schoolTag = player.getPersistentData()
+                    .getCompound("ApprenticeCodexElementalBowOverheat")
+                    .getCompound(SchoolRegistry.FIRE_RESOURCE.toString());
+            schoolTag.putLong("ExpireGameTime", player.level().getGameTime() + 72000L);
+
+            var state = jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBowOverheatManager.getState(
+                    player,
+                    SchoolRegistry.FIRE_RESOURCE
+            );
+
+            helper.assertTrue(state.expireGameTime() <= player.level().getGameTime() + 40L,
+                    "Elemental Bow stored overheat should be clamped to the last applied duration");
+            helper.assertTrue(schoolTag.getLong("ExpireGameTime") == state.expireGameTime(),
+                    "Elemental Bow persistent overheat NBT should be rewritten after clamping");
+            helper.succeed();
+        });
+    }
+
     static void elementalBowKeepsCurrentEmptySpecialSelectionOnlyWhileSelected(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "elemental_bow_empty_selection_test");

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
@@ -738,6 +738,36 @@ final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodex
         helper.succeed();
     }
 
+    static void spellchargedGreatswordClampsPersistedFutureOvercharge(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var gameTime = helper.getLevel().getGameTime();
+            var stack = new ItemStack(ItemRegistry.SPELLCHARGED_GREATSWORD.get());
+            CustomData.update(DataComponents.CUSTOM_DATA, stack, tag -> {
+                tag.putDouble("SpellchargedGreatswordChargeTicks", 400.0D);
+                tag.putLong("SpellchargedGreatswordLastChargeGameTime", gameTime + 72000L);
+                tag.putInt("SpellchargedGreatswordChargeLevel", 2);
+                tag.putInt("SpellchargedGreatswordOverchargeRemainingTicks", 72000);
+                tag.putInt("SpellchargedGreatswordOverchargeMaxTicks", SpellchargedGreatsword.OVERCHARGE_LEVEL_3_DURATION_TICKS);
+                tag.putLong("SpellchargedGreatswordOverchargeActivatedGameTime", gameTime + 72000L);
+                tag.putLong("SpellchargedGreatswordOverchargeEndGameTime", gameTime + 72000L);
+                tag.putLong("SpellchargedGreatswordOverchargeFadeStartGameTime", gameTime + 72000L);
+            });
+
+            helper.assertTrue(SpellchargedGreatsword.sanitizePersistentGameTimes(stack, gameTime),
+                    "Spellcharged Greatsword sanitizer should rewrite future persisted game times");
+            var tag = stack.get(DataComponents.CUSTOM_DATA).copyTag();
+            helper.assertTrue(tag.getLong("SpellchargedGreatswordLastChargeGameTime") <= gameTime,
+                    "Spellcharged Greatsword future last charge time should be clamped to now");
+            helper.assertTrue(tag.getLong("SpellchargedGreatswordOverchargeActivatedGameTime") <= gameTime,
+                    "Spellcharged Greatsword future overcharge activation time should be clamped to now");
+            helper.assertTrue(tag.getLong("SpellchargedGreatswordOverchargeEndGameTime")
+                            <= gameTime + SpellchargedGreatsword.OVERCHARGE_LEVEL_3_DURATION_TICKS,
+                    "Spellcharged Greatsword future overcharge end time should be clamped to max overcharge duration");
+            helper.assertTrue(tag.getLong("SpellchargedGreatswordOverchargeFadeStartGameTime") <= gameTime,
+                    "Spellcharged Greatsword future fade start time should be clamped to now");
+        });
+    }
+
     static void spellchargedGreatswordSweepingEdgeBonusAndSweepHitbox(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var item = (SpellchargedGreatsword) ItemRegistry.SPELLCHARGED_GREATSWORD.get();

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/MultipurposeStaffrifleGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/MultipurposeStaffrifleGameTestScenarios.java
@@ -96,6 +96,7 @@ import jp.aquafactory.apprenticecodex.item.multicastechostaff.MulticastEchoStaff
 import jp.aquafactory.apprenticecodex.item.multicastechostaff.MulticastEchoStaffMobEffectProfileManager;
 import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeStaffrifleCastContext;
 import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeStaffrifleCastEvent;
+import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeStaffrifleRateLimiter;
 import jp.aquafactory.apprenticecodex.item.revolvercaststaff.RevolvercastStaffPendingAdvance;
 import jp.aquafactory.apprenticecodex.item.zenithstaff.ZenithStaffManaCostEvent;
 import jp.aquafactory.apprenticecodex.item.zenithstaff.ZenithStaffPowerHelper;
@@ -355,6 +356,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 final class MultipurposeStaffrifleGameTestScenarios extends ApprenticeCodexGameTestScenarios {
+    private static final String LEGACY_NEXT_SPECIAL_CAST_TICK_TAG =
+            "ApprenticeCodexMultipurposeStaffrifleNextSpecialCastTick";
+
     private MultipurposeStaffrifleGameTestScenarios() {
     }
 
@@ -469,6 +473,27 @@ final class MultipurposeStaffrifleGameTestScenarios extends ApprenticeCodexGameT
                     "Multipurpose Staffrifle should not reduce longer cooldowns below the default minimum");
             helper.assertTrue(item.resolveSpecialCooldownTicks(20 * 60) == 20 * 30,
                     "Multipurpose Staffrifle should subtract the default 30 seconds from long cooldowns");
+        });
+    }
+
+    static void multipurposeStaffrifleRateLimitIgnoresLegacyPersistentNbt(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "multipurpose_staffrifle_rate_limit_test");
+            MultipurposeStaffrifleRateLimiter.clear(player);
+            try {
+                player.getPersistentData().putLong(LEGACY_NEXT_SPECIAL_CAST_TICK_TAG, Long.MAX_VALUE);
+
+                helper.assertTrue(MultipurposeStaffrifleRateLimiter.canAttemptSpecialCast(player),
+                        "Multipurpose Staffrifle should ignore legacy persistent next-cast NBT");
+                helper.assertFalse(MultipurposeStaffrifleRateLimiter.canAttemptSpecialCast(player),
+                        "Multipurpose Staffrifle should still rate-limit repeated same-tick attempts");
+
+                MultipurposeStaffrifleCastEvent.onPlayerLoggedOut(new PlayerEvent.PlayerLoggedOutEvent(player));
+                helper.assertTrue(MultipurposeStaffrifleRateLimiter.canAttemptSpecialCast(player),
+                        "Multipurpose Staffrifle rate limit should be cleared on logout");
+            } finally {
+                MultipurposeStaffrifleRateLimiter.clear(player);
+            }
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
@@ -251,14 +251,14 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
         }
 
         var expireGameTime = tag.getLong(OVERHEAT_EXPIRE_GAME_TIME_TAG);
-        if (!level.isClientSide) {
-            var sanitizedExpireGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
-                    level.getGameTime(),
-                    expireGameTime,
-                    resolveStoredStaffOverheatRepairMaxTicks(tag)
-            );
-            if (sanitizedExpireGameTime != expireGameTime) {
-                expireGameTime = sanitizedExpireGameTime;
+        var sanitizedExpireGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                level.getGameTime(),
+                expireGameTime,
+                resolveStoredStaffOverheatRepairMaxTicks(tag)
+        );
+        if (sanitizedExpireGameTime != expireGameTime) {
+            expireGameTime = sanitizedExpireGameTime;
+            if (!level.isClientSide) {
                 CustomData.update(
                         DataComponents.CUSTOM_DATA,
                         stack,

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CircuitHeatStaff.java
@@ -23,9 +23,11 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.circuitheatstaff.CircuitHeatStaffConfigState;
 import jp.aquafactory.apprenticecodex.item.circuitheatstaff.CircuitHeatStaffCoolingHandler;
 import jp.aquafactory.apprenticecodex.item.circuitheatstaff.CircuitHeatStaffOverheatManager;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
@@ -67,6 +69,7 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
     private static final String FRAME_CONTROLLER = "frame";
     private static final String COG_CONTROLLER = "cog";
     private static final String OVERHEAT_EXPIRE_GAME_TIME_TAG = "CircuitHeatStaffOverheatExpireGameTime";
+    private static final String OVERHEAT_DURATION_TICKS_TAG = "CircuitHeatStaffOverheatDurationTicks";
     private static final String VANILLA_NAMESPACE = "minecraft";
     private static final Set<ResourceLocation> ALLOWED_APPRENTICE_ENCHANTMENTS = Set.of(
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "wisdom")
@@ -246,9 +249,30 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
         if (!tag.contains(OVERHEAT_EXPIRE_GAME_TIME_TAG, Tag.TAG_LONG)) {
             return 0;
         }
-        var remainingTicks = (int)Math.max(0L, tag.getLong(OVERHEAT_EXPIRE_GAME_TIME_TAG) - level.getGameTime());
+
+        var expireGameTime = tag.getLong(OVERHEAT_EXPIRE_GAME_TIME_TAG);
+        if (!level.isClientSide) {
+            var sanitizedExpireGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                    level.getGameTime(),
+                    expireGameTime,
+                    resolveStoredStaffOverheatRepairMaxTicks(tag)
+            );
+            if (sanitizedExpireGameTime != expireGameTime) {
+                expireGameTime = sanitizedExpireGameTime;
+                CustomData.update(
+                        DataComponents.CUSTOM_DATA,
+                        stack,
+                        data -> data.putLong(OVERHEAT_EXPIRE_GAME_TIME_TAG, sanitizedExpireGameTime)
+                );
+            }
+        }
+
+        var remainingTicks = (int)Math.max(0L, expireGameTime - level.getGameTime());
         if (remainingTicks <= 0 && !level.isClientSide) {
-            CustomData.update(DataComponents.CUSTOM_DATA, stack, data -> data.remove(OVERHEAT_EXPIRE_GAME_TIME_TAG));
+            CustomData.update(DataComponents.CUSTOM_DATA, stack, data -> {
+                data.remove(OVERHEAT_EXPIRE_GAME_TIME_TAG);
+                data.remove(OVERHEAT_DURATION_TICKS_TAG);
+            });
         }
         return remainingTicks;
     }
@@ -261,10 +285,13 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
         CustomData.update(
                 DataComponents.CUSTOM_DATA,
                 stack,
-                tag -> tag.putLong(
-                        OVERHEAT_EXPIRE_GAME_TIME_TAG,
-                        level.getGameTime() + cooldownTicks
-                )
+                tag -> {
+                    tag.putLong(
+                            OVERHEAT_EXPIRE_GAME_TIME_TAG,
+                            level.getGameTime() + cooldownTicks
+                    );
+                    tag.putInt(OVERHEAT_DURATION_TICKS_TAG, cooldownTicks);
+                }
         );
     }
 
@@ -275,7 +302,10 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
 
         var remainingTicks = getStaffOverheatRemainingTicks(stack, level);
         if (remainingTicks <= reductionTicks) {
-            CustomData.update(DataComponents.CUSTOM_DATA, stack, data -> data.remove(OVERHEAT_EXPIRE_GAME_TIME_TAG));
+            CustomData.update(DataComponents.CUSTOM_DATA, stack, data -> {
+                data.remove(OVERHEAT_EXPIRE_GAME_TIME_TAG);
+                data.remove(OVERHEAT_DURATION_TICKS_TAG);
+            });
             return 0;
         }
 
@@ -283,7 +313,10 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
         CustomData.update(
                 DataComponents.CUSTOM_DATA,
                 stack,
-                tag -> tag.putLong(OVERHEAT_EXPIRE_GAME_TIME_TAG, level.getGameTime() + reducedTicks)
+                tag -> {
+                    tag.putLong(OVERHEAT_EXPIRE_GAME_TIME_TAG, level.getGameTime() + reducedTicks);
+                    tag.putInt(OVERHEAT_DURATION_TICKS_TAG, reducedTicks);
+                }
         );
         return reducedTicks;
     }
@@ -456,6 +489,16 @@ public class CircuitHeatStaff extends StaffItem implements GeoItem, UniqueItem, 
         }
 
         return (int) Math.min(overheatTicks, Integer.MAX_VALUE);
+    }
+
+    private static int resolveStoredStaffOverheatRepairMaxTicks(CompoundTag tag) {
+        var storedDurationTicks = Math.max(0, tag.getInt(OVERHEAT_DURATION_TICKS_TAG));
+        if (storedDurationTicks > 0) {
+            return storedDurationTicks;
+        }
+
+        var capTicks = ApprenticeCodexServerConfig.circuitHeatStaffOverheatDurationCapTicks();
+        return Math.max(capTicks, 0);
     }
 
     private static boolean isDurabilityTargetEnchantment(Holder<Enchantment> enchantment) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/MultipurposeStaffrifle.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/MultipurposeStaffrifle.java
@@ -16,6 +16,7 @@ import jp.aquafactory.apprenticecodex.compat.malum.MalumCompatibility;
 import jp.aquafactory.apprenticecodex.enchantment.Enchantments;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterammopouch.SpellcasterAmmoPouch;
 import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeStaffrifleCastContext;
+import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeStaffrifleRateLimiter;
 import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.SyncMultipurposeStaffrifleFireEffectPacket;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
@@ -72,7 +73,6 @@ public final class MultipurposeStaffrifle extends Item
     private static final RawAnimation ANIM_FIRED = RawAnimation.begin().thenPlay("fired");
     private static final int MAX_USE_DURATION = 72000;
     private static final float ADS_FOV_MODIFIER = 0.85F;
-    private static final String NEXT_SPECIAL_CAST_TICK_TAG = "ApprenticeCodexMultipurposeStaffrifleNextSpecialCastTick";
     private static final int MUZZLE_RHOMBUS_COUNT = 4;
     private static final int MUZZLE_SPARK_COUNT = 7;
     private static final int MUZZLE_RHOMBUS_WHITEN_TICKS = 2;
@@ -476,17 +476,7 @@ public final class MultipurposeStaffrifle extends Item
     }
 
     private static boolean canAttemptSpecialCast(ServerPlayer player) {
-        var interval = Math.max(1, ApprenticeCodexServerConfig.multipurposeStaffrifleAdsFullAutoIntervalTicks());
-        var tag = player.getPersistentData();
-        var gameTime = player.level().getGameTime();
-        var nextAllowedTick = tag.getLong(NEXT_SPECIAL_CAST_TICK_TAG);
-        if (gameTime < nextAllowedTick) {
-            return false;
-        }
-
-        // クライアント入力経路や連携MODの差に関係なく、専用詠唱はADS連射設定より速く通さない。
-        tag.putLong(NEXT_SPECIAL_CAST_TICK_TAG, gameTime + interval);
-        return true;
+        return MultipurposeStaffrifleRateLimiter.canAttemptSpecialCast(player);
     }
 
     private static void sendActionBarError(ServerPlayer player, Component component) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/circuitheatstaff/CircuitHeatStaffOverheatManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/circuitheatstaff/CircuitHeatStaffOverheatManager.java
@@ -1,6 +1,7 @@
 package jp.aquafactory.apprenticecodex.item.circuitheatstaff;
 
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerPlayer;
@@ -68,7 +69,7 @@ public final class CircuitHeatStaffOverheatManager {
         }
 
         var spellTag = rootTag.getCompound(spellId);
-        var expireGameTime = spellTag.getLong(EXPIRE_GAME_TIME_TAG);
+        var expireGameTime = sanitizeExpireGameTime(player, spellTag, true);
         var chainDepth = Math.max(0, spellTag.getInt(CHAIN_DEPTH_TAG));
         if (chainDepth == 0 || expireGameTime <= player.level().getGameTime()) {
             rootTag.remove(spellId);
@@ -186,6 +187,32 @@ public final class CircuitHeatStaffOverheatManager {
         if (player instanceof ServerPlayer serverPlayer) {
             CircuitHeatStaffOverheatSync.syncToClient(serverPlayer);
         }
+    }
+
+    private static long sanitizeExpireGameTime(Player player, CompoundTag spellTag, boolean sync) {
+        var expireGameTime = spellTag.getLong(EXPIRE_GAME_TIME_TAG);
+        var sanitizedExpireGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                player.level().getGameTime(),
+                expireGameTime,
+                resolveStoredOverheatRepairMaxTicks(spellTag)
+        );
+        if (sanitizedExpireGameTime != expireGameTime) {
+            spellTag.putLong(EXPIRE_GAME_TIME_TAG, sanitizedExpireGameTime);
+            if (sync) {
+                syncToClientIfNeeded(player);
+            }
+        }
+        return sanitizedExpireGameTime;
+    }
+
+    private static int resolveStoredOverheatRepairMaxTicks(CompoundTag spellTag) {
+        var lastAppliedCooldownTicks = Math.max(0, spellTag.getInt(LAST_APPLIED_COOLDOWN_TICKS_TAG));
+        if (lastAppliedCooldownTicks > 0) {
+            return lastAppliedCooldownTicks;
+        }
+
+        var capTicks = ApprenticeCodexServerConfig.circuitHeatStaffOverheatDurationCapTicks();
+        return Math.max(capTicks, 0);
     }
 
     public record OverheatState(int chainDepth, long expireGameTime) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/absorptionamplifyamulet/AbsorptionAmplifyAmuletLogic.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/absorptionamplifyamulet/AbsorptionAmplifyAmuletLogic.java
@@ -11,6 +11,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.event.KnockbackControlEvent;
 import jp.aquafactory.apprenticecodex.spell.forcefield.ForceFieldDefenseEvent;
 import jp.aquafactory.apprenticecodex.utility.AudioTools;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -73,6 +74,7 @@ final class AbsorptionAmplifyAmuletLogic {
 
         withState(player, state -> {
             var gameTime = player.level().getGameTime();
+            sanitizePersistentGameTimes(state, gameTime);
 
             if (!state.initialized) {
                 state.initialized = true;
@@ -130,6 +132,7 @@ final class AbsorptionAmplifyAmuletLogic {
             var currentAbsorption = player.getAbsorptionAmount();
             if (currentAbsorption < state.lastKnownAbsorption) {
                 var gameTime = player.level().getGameTime();
+                sanitizePersistentGameTimes(state, gameTime);
                 scheduleRecovery(state, gameTime);
                 KnockbackControlEvent.markIgnoreNextKnockback(player);
 
@@ -203,6 +206,24 @@ final class AbsorptionAmplifyAmuletLogic {
         var recoveryDelayTicks = ApprenticeCodexServerConfig.absorptionAmplifyAmuletRecoveryDelayTicks();
         state.recoveryResumeGameTime = gameTime + recoveryDelayTicks;
         state.nextRecoveryGameTime = state.recoveryResumeGameTime;
+    }
+
+    private static void sanitizePersistentGameTimes(AbsorptionAmplifyAmuletState state, long gameTime) {
+        state.recoveryResumeGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntilWithKnownMax(
+                gameTime,
+                state.recoveryResumeGameTime,
+                ApprenticeCodexServerConfig.absorptionAmplifyAmuletRecoveryDelayTicks()
+        );
+        state.nextRecoveryGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                gameTime,
+                state.nextRecoveryGameTime,
+                RECOVERY_INTERVAL_TICKS
+        );
+        state.nextProcGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                gameTime,
+                state.nextProcGameTime,
+                PROC_COOLDOWN_TICKS
+        );
     }
 
     private static void resetState(ServerPlayer player) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmulet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmulet.java
@@ -171,6 +171,7 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
     }
 
     public static boolean isRetrySequenceCoolingDown(ItemStack stack, long currentTick) {
+        sanitizeRetrySequence(stack, currentTick);
         var tag = getCustomDataTag(stack);
         if (tag == null || !tag.contains(RETRY_SEQUENCE_TICK_TAG, Tag.TAG_LONG)) {
             return false;
@@ -179,6 +180,7 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
     }
 
     public static int consumeReadyRetrySkipSlot(ItemStack stack, long currentTick) {
+        sanitizeRetrySequence(stack, currentTick);
         var skipSlot = new int[]{-1};
         CustomData.update(DataComponents.CUSTOM_DATA, stack, tag -> {
             if (!tag.contains(RETRY_SEQUENCE_TICK_TAG, Tag.TAG_LONG) || tag.getLong(RETRY_SEQUENCE_TICK_TAG) > currentTick) {
@@ -200,6 +202,22 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
     public static int getRetrySkipSlot(ItemStack stack) {
         var tag = getCustomDataTag(stack);
         return tag == null || !tag.contains(RETRY_SKIP_SLOT_TAG, Tag.TAG_INT) ? -1 : tag.getInt(RETRY_SKIP_SLOT_TAG);
+    }
+
+    private static void sanitizeRetrySequence(ItemStack stack, long currentTick) {
+        var tag = getCustomDataTag(stack);
+        if (tag == null || !tag.contains(RETRY_SEQUENCE_TICK_TAG, Tag.TAG_LONG)) {
+            return;
+        }
+
+        if (tag.getLong(RETRY_SEQUENCE_TICK_TAG) <= currentTick + ERROR_RETRY_DELAY_TICKS) {
+            return;
+        }
+
+        CustomData.update(DataComponents.CUSTOM_DATA, stack, mutableTag -> {
+            mutableTag.remove(RETRY_SEQUENCE_TICK_TAG);
+            mutableTag.remove(RETRY_SKIP_SLOT_TAG);
+        });
     }
 
     public static Component createInsufficientManaMessage(AbstractSpell spell, Player player, int requiredMana) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBowOverheatManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBowOverheatManager.java
@@ -1,6 +1,7 @@
 package jp.aquafactory.apprenticecodex.item.elementalbow;
 
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
@@ -134,7 +135,7 @@ public final class ElementalBowOverheatManager {
         }
 
         var schoolTag = rootTag.getCompound(schoolId.toString());
-        var expireGameTime = schoolTag.getLong(EXPIRE_GAME_TIME_TAG);
+        var expireGameTime = sanitizeExpireGameTime(player, schoolTag, true);
         var chainDepth = Math.max(0, schoolTag.getInt(CHAIN_DEPTH_TAG));
         if (chainDepth == 0 || expireGameTime <= player.level().getGameTime()) {
             rootTag.remove(schoolId.toString());
@@ -239,7 +240,7 @@ public final class ElementalBowOverheatManager {
             }
 
             var schoolTag = rootTag.getCompound(schoolKey);
-            var expireGameTime = schoolTag.getLong(EXPIRE_GAME_TIME_TAG);
+            var expireGameTime = sanitizeExpireGameTime(player, schoolTag, false);
             var chainDepth = Math.max(0, schoolTag.getInt(CHAIN_DEPTH_TAG));
             if (chainDepth == 0 || expireGameTime <= gameTime) {
                 rootTag.remove(schoolKey);
@@ -364,6 +365,32 @@ public final class ElementalBowOverheatManager {
             // player persistentData は自動同期されないため、描画用の overheat 状態は明示的に client へ送る。
             ElementalBowOverheatSync.syncToClient(serverPlayer);
         }
+    }
+
+    private static long sanitizeExpireGameTime(Player player, CompoundTag schoolTag, boolean sync) {
+        var expireGameTime = schoolTag.getLong(EXPIRE_GAME_TIME_TAG);
+        var sanitizedExpireGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                player.level().getGameTime(),
+                expireGameTime,
+                resolveStoredOverheatRepairMaxTicks(schoolTag)
+        );
+        if (sanitizedExpireGameTime != expireGameTime) {
+            schoolTag.putLong(EXPIRE_GAME_TIME_TAG, sanitizedExpireGameTime);
+            if (sync) {
+                syncToClientIfNeeded(player);
+            }
+        }
+        return sanitizedExpireGameTime;
+    }
+
+    private static int resolveStoredOverheatRepairMaxTicks(CompoundTag schoolTag) {
+        var lastAppliedCooldownTicks = Math.max(0, schoolTag.getInt(LAST_APPLIED_COOLDOWN_TICKS_TAG));
+        if (lastAppliedCooldownTicks > 0) {
+            return lastAppliedCooldownTicks;
+        }
+
+        var capTicks = ApprenticeCodexServerConfig.elementalBowOverheatDurationCapTicks();
+        return Math.max(capTicks, 0);
     }
 
     public record OverheatState(int chainDepth, long expireGameTime) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/multicastechostaff/MulticastEchoStaffCastHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/multicastechostaff/MulticastEchoStaffCastHelper.java
@@ -183,10 +183,11 @@ public final class MulticastEchoStaffCastHelper {
     ) {
         var previousCastData = magicData.getAdditionalCastData();
         try {
+            // 長詠唱開始時のターゲット情報を再利用すると、完了時点で無効になった対象にもMulticastが続く。
             magicData.setAdditionalCastData(null);
             return spell.checkPreCastConditions(level, spellLevel, player, magicData);
         } finally {
-            clearRepeatedCastData(magicData, previousCastData);
+            restoreCastData(magicData, previousCastData);
         }
     }
 
@@ -421,6 +422,14 @@ public final class MulticastEchoStaffCastHelper {
         }
 
         if (currentCastData != null) {
+            currentCastData.reset();
+        }
+        magicData.setAdditionalCastData(previousCastData);
+    }
+
+    private static void restoreCastData(MagicData magicData, @Nullable ICastData previousCastData) {
+        var currentCastData = magicData.getAdditionalCastData();
+        if (currentCastData != null && currentCastData != previousCastData) {
             currentCastData.reset();
         }
         magicData.setAdditionalCastData(previousCastData);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/multipurposestaffrifle/MultipurposeStaffrifleCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/multipurposestaffrifle/MultipurposeStaffrifleCastEvent.java
@@ -10,6 +10,8 @@ import jp.aquafactory.apprenticecodex.item.SpellGunCastEvent;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 
 @EventBusSubscriber(modid = ApprenticeCodex.MODID)
@@ -85,5 +87,17 @@ public final class MultipurposeStaffrifleCastEvent {
         }
 
         MultipurposeStaffrifleCastContext.clearExpiredPending(player.getUUID(), player.level().getGameTime());
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            MultipurposeStaffrifleRateLimiter.clear(player);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onServerStopping(ServerStoppingEvent event) {
+        MultipurposeStaffrifleRateLimiter.clearAll();
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/multipurposestaffrifle/MultipurposeStaffrifleRateLimiter.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/multipurposestaffrifle/MultipurposeStaffrifleRateLimiter.java
@@ -1,0 +1,37 @@
+package jp.aquafactory.apprenticecodex.item.multipurposestaffrifle;
+
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public final class MultipurposeStaffrifleRateLimiter {
+    private static final ConcurrentMap<UUID, Long> NEXT_SPECIAL_CAST_TICKS = new ConcurrentHashMap<>();
+
+    private MultipurposeStaffrifleRateLimiter() {
+    }
+
+    public static boolean canAttemptSpecialCast(ServerPlayer player) {
+        var interval = Math.max(1, ApprenticeCodexServerConfig.multipurposeStaffrifleAdsFullAutoIntervalTicks());
+        var gameTime = player.level().getGameTime();
+        var playerId = player.getUUID();
+        var nextAllowedTick = NEXT_SPECIAL_CAST_TICKS.getOrDefault(playerId, 0L);
+        if (gameTime < nextAllowedTick) {
+            return false;
+        }
+
+        // クライアント入力経路や連携MODの差に関係なく、専用詠唱はADS連射設定より速く通さない。
+        NEXT_SPECIAL_CAST_TICKS.put(playerId, gameTime + interval);
+        return true;
+    }
+
+    public static void clear(ServerPlayer player) {
+        NEXT_SPECIAL_CAST_TICKS.remove(player.getUUID());
+    }
+
+    public static void clearAll() {
+        NEXT_SPECIAL_CAST_TICKS.clear();
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellchargedgreatsword/SpellchargedGreatsword.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellchargedgreatsword/SpellchargedGreatsword.java
@@ -8,6 +8,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.SpellchargedGreatswordServerConfig;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import jp.aquafactory.apprenticecodex.renderer.item.SpellchargedGreatswordRenderer;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
@@ -195,6 +196,9 @@ public final class SpellchargedGreatsword extends SwordItem implements GeoItem, 
         }
 
         var gameTime = level.getGameTime();
+        if (!level.isClientSide && sanitizePersistentGameTimes(stack, gameTime)) {
+            syncInventoryIfServer(player);
+        }
         if (!level.isClientSide && refreshDecay(stack, gameTime)) {
             syncInventoryIfServer(player);
         }
@@ -448,12 +452,83 @@ public final class SpellchargedGreatsword extends SwordItem implements GeoItem, 
         clearOvercharge(stack, 0L, false);
     }
 
+    public static boolean sanitizePersistentGameTimes(ItemStack stack, long gameTime) {
+        var tag = getCustomDataTag(stack);
+        if (!isSpellchargedGreatsword(stack) || tag == null) {
+            return false;
+        }
+
+        var changed = false;
+        if (tag.contains(TAG_LAST_CHARGE_GAME_TIME)) {
+            var sanitizedLastChargeGameTime = PersistentGameTimeSanitizer.clampFutureStart(
+                    gameTime,
+                    tag.getLong(TAG_LAST_CHARGE_GAME_TIME)
+            );
+            if (sanitizedLastChargeGameTime != tag.getLong(TAG_LAST_CHARGE_GAME_TIME)) {
+                tag.putLong(TAG_LAST_CHARGE_GAME_TIME, sanitizedLastChargeGameTime);
+                changed = true;
+            }
+        }
+
+        if (tag.contains(TAG_OVERCHARGE_ACTIVATED_GAME_TIME)) {
+            var sanitizedActivatedGameTime = PersistentGameTimeSanitizer.clampFutureStart(
+                    gameTime,
+                    tag.getLong(TAG_OVERCHARGE_ACTIVATED_GAME_TIME)
+            );
+            if (sanitizedActivatedGameTime != tag.getLong(TAG_OVERCHARGE_ACTIVATED_GAME_TIME)) {
+                tag.putLong(TAG_OVERCHARGE_ACTIVATED_GAME_TIME, sanitizedActivatedGameTime);
+                changed = true;
+            }
+        }
+
+        if (tag.contains(TAG_OVERCHARGE_END_GAME_TIME)) {
+            var repairMaxTicks = resolveStoredOverchargeRepairMaxTicks(tag);
+            var sanitizedEndGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                    gameTime,
+                    tag.getLong(TAG_OVERCHARGE_END_GAME_TIME),
+                    repairMaxTicks
+            );
+            if (sanitizedEndGameTime != tag.getLong(TAG_OVERCHARGE_END_GAME_TIME)) {
+                var remainingTicks = Math.max(0, (int)(sanitizedEndGameTime - gameTime));
+                tag.putLong(TAG_OVERCHARGE_END_GAME_TIME, sanitizedEndGameTime);
+                tag.putInt(TAG_OVERCHARGE_REMAINING_TICKS, remainingTicks);
+                tag.putInt(TAG_OVERCHARGE_MAX_TICKS, Math.max(1, repairMaxTicks));
+                changed = true;
+            }
+        }
+
+        if (tag.contains(TAG_OVERCHARGE_FADE_START_GAME_TIME)) {
+            var sanitizedFadeStartGameTime = PersistentGameTimeSanitizer.clampFutureStart(
+                    gameTime,
+                    tag.getLong(TAG_OVERCHARGE_FADE_START_GAME_TIME)
+            );
+            if (sanitizedFadeStartGameTime != tag.getLong(TAG_OVERCHARGE_FADE_START_GAME_TIME)) {
+                tag.putLong(TAG_OVERCHARGE_FADE_START_GAME_TIME, sanitizedFadeStartGameTime);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            var sanitizedTag = tag.copy();
+            CustomData.update(DataComponents.CUSTOM_DATA, stack, data -> data.merge(sanitizedTag));
+        }
+        cleanupEmptyTag(stack);
+        return changed;
+    }
+
     private static boolean hasChargeState(ItemStack stack) {
         var tag = getCustomDataTag(stack);
         return tag != null
                 && (tag.contains(TAG_CHARGE_TICKS)
                 || tag.contains(TAG_LAST_CHARGE_GAME_TIME)
                 || tag.contains(TAG_CHARGE_LEVEL));
+    }
+
+    private static int resolveStoredOverchargeRepairMaxTicks(CompoundTag tag) {
+        var storedMaxTicks = Math.max(0, tag.getInt(TAG_OVERCHARGE_MAX_TICKS));
+        return storedMaxTicks > 0
+                ? Math.min(storedMaxTicks, OVERCHARGE_LEVEL_3_DURATION_TICKS)
+                : OVERCHARGE_LEVEL_3_DURATION_TICKS;
     }
 
     private static boolean isSpellchargedGreatsword(ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellchargedgreatsword/SpellchargedGreatsword.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellchargedgreatsword/SpellchargedGreatsword.java
@@ -135,11 +135,15 @@ public final class SpellchargedGreatsword extends SwordItem implements GeoItem, 
             return InteractionResultHolder.pass(stack);
         }
 
-        if (isOverchargeActive(stack, level.getGameTime())) {
+        var gameTime = level.getGameTime();
+        if (sanitizePersistentGameTimes(stack, gameTime) && !level.isClientSide) {
+            syncInventoryIfServer(player);
+        }
+        if (isOverchargeActive(stack, gameTime)) {
             return InteractionResultHolder.pass(stack);
         }
 
-        if (getChargeLevel(stack, level.getGameTime()) < 2) {
+        if (getChargeLevel(stack, gameTime) < 2) {
             return InteractionResultHolder.pass(stack);
         }
 
@@ -196,7 +200,7 @@ public final class SpellchargedGreatsword extends SwordItem implements GeoItem, 
         }
 
         var gameTime = level.getGameTime();
-        if (!level.isClientSide && sanitizePersistentGameTimes(stack, gameTime)) {
+        if (sanitizePersistentGameTimes(stack, gameTime) && !level.isClientSide) {
             syncInventoryIfServer(player);
         }
         if (!level.isClientSide && refreshDecay(stack, gameTime)) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellchargedgreatsword/SpellchargedGreatsword.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellchargedgreatsword/SpellchargedGreatsword.java
@@ -516,7 +516,6 @@ public final class SpellchargedGreatsword extends SwordItem implements GeoItem, 
             var sanitizedTag = tag.copy();
             CustomData.update(DataComponents.CUSTOM_DATA, stack, data -> data.merge(sanitizedTag));
         }
-        cleanupEmptyTag(stack);
         return changed;
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -59,7 +59,7 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "53";
+    private static final String PROTOCOL_VERSION = "54";
 
     private Networks() {
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncRemoteEyeStatePacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncRemoteEyeStatePacket.java
@@ -21,14 +21,16 @@ public class SyncRemoteEyeStatePacket implements CustomPacketPayload {
             StreamCodec.of((buffer, packet) -> encode(packet, buffer), SyncRemoteEyeStatePacket::decode);
 
     private final long activeUntilGameTime;
+    private final long activeDurationTicks;
     private final double anchorX;
     private final double anchorY;
     private final double anchorZ;
     private final float anchorYaw;
     private final float anchorPitch;
 
-    public SyncRemoteEyeStatePacket(long activeUntilGameTime, double anchorX, double anchorY, double anchorZ, float anchorYaw, float anchorPitch) {
+    public SyncRemoteEyeStatePacket(long activeUntilGameTime, long activeDurationTicks, double anchorX, double anchorY, double anchorZ, float anchorYaw, float anchorPitch) {
         this.activeUntilGameTime = activeUntilGameTime;
+        this.activeDurationTicks = activeDurationTicks;
         this.anchorX = anchorX;
         this.anchorY = anchorY;
         this.anchorZ = anchorZ;
@@ -43,6 +45,7 @@ public class SyncRemoteEyeStatePacket implements CustomPacketPayload {
 
     public static void encode(SyncRemoteEyeStatePacket packet, FriendlyByteBuf buffer) {
         buffer.writeLong(packet.activeUntilGameTime);
+        buffer.writeLong(packet.activeDurationTicks);
         buffer.writeDouble(packet.anchorX);
         buffer.writeDouble(packet.anchorY);
         buffer.writeDouble(packet.anchorZ);
@@ -52,6 +55,7 @@ public class SyncRemoteEyeStatePacket implements CustomPacketPayload {
 
     public static SyncRemoteEyeStatePacket decode(FriendlyByteBuf buffer) {
         return new SyncRemoteEyeStatePacket(
+                buffer.readLong(),
                 buffer.readLong(),
                 buffer.readDouble(),
                 buffer.readDouble(),
@@ -84,6 +88,7 @@ public class SyncRemoteEyeStatePacket implements CustomPacketPayload {
             Capabilities.getSpellData(player).ifPresent(data ->
                     data.edit(CodexSpellStateTypeRegister.REMOTE_EYE_STATE, state -> {
                         state.activeUntilGameTime = packet.activeUntilGameTime;
+                        state.activeDurationTicks = packet.activeDurationTicks;
                         state.anchorX = packet.anchorX;
                         state.anchorY = packet.anchorY;
                         state.anchorZ = packet.anchorZ;

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/featherrush/FeatherRush.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/featherrush/FeatherRush.java
@@ -45,7 +45,7 @@ public class FeatherRush extends AbstractSummonWeaponSpell<FeatherRushWingEntity
     private static final float RPM_AT_LOW_POWER = 300.0f;
     private static final float RPM_AT_HIGH_POWER = 900.0f;
     private static final float TICKS_PER_MINUTE = 1200.0f;
-    private static final long ACTIVE_TICK_GRACE = 2L;
+    public static final long ACTIVE_TICK_GRACE = 2L;
 
     private final ResourceLocation spellId = ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "feather_rush");
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/featherrush/FeatherRushGravityControlEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/featherrush/FeatherRushGravityControlEvent.java
@@ -5,7 +5,7 @@ import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellData;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.FeatherRushState;
-import jp.aquafactory.apprenticecodex.spell.featherrush.FeatherRushWingEntity;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
@@ -31,6 +31,7 @@ public final class FeatherRushGravityControlEvent {
         }
 
         var state = spellData.get(CodexSpellStateTypeRegister.FEATHER_RUSH_STATE);
+        sanitizePersistentGameTimes(spellData, level, state);
         if (!isActive(level, state)) {
             deactivate(spellData, player, state);
             return;
@@ -63,6 +64,20 @@ public final class FeatherRushGravityControlEvent {
 
     private static boolean isActive(Level level, FeatherRushState state) {
         return state.activeUntilGameTime >= level.getGameTime();
+    }
+
+    private static void sanitizePersistentGameTimes(CodexSpellData spellData, Level level, FeatherRushState state) {
+        var sanitizedActiveUntilGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                level.getGameTime(),
+                state.activeUntilGameTime,
+                FeatherRush.ACTIVE_TICK_GRACE
+        );
+        if (sanitizedActiveUntilGameTime == state.activeUntilGameTime) {
+            return;
+        }
+
+        spellData.edit(CodexSpellStateTypeRegister.FEATHER_RUSH_STATE, s -> s.activeUntilGameTime = sanitizedActiveUntilGameTime);
+        state.activeUntilGameTime = sanitizedActiveUntilGameTime;
     }
 
     private static boolean isWingValid(Level level, Player player, int wingEntityId) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidanceEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/mirageavoidance/MirageAvoidanceEvents.java
@@ -7,6 +7,7 @@ import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateT
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.MirageAvoidanceState;
 import jp.aquafactory.apprenticecodex.particle.AdditiveGlowParticleOptions;
 import jp.aquafactory.apprenticecodex.registry.ParticleRegistry;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.particles.DustParticleOptions;
 import net.minecraft.core.particles.ParticleTypes;
@@ -62,6 +63,7 @@ public final class MirageAvoidanceEvents {
 
         var level = player.level();
         var state = spellData.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE);
+        sanitizePersistentGameTimes(spellData, player, state);
         if (!isActive(level, state)) {
             resetInactiveState(spellData, player, state);
             return;
@@ -150,9 +152,49 @@ public final class MirageAvoidanceEvents {
         return state.activeUntilGameTime > level.getGameTime();
     }
 
+    private static void sanitizePersistentGameTimes(CodexSpellData spellData, Player player, MirageAvoidanceState state) {
+        var gameTime = player.level().getGameTime();
+        var sanitizedStartGameTime = state.startGameTime > 0L
+                ? PersistentGameTimeSanitizer.clampFutureStart(gameTime, state.startGameTime)
+                : state.startGameTime;
+        var sanitizedActiveUntilGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                gameTime,
+                state.activeUntilGameTime,
+                EFFECT_DURATION_TICKS
+        );
+        var sanitizedInvulnerableUntilGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                gameTime,
+                state.invulnerableUntilGameTime,
+                INVULNERABLE_TICKS
+        );
+        if (sanitizedStartGameTime == state.startGameTime
+                && sanitizedActiveUntilGameTime == state.activeUntilGameTime
+                && sanitizedInvulnerableUntilGameTime == state.invulnerableUntilGameTime) {
+            return;
+        }
+
+        spellData.edit(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE, s -> {
+            s.startGameTime = sanitizedStartGameTime;
+            s.activeUntilGameTime = sanitizedActiveUntilGameTime;
+            s.invulnerableUntilGameTime = sanitizedInvulnerableUntilGameTime;
+        });
+        state.startGameTime = sanitizedStartGameTime;
+        state.activeUntilGameTime = sanitizedActiveUntilGameTime;
+        state.invulnerableUntilGameTime = sanitizedInvulnerableUntilGameTime;
+        if (!player.level().isClientSide && player instanceof ServerPlayer serverPlayer) {
+            MirageAvoidanceSync.syncToClient(serverPlayer, spellData.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE));
+        }
+    }
+
     public static boolean isInputLocked(Player player) {
         var spellData = Capabilities.getSpellDataOrNull(player);
-        return spellData != null && isActive(player.level(), spellData.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE));
+        if (spellData == null) {
+            return false;
+        }
+
+        var state = spellData.get(CodexSpellStateTypeRegister.MIRAGE_AVOIDANCE_STATE);
+        sanitizePersistentGameTimes(spellData, player, state);
+        return isActive(player.level(), state);
     }
 
     public static boolean rejectServerInputCastIfLocked(ServerPlayer player) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/remoteeye/RemoteEye.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/remoteeye/RemoteEye.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.Optional;
 
 public class RemoteEye extends AbstractSpell {
+    // activeDurationTicks が無い旧保存データを補修するための既定上限.
+    public static final int PERSISTED_STATE_REPAIR_MAX_ACTIVE_TICKS = 20 * 30;
+
     private final ResourceLocation spellId = ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "remote_eye");
 
     private final DefaultConfig config = new DefaultConfig()
@@ -88,6 +91,7 @@ public class RemoteEye extends AbstractSpell {
         Capabilities.withSpellData(entity, data -> {
             data.edit(CodexSpellStateTypeRegister.REMOTE_EYE_STATE, state -> {
                 state.activeUntilGameTime = level.getGameTime() + duration;
+                state.activeDurationTicks = duration;
                 state.anchorX = entity.getX();
                 state.anchorY = entity.getY();
                 state.anchorZ = entity.getZ();

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/remoteeye/RemoteEyeBodyControlEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/remoteeye/RemoteEyeBodyControlEvent.java
@@ -5,6 +5,7 @@ import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellData;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.RemoteEyeState;
+import jp.aquafactory.apprenticecodex.utility.PersistentGameTimeSanitizer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
@@ -31,6 +32,7 @@ public final class RemoteEyeBodyControlEvent {
         }
 
         var state = spellData.get(CodexSpellStateTypeRegister.REMOTE_EYE_STATE);
+        sanitizePersistentGameTimes(spellData, player, state);
         if (!isActive(level.getGameTime(), state)) {
             deactivate(spellData, player, state);
             return;
@@ -47,6 +49,27 @@ public final class RemoteEyeBodyControlEvent {
 
     private static boolean isActive(long gameTime, RemoteEyeState state) {
         return state.activeUntilGameTime > gameTime;
+    }
+
+    private static void sanitizePersistentGameTimes(CodexSpellData spellData, Player player, RemoteEyeState state) {
+        var gameTime = player.level().getGameTime();
+        var repairMaxActiveTicks = state.activeDurationTicks > 0L
+                ? state.activeDurationTicks
+                : RemoteEye.PERSISTED_STATE_REPAIR_MAX_ACTIVE_TICKS;
+        var sanitizedActiveUntilGameTime = PersistentGameTimeSanitizer.repairPersistedFutureUntil(
+                gameTime,
+                state.activeUntilGameTime,
+                repairMaxActiveTicks
+        );
+        if (sanitizedActiveUntilGameTime == state.activeUntilGameTime) {
+            return;
+        }
+
+        spellData.edit(CodexSpellStateTypeRegister.REMOTE_EYE_STATE, s -> s.activeUntilGameTime = sanitizedActiveUntilGameTime);
+        state.activeUntilGameTime = sanitizedActiveUntilGameTime;
+        if (!player.level().isClientSide && player instanceof ServerPlayer serverPlayer) {
+            RemoteEyeSync.syncToClient(serverPlayer, spellData.get(CodexSpellStateTypeRegister.REMOTE_EYE_STATE));
+        }
     }
 
     private static void anchorBody(Player player, RemoteEyeState state) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/remoteeye/RemoteEyeSync.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/remoteeye/RemoteEyeSync.java
@@ -12,6 +12,7 @@ public final class RemoteEyeSync {
     public static void syncToClient(ServerPlayer player, RemoteEyeState state) {
         Networks.sendToPlayer(player, new SyncRemoteEyeStatePacket(
                 state.activeUntilGameTime,
+                state.activeDurationTicks,
                 state.anchorX,
                 state.anchorY,
                 state.anchorZ,

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/PersistentGameTimeSanitizer.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/PersistentGameTimeSanitizer.java
@@ -1,0 +1,33 @@
+package jp.aquafactory.apprenticecodex.utility;
+
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+
+public final class PersistentGameTimeSanitizer {
+    private PersistentGameTimeSanitizer() {
+    }
+
+    public static long clampFutureUntil(long now, long storedUntil, long maxRemainingTicks) {
+        if (maxRemainingTicks <= 0L) {
+            return storedUntil;
+        }
+
+        var limit = now + maxRemainingTicks;
+        return Math.min(storedUntil, limit);
+    }
+
+    public static long repairPersistedFutureUntil(long now, long storedUntil, long knownMaxRemainingTicks) {
+        if (knownMaxRemainingTicks > 0L) {
+            return clampFutureUntil(now, storedUntil, knownMaxRemainingTicks);
+        }
+
+        return clampFutureUntil(now, storedUntil, ApprenticeCodexServerConfig.savedAbsoluteTickClampMaxTicks());
+    }
+
+    public static long repairPersistedFutureUntilWithKnownMax(long now, long storedUntil, long knownMaxRemainingTicks) {
+        return Math.min(storedUntil, now + Math.max(0L, knownMaxRemainingTicks));
+    }
+
+    public static long clampFutureStart(long now, long storedStart) {
+        return Math.min(storedStart, now);
+    }
+}


### PR DESCRIPTION
## 概要
- PR #698 の `main` 向け変更を `1.21.1-main` へ forward-port しました。
- 対象コミット 5 件を `git cherry-pick -x` で取り込み、1.21.1 API 差分は追加コミットで調整しています。
- generated resources / datagen 出力の差分はありません。

## 移植元
- https://github.com/hexqua/apprentice_codex/pull/698

## 1.21.1 調整
- NeoForge payload / event / capability / Curios API に合わせて GameTest と同期処理を調整しました。
- 1.21.1 の DataComponent ベースの ItemStack custom data に合わせて、時刻修復テストと Spellcharged Greatsword / Circuit Heat Staff 周辺を調整しました。

## 検証
- `./gradlew.bat compileJava`
- `./gradlew.bat runGameTestServer`（763 required tests passed）
- `./gradlew.bat build`