### PR TITLE
フィールドオーバーシアーの杖が消えないことがある不具合の対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -158,6 +158,7 @@ import jp.aquafactory.apprenticecodex.spell.dualacrobat.DualAcrobatSmgEntity;
 import jp.aquafactory.apprenticecodex.spell.earthforge.EarthForge;
 import jp.aquafactory.apprenticecodex.spell.extract.ExtractPotionProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.fieldoverseer.FieldOverseer;
+import jp.aquafactory.apprenticecodex.spell.fieldoverseer.FieldOverseerManager;
 import jp.aquafactory.apprenticecodex.spell.fieldoverseer.FieldOverseerStaffEntity;
 import jp.aquafactory.apprenticecodex.spell.flyswatter.FlySwatterProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.grindrunner.GrindRunnerWheelEntity;
@@ -7149,15 +7150,17 @@ public class ApprenticeCodexGameTestScenarios {
         });
     }
 
-    static void fieldOverseerCastDataRoundTripsPlacementAndSummons(GameTestHelper helper) {
+    static void fieldOverseerCastDataRoundTripsPlacementAndIdentity(GameTestHelper helper) {
         var source = new FieldOverseer.FieldOverseerCastData();
         var expectedPosition = helper.absolutePos(new BlockPos(1, 2, 3));
+        var expectedStaffUuid = UUID.randomUUID();
+        var expectedDimension = helper.getLevel().dimension().location();
         var sourceTag = new CompoundTag();
         sourceTag.putLong("Position", expectedPosition.asLong());
+        sourceTag.putUUID("Staff", expectedStaffUuid);
+        sourceTag.putString("Dimension", expectedDimension.toString());
         source.deserializeNBT(sourceTag);
 
-        var marker = helper.spawn(EntityType.ARMOR_STAND, new BlockPos(0, 2, 0));
-        source.add(marker);
         var buffer = new FriendlyByteBuf(Unpooled.buffer());
         source.writeToBuffer(buffer);
 
@@ -7166,8 +7169,10 @@ public class ApprenticeCodexGameTestScenarios {
         var restoredTag = restored.serializeNBT();
         helper.assertTrue(restoredTag.getLong("Position") == expectedPosition.asLong(),
                 "FieldOverseer cast data should preserve placement through network serialization");
-        helper.assertTrue(restored.getSummons().contains(marker.getUUID()),
-                "FieldOverseer cast data should preserve summons through network serialization");
+        helper.assertTrue(restoredTag.getUUID("Staff").equals(expectedStaffUuid),
+                "FieldOverseer cast data should preserve the managed staff UUID");
+        helper.assertTrue(restoredTag.getString("Dimension").equals(expectedDimension.toString()),
+                "FieldOverseer cast data should preserve the managed dimension");
         helper.succeed();
     }
 
@@ -7195,6 +7200,10 @@ public class ApprenticeCodexGameTestScenarios {
                 "FieldOverseer staff should survive chunk save and reload during its summon duration");
         helper.assertFalse(staff.removeWhenFarAway(Double.MAX_VALUE),
                 "FieldOverseer staff should not despawn when the owner moves far away");
+        var savedStaff = new CompoundTag();
+        staff.saveWithoutId(savedStaff);
+        helper.assertTrue(savedStaff.contains("ExpirationGameTime"),
+                "FieldOverseer staff should persist its absolute expiration time");
         helper.succeed();
     }
 
@@ -7235,8 +7244,51 @@ public class ApprenticeCodexGameTestScenarios {
         });
     }
 
