### PR TITLE
クリエイティブのクールダウン付与迂回対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -299,6 +299,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void continuousShieldCreativeFinishSkipsCooldown(GameTestHelper helper) {
+        BulwarkGreatshieldGameTestScenarios.continuousShieldCreativeFinishSkipsCooldown(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void parrycastBucklerKeepsCoreContract(GameTestHelper helper) {
         ParrycastBucklerGameTestScenarios.parrycastBucklerKeepsCoreContract(helper);
     }
@@ -972,6 +977,16 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     @GameTest(template = TEMPLATE)
     public static void focusStaffbowCreativeOverchargeDoesNotConsumeManaOrCreateLoan(GameTestHelper helper) {
         FocusStaffbowGameTestScenarios.focusStaffbowCreativeOverchargeDoesNotConsumeManaOrCreateLoan(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = FOCUS_STAFFBOW_CONTINUOUS_BATCH)
+    public static void focusStaffbowCreativeContinuousReleaseSkipsCooldown(GameTestHelper helper) {
+        FocusStaffbowGameTestScenarios.focusStaffbowCreativeContinuousReleaseSkipsCooldown(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void focusStaffbowCreativeInterruptionSkipsPreviousSpellCooldown(GameTestHelper helper) {
+        FocusStaffbowGameTestScenarios.focusStaffbowCreativeInterruptionSkipsPreviousSpellCooldown(helper);
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -4956,6 +4956,42 @@ public class ApprenticeCodexGameTestScenarios {
         });
     }
 
+    static void multicastEchoStaffCreativeCastSkipsFinalCooldown(GameTestHelper helper) {
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "multicast_echo_staff_creative_cooldown_test");
+        player.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.CREATIVE);
+        var staffStack = new ItemStack(ItemRegistry.MULTICAST_ECHO_STAFF.get());
+        var spell = SpellRegistry.SHOCK.get();
+        var spellLevel = 1;
+        var manaCost = spell.getManaCost(spellLevel);
+        player.setItemInHand(InteractionHand.MAIN_HAND, staffStack);
+
+        helper.runAtTickTime(1, () -> completeMulticastEchoStaffCast(
+                helper.getLevel(),
+                player,
+                staffStack,
+                spell,
+                spellLevel,
+                0,
+                manaCost * 3.0F
+        ));
+        helper.runAtTickTime(2, () ->
+                MulticastEchoStaffCastHelper.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player))
+        );
+        helper.runAtTickTime(4, () -> {
+            var originalCreativeCooldown = io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.get();
+            try {
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(false);
+                MulticastEchoStaffCastHelper.onPlayerTick(new TickEvent.PlayerTickEvent(TickEvent.Phase.END, player));
+            } finally {
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(originalCreativeCooldown);
+            }
+            var magicData = MagicData.getPlayerMagicData(player);
+            helper.assertFalse(magicData.getPlayerCooldowns().isOnCooldown(spell),
+                    "Multicast Echo Staff creative finalization should respect disabled creative cooldowns");
+            helper.succeed();
+        });
+    }
+
     static void multicastEchoStaffInsufficientManaEndsWithPenaltyCooldown(GameTestHelper helper) {
         var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "multicast_echo_staff_mana_penalty_test");
         var staffStack = new ItemStack(ItemRegistry.MULTICAST_ECHO_STAFF.get());

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexRemoteOwnerCastGameTests.java
@@ -23,6 +23,8 @@ import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastOrigin;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastProfile;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastProfileManager;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastRunner;
+import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCooldownManager;
+import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCooldownPolicy;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerDirectionMode;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerOriginMode;
 import jp.aquafactory.apprenticecodex.spell.AbstractSummonWeaponSpell;