+    static void fieldOverseerCancelledWhileUnloadedDoesNotReturn(GameTestHelper helper) {
+        var owner = createEquipmentTestPlayer(helper, new BlockPos(0, 2, -2), "field_overseer_unloaded_cancel_test");
+        var anchorPos = new BlockPos(0, 2, 0);
+        helper.setBlock(anchorPos.below(), Blocks.STONE);
+        var staff = createDurationBoundFieldOverseer(helper, owner, 1, anchorPos, 200);
+        var savedStaff = new CompoundTag();
+        staff.saveWithoutId(savedStaff);
+        staff.remove(net.minecraft.world.entity.Entity.RemovalReason.UNLOADED_TO_CHUNK);
+
+        FieldOverseerManager.cancel(owner);
+        var magicData = MagicData.getPlayerMagicData(owner);
+        helper.assertFalse(magicData.getPlayerRecasts().hasRecastForSpell(SpellRegistry.FIELD_OVERSEER.get()),
+                "FieldOverseer cancel should remove recast data while the staff is unloaded");
+        helper.assertTrue(magicData.getPlayerCooldowns().isOnCooldown(SpellRegistry.FIELD_OVERSEER.get()),
+                "FieldOverseer cancel should apply the normal cooldown");
+
+        var restored = new FieldOverseerStaffEntity(EntityRegistry.FIELD_OVERSEER_STAFF.get(), helper.getLevel());
+        restored.load(savedStaff);
+        helper.getLevel().addFreshEntity(restored);
+        helper.succeedWhen(() -> helper.assertTrue(restored.isRemoved(),
+                "FieldOverseer loaded after cancellation should discard itself before acting"));
+    }
+
+    static void fieldOverseerDestructionEndsMatchingRecast(GameTestHelper helper) {
+        var owner = createEquipmentTestPlayer(helper, new BlockPos(0, 2, -2), "field_overseer_destroy_test");
+        var anchorPos = new BlockPos(0, 2, 0);
+        helper.setBlock(anchorPos.below(), Blocks.STONE);
+        var staff = createDurationBoundFieldOverseer(helper, owner, 1, anchorPos, 200);
+        var magicData = MagicData.getPlayerMagicData(owner);
+
+        staff.remove(net.minecraft.world.entity.Entity.RemovalReason.KILLED);
+
+        helper.assertFalse(magicData.getPlayerRecasts().hasRecastForSpell(SpellRegistry.FIELD_OVERSEER.get()),
+                "Destroying FieldOverseer should remove its matching recast");
+        helper.assertTrue(magicData.getPlayerCooldowns().isOnCooldown(SpellRegistry.FIELD_OVERSEER.get()),
+                "Destroying FieldOverseer should apply the normal cooldown");
+        helper.succeed();
+    }
+
     static void fieldOverseerPrioritizesHealthAndTransfersMana(GameTestHelper helper) {
         var owner = createEquipmentTestPlayer(helper, new BlockPos(0, 2, -2), "field_overseer_attack_test");
+        var manaRegen = owner.getAttribute(AttributeRegistry.MANA_REGEN.get());
+        if (manaRegen != null) {
+            manaRegen.setBaseValue(0.0D);
+        }
         var ownerMagicData = MagicData.getPlayerMagicData(owner);
         ownerMagicData.setMana(75.0F);
         var anchorPos = helper.absolutePos(new BlockPos(0, 2, 0));
@@ -7275,30 +7327,36 @@ public class ApprenticeCodexGameTestScenarios {
 
     private static FieldOverseerStaffEntity createFieldOverseerTestEntity(
             GameTestHelper helper, FakePlayer owner, BlockPos anchorPos, float maxMana, int attackManaCost) {
-        var level = helper.getLevel();
-        var center = Vec3.atBottomCenterOf(anchorPos);
-        var staff = new FieldOverseerStaffEntity(EntityRegistry.FIELD_OVERSEER_STAFF.get(), level);
-        staff.setOwner(owner);
-        staff.configure(anchorPos, 4.0F, 24.0D, attackManaCost, maxMana, 20);
-        staff.moveTo(center.x, center.y, center.z, 0.0F, 0.0F);
-        level.addFreshEntity(staff);
-        io.redspace.ironsspellbooks.capabilities.magic.SummonManager.setOwner(staff, owner);
-        return staff;
+        return createDurationBoundFieldOverseer(
+                helper, owner, 1, anchorPos, maxMana, attackManaCost,
+                ((FieldOverseer) SpellRegistry.FIELD_OVERSEER.get()).getDuration());
     }
 
     private static FieldOverseerStaffEntity createDurationBoundFieldOverseer(
             GameTestHelper helper, FakePlayer owner, int spellLevel, BlockPos anchorPos, int duration) {
-        helper.getLevel().addFreshEntity(owner);
-        var staff = createFieldOverseerTestEntity(
-                helper, owner, helper.absolutePos(anchorPos), 100.0F, 40);
+        return createDurationBoundFieldOverseer(
+                helper, owner, spellLevel, helper.absolutePos(anchorPos), 100.0F, 40, duration);
+    }
+
+    private static FieldOverseerStaffEntity createDurationBoundFieldOverseer(
+            GameTestHelper helper, FakePlayer owner, int spellLevel, BlockPos anchorPos,
+            float maxMana, int attackManaCost, int duration) {
+        var level = helper.getLevel();
+        level.addFreshEntity(owner);
+        var center = Vec3.atBottomCenterOf(anchorPos);
+        var staff = new FieldOverseerStaffEntity(EntityRegistry.FIELD_OVERSEER_STAFF.get(), level);
+        staff.configure(anchorPos, 4.0F, 24.0D, attackManaCost, maxMana, 20);
+        staff.moveTo(center.x, center.y, center.z, 0.0F, 0.0F);
         var castData = new FieldOverseer.FieldOverseerCastData();
+        FieldOverseerManager.initialize(owner, staff, anchorPos, duration, castData);
+        level.addFreshEntity(staff);
         var spell = (FieldOverseer) SpellRegistry.FIELD_OVERSEER.get();
-        io.redspace.ironsspellbooks.capabilities.magic.SummonManager.initSummon(
-                owner, staff, duration, castData);
         var magicData = MagicData.getPlayerMagicData(owner);
         magicData.getPlayerRecasts().addRecast(new RecastInstance(
                 spell.getSpellId(), spellLevel, spell.getRecastCount(spellLevel, owner),
                 duration, CastSource.SPELLBOOK, castData), magicData);
+        helper.assertFalse(SummonManager.getSummons(owner).contains(staff.getUUID()),
+                "FieldOverseer should not register itself with Iron's SummonManager");
         return staff;
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellBehaviorGameTests.java
@@ -348,8 +348,8 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     }
 
     @GameTest(template = TEMPLATE, batch = FIELD_OVERSEER_ISOLATED_BATCH)
-    public static void fieldOverseerCastDataRoundTripsPlacementAndSummons(GameTestHelper helper) {
-        ApprenticeCodexGameTestScenarios.fieldOverseerCastDataRoundTripsPlacementAndSummons(helper);
+    public static void fieldOverseerCastDataRoundTripsPlacementAndIdentity(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.fieldOverseerCastDataRoundTripsPlacementAndIdentity(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = FIELD_OVERSEER_ISOLATED_BATCH)
@@ -370,6 +370,16 @@ public final class ApprenticeCodexSpellBehaviorGameTests {
     @GameTest(template = TEMPLATE, batch = FIELD_OVERSEER_LIFECYCLE_BATCH)
     public static void fieldOverseerTimeoutRemovesPlacedStaff(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.fieldOverseerTimeoutRemovesPlacedStaff(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = FIELD_OVERSEER_LIFECYCLE_BATCH)
+    public static void fieldOverseerCancelledWhileUnloadedDoesNotReturn(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.fieldOverseerCancelledWhileUnloadedDoesNotReturn(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = FIELD_OVERSEER_LIFECYCLE_BATCH)
+    public static void fieldOverseerDestructionEndsMatchingRecast(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.fieldOverseerDestructionEndsMatchingRecast(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = FIELD_OVERSEER_ISOLATED_BATCH, timeoutTicks = 100)

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseer.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseer.java
@@ -14,8 +14,6 @@ import io.redspace.ironsspellbooks.api.util.AnimationHolder;
 import io.redspace.ironsspellbooks.api.util.Utils;
 import io.redspace.ironsspellbooks.capabilities.magic.RecastInstance;
 import io.redspace.ironsspellbooks.capabilities.magic.RecastResult;
-import io.redspace.ironsspellbooks.capabilities.magic.SummonManager;
-import io.redspace.ironsspellbooks.capabilities.magic.SummonedEntitiesCastData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.DamageMultiplierKey;
@@ -44,6 +42,7 @@ import net.minecraft.world.level.Level;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public class FieldOverseer extends AbstractSpell implements IClientBlockTargetingSpell,
         IClientBlockTargetCaptureSpell, IClientPlacementPreviewSpell {
@@ -208,10 +207,10 @@ public class FieldOverseer extends AbstractSpell implements IClientBlockTargetin
                     );
                     staff.moveTo(placement.get().center().x, placement.get().center().y, placement.get().center().z,
                             entity.getYRot(), 0.0F);
-                    serverLevel.addFreshEntity(staff);
-
                     var castData = new FieldOverseerCastData();
-                    SummonManager.initSummon(entity, staff, getDuration(), castData);
+                    FieldOverseerManager.initialize(
+                            entity, staff, placement.get().blockPos(), getDuration(), castData);
+                    serverLevel.addFreshEntity(staff);
                     recasts.addRecast(new RecastInstance(
                             getSpellId(), spellLevel, getRecastCount(spellLevel, entity), getDuration(), castSource, castData),
                             playerMagicData);
@@ -224,7 +223,7 @@ public class FieldOverseer extends AbstractSpell implements IClientBlockTargetin
     @Override
     public void onRecastFinished(ServerPlayer serverPlayer, RecastInstance recastInstance, RecastResult recastResult,
                                  ICastDataSerializable castDataSerializable) {
-        if (SummonManager.recastFinishedHelper(serverPlayer, recastInstance, recastResult, castDataSerializable)) {
+        if (FieldOverseerManager.finishRecast(serverPlayer, recastInstance, recastResult, castDataSerializable)) {
             super.onRecastFinished(serverPlayer, recastInstance, recastResult, castDataSerializable);
         }
     }
@@ -255,39 +254,70 @@ public class FieldOverseer extends AbstractSpell implements IClientBlockTargetin
         }
     }
 
-    public static class FieldOverseerCastData extends SummonedEntitiesCastData {
+    public static class FieldOverseerCastData implements ICastDataSerializable {
         private BlockPos position;
+        private UUID staffUuid;
+        private ResourceLocation dimension;
+
+        void bindStaff(FieldOverseerStaffEntity staff, BlockPos position) {
+            this.position = position.immutable();
+            staffUuid = staff.getUUID();
+            dimension = staff.level().dimension().location();
+        }
+
+        boolean matches(FieldOverseerStaffEntity staff) {
+            return staffUuid != null
+                    && staffUuid.equals(staff.getUUID())
+                    && dimension != null
+                    && dimension.equals(staff.level().dimension().location());
+        }
+
+        UUID getStaffUuid() {
+            return staffUuid;
+        }
+
+        ResourceLocation getDimension() {
+            return dimension;
+        }
 
         @Override
         public void writeToBuffer(FriendlyByteBuf buffer) {
-            super.writeToBuffer(buffer);
             buffer.writeBoolean(position != null);
             if (position != null) buffer.writeBlockPos(position);
+            buffer.writeBoolean(staffUuid != null);
+            if (staffUuid != null) buffer.writeUUID(staffUuid);
+            buffer.writeBoolean(dimension != null);
+            if (dimension != null) buffer.writeResourceLocation(dimension);
         }
 
         @Override
         public void readFromBuffer(FriendlyByteBuf buffer) {
-            super.readFromBuffer(buffer);
             position = buffer.readBoolean() ? buffer.readBlockPos() : null;
+            staffUuid = buffer.readBoolean() ? buffer.readUUID() : null;
+            dimension = buffer.readBoolean() ? buffer.readResourceLocation() : null;
         }
 
         @Override
         public void reset() {
-            super.reset();
             position = null;
+            staffUuid = null;
+            dimension = null;
         }
 
         @Override
         public CompoundTag serializeNBT() {
-            var tag = super.serializeNBT();
+            var tag = new CompoundTag();
             if (position != null) tag.putLong("Position", position.asLong());
+            if (staffUuid != null) tag.putUUID("Staff", staffUuid);
+            if (dimension != null) tag.putString("Dimension", dimension.toString());
             return tag;
         }
 
         @Override
         public void deserializeNBT(CompoundTag tag) {
-            super.deserializeNBT(tag);
             position = tag.contains("Position") ? BlockPos.of(tag.getLong("Position")) : null;
+            staffUuid = tag.hasUUID("Staff") ? tag.getUUID("Staff") : null;
+            dimension = tag.contains("Dimension") ? ResourceLocation.tryParse(tag.getString("Dimension")) : null;
         }
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseerEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseerEvents.java
@@ -1,0 +1,28 @@
+package jp.aquafactory.apprenticecodex.spell.fieldoverseer;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = ApprenticeCodex.MODID)
+public final class FieldOverseerEvents {
+    private FieldOverseerEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            FieldOverseerManager.cancel(player);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player) {
+            // 固定設置物を別ディメンションへ移さず、手動解除と同じ再詠唱終了として扱う。
+            FieldOverseerManager.cancel(player);
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseerManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseerManager.java
@@ -1,0 +1,123 @@
+package jp.aquafactory.apprenticecodex.spell.fieldoverseer;
+
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.api.spells.ICastDataSerializable;
+import io.redspace.ironsspellbooks.capabilities.magic.RecastInstance;
+import io.redspace.ironsspellbooks.capabilities.magic.RecastResult;
+import io.redspace.ironsspellbooks.registries.ItemRegistry;
+import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import org.jetbrains.annotations.Nullable;
+
+public final class FieldOverseerManager {
+    private FieldOverseerManager() {
+    }
+
+    public enum ValidationResult {
+        ACTIVE,
+        EXPIRED,
+        INVALID
+    }
+
+    public static void initialize(LivingEntity owner, FieldOverseerStaffEntity staff, BlockPos position, int duration,
+                                  FieldOverseer.FieldOverseerCastData castData) {
+        staff.setOwner(owner);
+        staff.setExpirationGameTime(staff.level().getGameTime() + duration);
+        castData.bindStaff(staff, position);
+    }
+
+    public static ValidationResult validate(FieldOverseerStaffEntity staff) {
+        if (!staff.hasExpirationGameTime()) {
+            return ValidationResult.INVALID;
+        }
+        if (staff.level().getGameTime() >= staff.getExpirationGameTime()) {
+            return ValidationResult.EXPIRED;
+        }
+        if (!staff.isPlayerOwned()) {
+            return ValidationResult.ACTIVE;
+        }
+        var owner = staff.resolvePlayerOwner();
+        if (owner == null || owner.level() != staff.level()) {
+            return ValidationResult.INVALID;
+        }
+        var recast = getActiveRecast(owner);
+        return recast != null
+                && recast.getCastData() instanceof FieldOverseer.FieldOverseerCastData castData
+                && castData.matches(staff)
+                ? ValidationResult.ACTIVE
+                : ValidationResult.INVALID;
+    }
+
+    public static boolean finishRecast(ServerPlayer player, RecastInstance recast, RecastResult result,
+                                       ICastDataSerializable rawCastData) {
+        if (result == RecastResult.COUNTERSPELL) {
+            // Iron's の既存召喚と同様、カウンタースペルでは設置済みの杖と再詠唱を維持する。
+            MagicData.getPlayerMagicData(player).getPlayerRecasts().forceAddRecast(recast);
+        } else if (rawCastData instanceof FieldOverseer.FieldOverseerCastData castData) {
+            discardLoadedStaff(player, castData);
+        }
+        return result != RecastResult.TIMEOUT
+                || !ItemRegistry.GREATER_CONJURERS_TALISMAN.get().isEquippedBy(player);
+    }
+
+    public static void cancel(ServerPlayer player) {
+        var recast = getActiveRecast(player);
+        if (recast != null) {
+            MagicData.getPlayerMagicData(player).getPlayerRecasts()
+                    .removeRecast(recast, RecastResult.USER_CANCEL);
+        }
+    }
+
+    public static void expire(FieldOverseerStaffEntity staff) {
+        var owner = staff.resolvePlayerOwner();
+        var recast = owner == null ? null : getMatchingRecast(owner, staff);
+        if (recast != null) {
+            MagicData.getPlayerMagicData(owner).getPlayerRecasts().removeRecast(recast, RecastResult.TIMEOUT);
+        } else {
+            staff.discardForLifecycle();
+        }
+    }
+
+    public static void onDestroyed(FieldOverseerStaffEntity staff) {
+        var owner = staff.resolvePlayerOwner();
+        var recast = owner == null ? null : getMatchingRecast(owner, staff);
+        if (recast != null) {
+            MagicData.getPlayerMagicData(owner).getPlayerRecasts()
+                    .removeRecast(recast, RecastResult.USED_ALL_RECASTS);
+        }
+    }
+
+    private static @Nullable RecastInstance getActiveRecast(ServerPlayer player) {
+        var recasts = MagicData.getPlayerMagicData(player).getPlayerRecasts();
+        var recast = recasts.getRecastInstance(SpellRegistry.FIELD_OVERSEER.get().getSpellId());
+        return recasts.isRecastActive(recast) ? recast : null;
+    }
+
+    private static @Nullable RecastInstance getMatchingRecast(ServerPlayer player,
+                                                               FieldOverseerStaffEntity staff) {
+        var recast = getActiveRecast(player);
+        return recast != null
+                && recast.getCastData() instanceof FieldOverseer.FieldOverseerCastData castData
+                && castData.matches(staff)
+                ? recast
+                : null;
+    }
+
+    private static void discardLoadedStaff(ServerPlayer player, FieldOverseer.FieldOverseerCastData castData) {
+        if (castData.getStaffUuid() == null || castData.getDimension() == null) {
+            return;
+        }
+        for (var level : player.server.getAllLevels()) {
+            if (!level.dimension().location().equals(castData.getDimension())) {
+                continue;
+            }
+            var entity = level.getEntity(castData.getStaffUuid());
+            if (entity instanceof FieldOverseerStaffEntity staff && staff.isOwnedBy(player)) {
+                staff.discardForLifecycle();
+            }
+            return;
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseerStaffEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/spell/fieldoverseer/FieldOverseerStaffEntity.java
@@ -1,7 +1,6 @@
 package jp.aquafactory.apprenticecodex.spell.fieldoverseer;
 
 import io.redspace.ironsspellbooks.api.magic.MagicData;
-import io.redspace.ironsspellbooks.capabilities.magic.SummonManager;
 import io.redspace.ironsspellbooks.entity.mobs.IMagicSummon;
 import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import io.redspace.ironsspellbooks.particle.ZapParticleOption;
@@ -89,6 +88,9 @@ public class FieldOverseerStaffEntity extends PathfinderMob implements GeoEntity
     private final List<UUID> selectedTargets = new ArrayList<>(MAX_TARGETS);
     private UUID ownerUuid;
     private LivingEntity cachedOwner;
+    private boolean playerOwned;
+    private long expirationGameTime = -1L;
+    private boolean lifecycleEnding;
 
     public FieldOverseerStaffEntity(EntityType<? extends PathfinderMob> type, Level level) {
         super(type, level);
@@ -142,7 +144,35 @@ public class FieldOverseerStaffEntity extends PathfinderMob implements GeoEntity
     public void setOwner(LivingEntity owner) {
         ownerUuid = owner.getUUID();
         cachedOwner = owner;
+        playerOwned = owner instanceof ServerPlayer;
         entityData.set(OWNER_UUID, Optional.of(ownerUuid));
+    }
+
+    void setExpirationGameTime(long expirationGameTime) {
+        this.expirationGameTime = expirationGameTime;
+    }
+
+    long getExpirationGameTime() {
+        return expirationGameTime;
+    }
+
+    boolean hasExpirationGameTime() {
+        return expirationGameTime >= 0L;
+    }
+
+    boolean isPlayerOwned() {
+        return playerOwned;
+    }
+
+    @Nullable ServerPlayer resolvePlayerOwner() {
+        if (!playerOwned || ownerUuid == null || !(level() instanceof ServerLevel serverLevel)) {
+            return null;
+        }
+        var onlinePlayer = serverLevel.getServer().getPlayerList().getPlayer(ownerUuid);
+        if (onlinePlayer != null) {
+            return onlinePlayer;
+        }
+        return serverLevel.getEntity(ownerUuid) instanceof ServerPlayer player ? player : null;
     }
 
     @Override
@@ -150,11 +180,12 @@ public class FieldOverseerStaffEntity extends PathfinderMob implements GeoEntity
         if (cachedOwner != null && !cachedOwner.isRemoved()) {
             return cachedOwner;
         }
-        var managedOwner = SummonManager.getOwner(this);
-        if (managedOwner instanceof LivingEntity livingOwner) {
-            ownerUuid = livingOwner.getUUID();
-            cachedOwner = livingOwner;
-            return livingOwner;
+        if (playerOwned) {
+            var player = resolvePlayerOwner();
+            if (player != null) {
+                cachedOwner = player;
+            }
+            return player;
         }
         if (ownerUuid != null && level() instanceof ServerLevel serverLevel
                 && serverLevel.getEntity(ownerUuid) instanceof LivingEntity livingOwner) {
@@ -176,6 +207,16 @@ public class FieldOverseerStaffEntity extends PathfinderMob implements GeoEntity
     }
 
     private void tickServer(ServerLevel level) {
+        var validation = FieldOverseerManager.validate(this);
+        if (validation == FieldOverseerManager.ValidationResult.EXPIRED) {
+            FieldOverseerManager.expire(this);
+            return;
+        }
+        if (validation == FieldOverseerManager.ValidationResult.INVALID) {
+            discardForLifecycle();
+            return;
+        }
+
         updateSupportState();
         transferOwnerMana(level);
 
@@ -407,16 +448,21 @@ public class FieldOverseerStaffEntity extends PathfinderMob implements GeoEntity
         discard();
     }
 
-    @Override
-    public void remove(@NotNull RemovalReason reason) {
-        super.remove(reason);
-        onRemovedHelper(this);
+    void discardForLifecycle() {
+        lifecycleEnding = true;
+        discard();
     }
 
     @Override
-    public void die(@NotNull DamageSource source) {
-        super.die(source);
-        onDeathHelper();
+    public void remove(@NotNull RemovalReason reason) {
+        var notifyOwner = reason.shouldDestroy() && !lifecycleEnding;
+        lifecycleEnding = true;
+        if (notifyOwner && !level().isClientSide) {
+            FieldOverseerManager.onDestroyed(this);
+        }
+        if (!isRemoved()) {
+            super.remove(reason);
+        }
     }
 
     @Override
@@ -453,6 +499,8 @@ public class FieldOverseerStaffEntity extends PathfinderMob implements GeoEntity
         tag.putFloat("MaxMana", getMaxStaffMana());
         tag.putInt("AttackManaCost", getAttackManaCost());
         if (ownerUuid != null) tag.putUUID("Owner", ownerUuid);
+        tag.putBoolean("PlayerOwned", playerOwned);
+        if (hasExpirationGameTime()) tag.putLong("ExpirationGameTime", expirationGameTime);
     }
 
     @Override
@@ -465,6 +513,8 @@ public class FieldOverseerStaffEntity extends PathfinderMob implements GeoEntity
         entityData.set(MAX_MANA, tag.getFloat("MaxMana"));
         entityData.set(ATTACK_MANA_COST, tag.getInt("AttackManaCost"));
         ownerUuid = tag.hasUUID("Owner") ? tag.getUUID("Owner") : null;
+        playerOwned = tag.getBoolean("PlayerOwned");
+        expirationGameTime = tag.contains("ExpirationGameTime") ? tag.getLong("ExpirationGameTime") : -1L;
         entityData.set(OWNER_UUID, Optional.ofNullable(ownerUuid));
         cachedOwner = null;
     }


### PR DESCRIPTION
- PR #710 で指摘されたP1指摘事項への修正対応
- Iron'sの`SummonManager`を使うと回避できないため、自前対応に変更
- それに合わせ、対応コストに対して利益が見合わない下記仕様を削除
    - ログアウト・ログイン時に杖が元通りになること(ログアウトは手動解除と同じ扱いに変更)
    - ディメンション間移動の追従(手動解除と同じ扱いに変更)
- `SummonManager`をやめたことで下記仕様が欠落するが重要度としては低めのため対応見送り
    - 呼び出した杖が発光エフェクトを伴う仕様
    - 消失時のチャットログ表示
- 未リリースの機能のため、既存の杖の救済は対応していない
- `runClient`及び`runGameTestServer`確認済み