@@ -149,6 +151,60 @@ public final class ApprenticeCodexRemoteOwnerCastGameTests {
         helper.assertFalse(amulet.canImbueSpell(SpellRegistry.RAISE_DEAD_SPELL.get(), 1),
                 "Satellite Followcast Amulet should keep rejecting recast spells.");
         helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void remoteOwnerCooldownRespectsCreativeConfig(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = ApprenticeCodexGameTestScenarios.createEquipmentTestPlayer(
+                    helper,
+                    new net.minecraft.core.BlockPos(0, 2, 0),
+                    "remote_owner_creative_cooldown_test"
+            );
+            var magicData = MagicData.getPlayerMagicData(player);
+            helper.assertTrue(magicData != null, "Remote Owner creative cooldown test requires MagicData");
+            var spell = jp.aquafactory.apprenticecodex.registry.SpellRegistry.MAGE_LIGHT.get();
+            var spellData = new SpellData(spell, 1);
+            var originalCreativeCooldown = io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.get();
+
+            try {
+                player.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.CREATIVE);
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(false);
+                RemoteOwnerCooldownManager.addCooldown(
+                        player,
+                        spellData,
+                        CastSource.SWORD,
+                        RemoteOwnerCooldownPolicy.WEAPON_IMBUE
+                );
+                helper.assertFalse(magicData.getPlayerCooldowns().isOnCooldown(spell),
+                        "Remote Owner should skip creative cooldowns when Iron's setting is disabled");
+
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(true);
+                RemoteOwnerCooldownManager.addCooldown(
+                        player,
+                        spellData,
+                        CastSource.SWORD,
+                        RemoteOwnerCooldownPolicy.WEAPON_IMBUE
+                );
+                helper.assertTrue(magicData.getPlayerCooldowns().isOnCooldown(spell),
+                        "Remote Owner should apply creative cooldowns when Iron's setting is enabled");
+
+                magicData.getPlayerCooldowns().clearCooldowns();
+                player.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.SURVIVAL);
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(false);
+                RemoteOwnerCooldownManager.addCooldown(
+                        player,
+                        spellData,
+                        CastSource.SWORD,
+                        RemoteOwnerCooldownPolicy.WEAPON_IMBUE
+                );
+                helper.assertTrue(magicData.getPlayerCooldowns().isOnCooldown(spell),
+                        "Remote Owner should keep applying survival cooldowns");
+            } finally {
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(originalCreativeCooldown);
+                magicData.getPlayerCooldowns().clearCooldowns();
+            }
+        });
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -643,6 +643,11 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     }
 
     @GameTest(template = TEMPLATE, batch = MULTICAST_ECHO_STAFF_ISOLATED_BATCH, timeoutTicks = 80)
+    public static void multicastEchoStaffCreativeCastSkipsFinalCooldown(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.multicastEchoStaffCreativeCastSkipsFinalCooldown(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = MULTICAST_ECHO_STAFF_ISOLATED_BATCH, timeoutTicks = 80)
     public static void multicastEchoStaffInsufficientManaEndsWithPenaltyCooldown(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.multicastEchoStaffInsufficientManaEndsWithPenaltyCooldown(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/BulwarkGreatshieldGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/BulwarkGreatshieldGameTestScenarios.java
@@ -472,6 +472,68 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
         helper.succeed();
     }
 
+    static void continuousShieldCreativeFinishSkipsCooldown(GameTestHelper helper) {
+        var spell = SpellRegistry.FIRE_BREATH_SPELL.get();
+        var bulwarkPlayer = BowGameTestSupport.createEquipmentTestPlayer(
+                helper, new BlockPos(0, 2, 0), "bulwark_creative_continuous_finish_test"
+        );
+        bulwarkPlayer.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.CREATIVE);
+        helper.assertTrue(bulwarkPlayer.isCreative(), "Bulwark creative cooldown test requires creative mode");
+        var bulwarkStack = createContinuousCastShieldStack(ItemRegistry.BULWARK_GREATSHIELD.get());
+        bulwarkPlayer.setItemInHand(InteractionHand.OFF_HAND, bulwarkStack);
+        bulwarkStack.getItem().use(helper.getLevel(), bulwarkPlayer, InteractionHand.OFF_HAND);
+        var bulwarkMagicData = MagicData.getPlayerMagicData(bulwarkPlayer);
+        helper.assertTrue(bulwarkMagicData != null, "Bulwark creative finish test requires MagicData");
+        bulwarkMagicData.setMana(1000.0F);
+        BulwarkGreatshieldRuntime.tryStartContinuousCast(
+                bulwarkPlayer, bulwarkStack, InteractionHand.OFF_HAND
+        );
+        helper.assertTrue(bulwarkMagicData.isCasting(),
+                "Bulwark creative finish test should start from an active cast");
+        helper.assertFalse(bulwarkMagicData.getPlayerCooldowns().isOnCooldown(spell),
+                "Bulwark creative finish test should not begin with a cooldown");
+        var originalCreativeCooldown = io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.get();
+        try {
+            io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(false);
+            BulwarkGreatshieldRuntime.finishUse(bulwarkPlayer);
+        } finally {
+            io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(originalCreativeCooldown);
+        }
+        helper.assertFalse(bulwarkMagicData.getPlayerCooldowns().isOnCooldown(spell),
+                "Bulwark creative finish should respect disabled creative cooldowns");
+
+        var reflectcastPlayer = BowGameTestSupport.createEquipmentTestPlayer(
+                helper, new BlockPos(2, 2, 0), "reflectcast_creative_continuous_finish_test"
+        );
+        reflectcastPlayer.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.CREATIVE);
+        helper.assertTrue(reflectcastPlayer.isCreative(), "Reflectcast creative cooldown test requires creative mode");
+        var reflectcastStack = createContinuousCastShieldStack(ItemRegistry.REFLECTCAST_SHIELD.get());
+        ReflectcastShield.setCalibrationAdjustment(
+                reflectcastStack,
+                0,
+                new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
+        );
+        reflectcastPlayer.setItemInHand(InteractionHand.OFF_HAND, reflectcastStack);
+        reflectcastStack.getItem().use(helper.getLevel(), reflectcastPlayer, InteractionHand.OFF_HAND);
+        var reflectcastMagicData = MagicData.getPlayerMagicData(reflectcastPlayer);
+        helper.assertTrue(reflectcastMagicData != null, "Reflectcast creative finish test requires MagicData");
+        reflectcastMagicData.setMana(1000.0F);
+        helper.assertTrue(ReflectcastShieldRuntime.tryTriggerSpell(
+                        reflectcastPlayer, reflectcastStack, InteractionHand.OFF_HAND),
+                "Reflectcast creative finish test should start from an active cast");
+        helper.assertFalse(reflectcastMagicData.getPlayerCooldowns().isOnCooldown(spell),
+                "Reflectcast creative finish test should not begin with a cooldown");
+        try {
+            io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(false);
+            ReflectcastShieldRuntime.finishUse(reflectcastPlayer);
+        } finally {
+            io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(originalCreativeCooldown);
+        }
+        helper.assertFalse(reflectcastMagicData.getPlayerCooldowns().isOnCooldown(spell),
+                "Reflectcast creative finish should respect disabled creative cooldowns");
+        helper.succeed();
+    }
+
     private static ItemStack createContinuousCastShieldStack(net.minecraft.world.item.Item shieldItem) {
         var stack = new ItemStack(shieldItem);
         var spellContainer = ISpellContainer.create(1, false, false).mutableCopy();

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/FocusStaffbowGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/FocusStaffbowGameTestScenarios.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.gametest;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
+import io.redspace.ironsspellbooks.api.spells.CastSource;
 import java.util.List;
 import java.util.UUID;
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
@@ -962,6 +963,91 @@ final class FocusStaffbowGameTestScenarios {
             helper.assertTrue(Math.abs(magicData.getMana() - 17.0F) < 1.0e-4F,
                     "Focus Staffbow creative overcharge test should leave mana unchanged but got " + magicData.getMana());
             helper.succeed();
+        });
+    }
+
+    static void focusStaffbowCreativeContinuousReleaseSkipsCooldown(GameTestHelper helper) {
+        var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "focus_staffbow_creative_continuous_cooldown_test");
+        player.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.CREATIVE);
+        var bowStack = new ItemStack(ItemRegistry.FOCUS_STAFFBOW.get());
+        var amplifierItem = (jp.aquafactory.apprenticecodex.item.AbstractOffhandMagicItem) ItemRegistry.COPPER_SPELL_AMPLIFIER.get();
+        var amplifierStack = new ItemStack(amplifierItem);
+        amplifierItem.initializeSpellContainer(amplifierStack);
+        var spell = jp.aquafactory.apprenticecodex.registry.SpellRegistry.FORCE_FIELD.get();
+        setSingleUnlockedSpell(helper, amplifierStack, spell, 1);
+
+        player.setItemInHand(InteractionHand.MAIN_HAND, bowStack);
+        player.setItemInHand(InteractionHand.OFF_HAND, amplifierStack);
+        setFocusStaffbowArrowCatalyst(player, new ItemStack(Items.ARROW, 1));
+        var magicData = MagicData.getPlayerMagicData(player);
+        helper.assertTrue(magicData != null, "Focus Staffbow creative continuous cooldown test requires MagicData");
+        magicData.setMana(1000.0F);
+
+        helper.runAtTickTime(1, () -> {
+            var result = bowStack.getItem().use(helper.getLevel(), player, InteractionHand.MAIN_HAND);
+            helper.assertTrue(result.getResult().consumesAction(),
+                    "Focus Staffbow creative continuous cooldown test should start casting");
+        });
+        helper.runAtTickTime(3, () -> {
+            var originalCreativeCooldown = io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.get();
+            try {
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(false);
+                bowStack.getItem().releaseUsing(
+                        bowStack,
+                        helper.getLevel(),
+                        player,
+                        bowStack.getUseDuration() - 2
+                );
+            } finally {
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(originalCreativeCooldown);
+            }
+        });
+        helper.runAtTickTime(4, () -> {
+            helper.assertFalse(magicData.getPlayerCooldowns().isOnCooldown(spell),
+                    "Focus Staffbow creative CONTINUOUS release should respect disabled creative cooldowns");
+            helper.succeed();
+        });
+    }
+
+    static void focusStaffbowCreativeInterruptionSkipsPreviousSpellCooldown(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = ApprenticeCodexGameTestScenarios.createTrackedEquipmentTestPlayer(
+                    helper,
+                    new BlockPos(0, 2, 0),
+                    "focus_staffbow_creative_interruption_cooldown_test"
+            );
+            player.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.CREATIVE);
+            var bowStack = new ItemStack(ItemRegistry.FOCUS_STAFFBOW.get());
+            var amplifierItem = (jp.aquafactory.apprenticecodex.item.AbstractOffhandMagicItem) ItemRegistry.COPPER_SPELL_AMPLIFIER.get();
+            var amplifierStack = new ItemStack(amplifierItem);
+            amplifierItem.initializeSpellContainer(amplifierStack);
+            setSingleUnlockedSpell(
+                    helper,
+                    amplifierStack,
+                    jp.aquafactory.apprenticecodex.registry.SpellRegistry.MANA_SLASH.get(),
+                    1
+            );
+            player.setItemInHand(InteractionHand.MAIN_HAND, bowStack);
+            player.setItemInHand(InteractionHand.OFF_HAND, amplifierStack);
+            setFocusStaffbowArrowCatalyst(player, new ItemStack(Items.ARROW, 1));
+
+            var interruptedSpell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.FIRE_BREATH_SPELL.get();
+            var magicData = MagicData.getPlayerMagicData(player);
+            helper.assertTrue(magicData != null, "Focus Staffbow creative interruption test requires MagicData");
+            magicData.initiateCast(interruptedSpell, 1, 60, CastSource.SPELLBOOK, "gametest");
+
+            var originalCreativeCooldown = io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.get();
+            net.minecraft.world.InteractionResultHolder<ItemStack> result;
+            try {
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(false);
+                result = bowStack.getItem().use(helper.getLevel(), player, InteractionHand.MAIN_HAND);
+            } finally {
+                io.redspace.ironsspellbooks.config.ServerConfigs.CREATIVE_COOLDOWN.set(originalCreativeCooldown);
+            }
+            helper.assertTrue(result.getResult().consumesAction(),
+                    "Focus Staffbow should accept input after interrupting a different creative cast");
+            helper.assertFalse(magicData.getPlayerCooldowns().isOnCooldown(interruptedSpell),
+                    "Focus Staffbow creative interruption should respect disabled creative cooldowns");
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmuletAutoCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmuletAutoCastEvent.java
@@ -134,6 +134,7 @@ public final class AutocastAmuletAutoCastEvent {
 
             if (!spell.checkPreCastConditions(player.level(), spellLevel, player, magicData)) {
                 magicData.resetAdditionalCastData();
+                // 条件不成立を毎 tick 再試行しないため、クリエイティブでも意図的に待機時間を設ける。
                 io.redspace.ironsspellbooks.api.magic.MagicHelper.MAGIC_MANAGER.addCooldown(player, spell, CastSource.SWORD);
                 scheduleRetry(slotResult.stack(), player.tickCount, index);
                 return SequenceResult.BLOCKED;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmuletCastEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmuletCastEvent.java
@@ -135,6 +135,7 @@ public final class AutocastAmuletCastEvent {
             return;
         }
 
+        // Autocast Amulet は連続発動を防ぐため、creativeCooldowns が無効でも意図的にクールダウンを付与する。
         MagicHelper.MAGIC_MANAGER.addCooldown(player, spell, pendingCooldown.castSource());
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/focusstaffbow/FocusStaffbowCastManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/focusstaffbow/FocusStaffbowCastManager.java
@@ -2,7 +2,6 @@
 
 import io.redspace.ironsspellbooks.api.events.SpellPreCastEvent;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
-import io.redspace.ironsspellbooks.api.magic.MagicHelper;
 import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
 import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
@@ -29,6 +28,7 @@ import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.SyncFocusStaffbowCastStatePacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncFocusStaffbowPresentationPacket;
 import jp.aquafactory.apprenticecodex.spell.AbstractSummonWeaponSpell;
+import jp.aquafactory.apprenticecodex.utility.SpellCooldownHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
 import net.minecraft.server.level.ServerPlayer;
@@ -665,7 +665,11 @@ public final class FocusStaffbowCastManager {
             var spell = SpellRegistry.getSpell(state.spellId);
             if (spell != null && spell != SpellRegistry.none()) {
                 if (triggerCooldown) {
-                    MagicHelper.MAGIC_MANAGER.addCooldown(player, spell, resolveCastSource(state.castSource));
+                    SpellCooldownHelper.addCooldownRespectingCreativeConfig(
+                            player,
+                            spell,
+                            resolveCastSource(state.castSource)
+                    );
                 }
                 spell.onServerCastComplete(player.level(), state.spellLevel, player, magicData, true);
             } else {
@@ -866,7 +870,7 @@ public final class FocusStaffbowCastManager {
         var spell = magicData.getCastingSpell().getSpell();
         if (spell != null && spell != SpellRegistry.none()) {
             if (magicData.getCastType() != CastType.LONG) {
-                MagicHelper.MAGIC_MANAGER.addCooldown(player, spell, magicData.getCastSource());
+                SpellCooldownHelper.addCooldownRespectingCreativeConfig(player, spell, magicData.getCastSource());
             }
             if (magicData.getCastSource() == CastSource.SCROLL && magicData.getCastType() == CastType.CONTINUOUS) {
                 Scroll.attemptRemoveScrollAfterCast(player);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/multicastechostaff/MulticastEchoStaffCastHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/multicastechostaff/MulticastEchoStaffCastHelper.java
@@ -2,7 +2,6 @@ package jp.aquafactory.apprenticecodex.item.multicastechostaff;
 
 import io.redspace.ironsspellbooks.api.events.SpellCooldownAddedEvent;
 import io.redspace.ironsspellbooks.api.events.SpellPreCastEvent;
-import io.redspace.ironsspellbooks.api.magic.MagicHelper;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
@@ -14,6 +13,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.item.MulticastEchoStaff;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
+import jp.aquafactory.apprenticecodex.utility.SpellCooldownHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -450,7 +450,7 @@ public final class MulticastEchoStaffCastHelper {
         MULTICAST_JOBS.remove(player.getUUID(), job);
         var context = new FinalCooldownContext(job.spellId(), job.spellLevel(), job.amplifier());
         FINAL_COOLDOWN_CONTEXTS.put(player.getUUID(), context);
-        MagicHelper.MAGIC_MANAGER.addCooldown(player, spell, job.castSource());
+        SpellCooldownHelper.addCooldownRespectingCreativeConfig(player, spell, job.castSource());
         FINAL_COOLDOWN_CONTEXTS.remove(player.getUUID(), context);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/BulwarkGreatshieldRuntime.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/BulwarkGreatshieldRuntime.java
@@ -1,7 +1,6 @@
 package jp.aquafactory.apprenticecodex.item.shield;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
-import io.redspace.ironsspellbooks.api.magic.MagicHelper;
 import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
 import io.redspace.ironsspellbooks.api.events.SpellPreCastEvent;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
@@ -11,6 +10,7 @@ import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import io.redspace.ironsspellbooks.setup.PacketDistributor;
 import jp.aquafactory.apprenticecodex.item.continuouscast.ContinuousCastDurationSimulation;
 import jp.aquafactory.apprenticecodex.mixin.MagicDataAccessor;
+import jp.aquafactory.apprenticecodex.utility.SpellCooldownHelper;
 import net.minecraft.network.chat.ComponentContents;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
@@ -259,7 +259,11 @@ public final class BulwarkGreatshieldRuntime {
             boolean preserveShieldUse
     ) {
         if (triggerCooldown) {
-            MagicHelper.MAGIC_MANAGER.addCooldown(player, activeCast.spell(), activeCast.castSource());
+            SpellCooldownHelper.addCooldownRespectingCreativeConfig(
+                    player,
+                    activeCast.spell(),
+                    activeCast.castSource()
+            );
         }
         var finishCast = (Runnable) () -> activeCast.spell().onServerCastComplete(
                 player.level(), activeCast.spellLevel(), player, magicData, true

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ReflectcastShieldRuntime.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ReflectcastShieldRuntime.java
@@ -3,7 +3,6 @@ package jp.aquafactory.apprenticecodex.item.shield;
 import io.redspace.ironsspellbooks.api.events.SpellPreCastEvent;
 import io.redspace.ironsspellbooks.api.events.SpellCooldownAddedEvent;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
-import io.redspace.ironsspellbooks.api.magic.MagicHelper;
 import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
@@ -16,6 +15,7 @@ import jp.aquafactory.apprenticecodex.mixin.LivingEntityAccessor;
 import jp.aquafactory.apprenticecodex.mixin.MagicDataAccessor;
 import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.SyncReflectcastShieldEffectPacket;
+import jp.aquafactory.apprenticecodex.utility.SpellCooldownHelper;
 import net.minecraft.network.protocol.game.ClientboundSetActionBarTextPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -346,7 +346,11 @@ public final class ReflectcastShieldRuntime {
             boolean preserveShieldUse
     ) {
         if (triggerCooldown) {
-            MagicHelper.MAGIC_MANAGER.addCooldown(player, activeCast.spell(), activeCast.castSource());
+            SpellCooldownHelper.addCooldownRespectingCreativeConfig(
+                    player,
+                    activeCast.spell(),
+                    activeCast.castSource()
+            );
         }
         var finishCast = (Runnable) () -> activeCast.spell().onServerCastComplete(
                 player.level(), activeCast.spellLevel(), player, magicData, true

--- a/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCooldownManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/remoteownercast/RemoteOwnerCooldownManager.java
@@ -1,12 +1,12 @@
 package jp.aquafactory.apprenticecodex.remoteownercast;
 
 import io.redspace.ironsspellbooks.api.events.SpellCooldownAddedEvent;
-import io.redspace.ironsspellbooks.api.magic.MagicHelper;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.CastType;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
+import jp.aquafactory.apprenticecodex.utility.SpellCooldownHelper;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -49,7 +49,7 @@ public final class RemoteOwnerCooldownManager {
                 resolveExtraCooldownTicks(owner, spellData, policy)
         ));
         try {
-            MagicHelper.MAGIC_MANAGER.addCooldown(owner, spell, castSource);
+            SpellCooldownHelper.addCooldownRespectingCreativeConfig(owner, spell, castSource);
         } finally {
             PENDING_COOLDOWNS.remove(owner.getUUID());
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/SpellCooldownHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/SpellCooldownHelper.java
@@ -1,0 +1,26 @@
+package jp.aquafactory.apprenticecodex.utility;
+
+import io.redspace.ironsspellbooks.api.magic.MagicHelper;
+import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
+import io.redspace.ironsspellbooks.api.spells.CastSource;
+import io.redspace.ironsspellbooks.config.ServerConfigs;
+import net.minecraft.server.level.ServerPlayer;
+
+public final class SpellCooldownHelper {
+    private SpellCooldownHelper() {
+    }
+
+    public static void addCooldownRespectingCreativeConfig(
+            ServerPlayer player,
+            AbstractSpell spell,
+            CastSource castSource
+    ) {
+        // Iron's 1.20.1 では creativeCooldowns 判定が AbstractSpell.castSpell 内にあるため、
+        // MagicManager を直接使う独自詠唱経路では同じ判定をここで補う。
+        if (player.isCreative() && !ServerConfigs.CREATIVE_COOLDOWN.get()) {
+            return;
+        }
+
+        MagicHelper.MAGIC_MANAGER.addCooldown(player, spell, castSource);
+    }
+}


### PR DESCRIPTION
- `AutocastAmulet`は迂回すると発動がスパム化するため意図的に付与
- `runGameTestServer`確認済み