### PR TITLE
PR #707を1.21.1へforward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchMenu.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchMenu.java
@@ -211,7 +211,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
     public int getEnabledScrollSlotCount() {
         if (hasGauntlet()) {
-            return ScrollcasterGauntlet.getEnabledCalibrationScrollSlotCount(getGauntletStack());
+            return ScrollcasterGauntlet.getEnabledCalibrationScrollSlotCount(getGauntletStack(), lookupProvider);
         }
         if (hasRevolvercastStaff()) {
             return RevolvercastStaff.getEnabledCalibrationScrollSlotCount(getGauntletStack());
@@ -274,7 +274,12 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
         var scrollStack = getScroll(slot);
         return !scrollStack.isEmpty()
-                && !SpellCalibrationImbueHelper.evaluateStoredScrollAt(getGauntletStack(), slot, scrollStack).isUsable();
+                && !SpellCalibrationImbueHelper.evaluateStoredScrollAt(
+                        getGauntletStack(),
+                        slot,
+                        scrollStack,
+                        lookupProvider
+                ).isUsable();
     }
 
     public boolean hasTargetSpellAt(int slot) {
@@ -326,7 +331,9 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
     private @NotNull ItemStack getAdjustment(int slot) {
         var target = getAdjustmentTarget();
-        return target == null ? ItemStack.EMPTY : target.getCalibrationAdjustment(getGauntletStack(), slot);
+        return target == null
+                ? ItemStack.EMPTY
+                : target.getCalibrationAdjustment(getGauntletStack(), slot, lookupProvider);
     }
 
     private void setAdjustment(int slot, @NotNull ItemStack stack) {
@@ -339,7 +346,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
         if (!storedStack.isEmpty()) {
             storedStack.setCount(1);
         }
-        target.trySetCalibrationAdjustment(getGauntletStack(), slot, storedStack);
+        target.trySetCalibrationAdjustment(getGauntletStack(), slot, storedStack, lookupProvider);
     }
 
     private @NotNull ItemStack getScroll(int slot) {
@@ -388,7 +395,12 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
         }
 
         if (!stack.isEmpty()
-                && !SpellCalibrationImbueHelper.evaluateScrollAt(getGauntletStack(), slot, stack).canInsert()) {
+                && !SpellCalibrationImbueHelper.evaluateScrollAt(
+                        getGauntletStack(),
+                        slot,
+                        stack,
+                        lookupProvider
+                ).canInsert()) {
             return;
         }
 
@@ -461,7 +473,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
             return false;
         }
         for (var slot = 0; slot < target.getCalibrationAdjustmentSlotCount(getGauntletStack()); ++slot) {
-            if (target.canPlaceCalibrationAdjustment(getGauntletStack(), slot, stack)) {
+            if (target.canPlaceCalibrationAdjustment(getGauntletStack(), slot, stack, lookupProvider)) {
                 return true;
             }
         }
@@ -717,7 +729,12 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
             var target = getAdjustmentTarget();
             return target != null
-                    && target.canPlaceCalibrationAdjustment(getGauntletStack(), calibrationSlot, stack);
+                    && target.canPlaceCalibrationAdjustment(
+                            getGauntletStack(),
+                            calibrationSlot,
+                            stack,
+                            lookupProvider
+                    );
         }
 
         @Override
@@ -749,7 +766,12 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
             if (!hasCalibrationTarget() || !isScrollSlotEnabled(calibrationSlot) || !isScroll(stack)) {
                 return false;
             }
-            return SpellCalibrationImbueHelper.evaluateScrollAt(getGauntletStack(), calibrationSlot, stack).canInsert();
+            return SpellCalibrationImbueHelper.evaluateScrollAt(
+                    getGauntletStack(),
+                    calibrationSlot,
+                    stack,
+                    lookupProvider
+            ).canInsert();
         }
 
         @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchMenu.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchMenu.java
@@ -1,6 +1,8 @@
 package jp.aquafactory.apprenticecodex.block.spellcalibrationbench;
 
 import io.redspace.ironsspellbooks.item.Scroll;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
 import jp.aquafactory.apprenticecodex.item.revolvercaststaff.RevolvercastStaff;
 import jp.aquafactory.apprenticecodex.item.scrollcastergauntlet.ScrollcasterGauntlet;
@@ -10,10 +12,8 @@ import jp.aquafactory.apprenticecodex.item.curios.satellitefollowcastamulet.Sate
 import jp.aquafactory.apprenticecodex.registry.BlockRegistry;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.MenuRegistry;
-import jp.aquafactory.apprenticecodex.registry.TagRegistry;
 import jp.aquafactory.apprenticecodex.utility.AdvancementTools;
 import jp.aquafactory.apprenticecodex.utility.SpellCalibrationImbueHelper;
-import jp.aquafactory.apprenticecodex.utility.ScrollcasterSchoolRuneResolver;
 import jp.aquafactory.apprenticecodex.item.shield.BulwarkGreatshield;
 import jp.aquafactory.apprenticecodex.item.shield.ParrycastBuckler;
 import jp.aquafactory.apprenticecodex.item.shield.ReflectcastShield;
@@ -127,7 +127,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
             if (!moveItemStackTo(stack, PLAYER_INVENTORY_START, HOTBAR_SLOT_END, true)) {
                 return ItemStack.EMPTY;
             }
-        } else if (hasStoredCalibrationTarget() && isAdjustmentItem(stack)) {
+        } else if (canPlaceAdjustmentInAnySlot(stack)) {
             if (!moveItemStackTo(stack, ADJUSTMENT_SLOT_START, ADJUSTMENT_SLOT_END, false)) {
                 return ItemStack.EMPTY;
             }
@@ -195,26 +195,18 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
         return getGauntletStack().getItem() instanceof ReflectcastShield;
     }
 
-    public boolean hasStoredCalibrationTarget() {
-        return hasGauntlet()
-                || hasRevolvercastStaff()
-                || hasMithrilFreecastStaff()
-                || hasMagiAgentSuit()
-                || hasAutocastAmulet()
-                || hasSatelliteFollowcastAmulet()
-                || hasBulwarkGreatshield()
-                || hasParrycastBuckler()
-                || hasReflectcastShield();
+    public boolean hasAdjustmentTarget() {
+        return getAdjustmentTarget() != null;
     }
 
     public boolean hasCalibrationTarget() {
-        return hasStoredCalibrationTarget() || SpellCalibrationImbueHelper.isVisibleImbueTarget(getGauntletStack());
+        return hasAdjustmentTarget() || SpellCalibrationImbueHelper.isVisibleImbueTarget(getGauntletStack());
     }
 
     public boolean hasOperationalImbueTarget() {
         return hasMagiAgentSuitImbueTarget()
                 || hasBulwarkGreatshield() || hasParrycastBuckler() || hasReflectcastShield()
-                || !hasStoredCalibrationTarget() && SpellCalibrationImbueHelper.isSupportedTarget(getGauntletStack());
+                || !hasAdjustmentTarget() && SpellCalibrationImbueHelper.isSupportedTarget(getGauntletStack());
     }
 
     public int getEnabledScrollSlotCount() {
@@ -241,28 +233,9 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
     }
 
     public boolean isAdjustmentSlotEnabled(int slot) {
-        if (!hasStoredCalibrationTarget() || slot < 0) {
-            return false;
-        }
-        if (hasMagiAgentSuit()) {
-            return slot < MagiAgentSuitItem.CALIBRATION_ADJUSTMENT_SLOT_COUNT;
-        }
-        if (hasAutocastAmulet()) {
-            return slot < AutocastAmulet.CALIBRATION_ADJUSTMENT_SLOT_COUNT;
-        }
-        if (hasSatelliteFollowcastAmulet()) {
-            return slot < SatelliteFollowcastAmulet.CALIBRATION_ADJUSTMENT_SLOT_COUNT;
-        }
-        if (hasBulwarkGreatshield()) {
-            return slot < BulwarkGreatshield.CALIBRATION_ADJUSTMENT_SLOT_COUNT;
-        }
-        if (hasParrycastBuckler()) {
-            return slot < ParrycastBuckler.CALIBRATION_ADJUSTMENT_SLOT_COUNT;
-        }
-        if (hasReflectcastShield()) {
-            return slot < ReflectcastShield.CALIBRATION_ADJUSTMENT_SLOT_COUNT;
-        }
-        return slot < ScrollcasterGauntlet.CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+        var target = getAdjustmentTarget();
+        return target != null && slot >= 0
+                && slot < target.getCalibrationAdjustmentSlotCount(getGauntletStack());
     }
 
     public @NotNull ItemStack getScrollItem(int slot) {
@@ -271,6 +244,13 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
     public @NotNull ItemStack getAdjustmentItem(int slot) {
         return getAdjustment(slot);
+    }
+
+    public @NotNull CalibrationAdjustmentProfile getAdjustmentProfile() {
+        var target = getAdjustmentTarget();
+        return target == null
+                ? CalibrationAdjustmentProfile.of()
+                : target.getCalibrationAdjustmentProfile(getGauntletStack());
     }
 
     public @NotNull ItemStack getLockedPreviewScrollItem(int slot) {
@@ -345,38 +325,13 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
     }
 
     private @NotNull ItemStack getAdjustment(int slot) {
-        if (hasGauntlet()) {
-            return ScrollcasterGauntlet.getCalibrationAdjustment(getGauntletStack(), slot, lookupProvider);
-        }
-        if (hasRevolvercastStaff()) {
-            return RevolvercastStaff.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        if (hasMithrilFreecastStaff()) {
-            return MithrilFreecastStaff.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        if (hasMagiAgentSuit()) {
-            return MagiAgentSuitItem.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        if (hasAutocastAmulet()) {
-            return AutocastAmulet.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        if (hasSatelliteFollowcastAmulet()) {
-            return SatelliteFollowcastAmulet.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        if (hasBulwarkGreatshield()) {
-            return BulwarkGreatshield.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        if (hasParrycastBuckler()) {
-            return ParrycastBuckler.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        if (hasReflectcastShield()) {
-            return ReflectcastShield.getCalibrationAdjustment(getGauntletStack(), slot);
-        }
-        return ItemStack.EMPTY;
+        var target = getAdjustmentTarget();
+        return target == null ? ItemStack.EMPTY : target.getCalibrationAdjustment(getGauntletStack(), slot);
     }
 
     private void setAdjustment(int slot, @NotNull ItemStack stack) {
-        if (!hasStoredCalibrationTarget()) {
+        var target = getAdjustmentTarget();
+        if (target == null) {
             return;
         }
 
@@ -384,25 +339,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
         if (!storedStack.isEmpty()) {
             storedStack.setCount(1);
         }
-        if (hasGauntlet()) {
-            ScrollcasterGauntlet.setCalibrationAdjustment(getGauntletStack(), slot, storedStack, lookupProvider);
-        } else if (hasRevolvercastStaff()) {
-            RevolvercastStaff.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        } else if (hasMithrilFreecastStaff()) {
-            MithrilFreecastStaff.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        } else if (hasMagiAgentSuit()) {
-            MagiAgentSuitItem.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        } else if (hasAutocastAmulet()) {
-            AutocastAmulet.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        } else if (hasSatelliteFollowcastAmulet()) {
-            SatelliteFollowcastAmulet.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        } else if (hasBulwarkGreatshield()) {
-            BulwarkGreatshield.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        } else if (hasParrycastBuckler()) {
-            ParrycastBuckler.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        } else if (hasReflectcastShield()) {
-            ReflectcastShield.setCalibrationAdjustment(getGauntletStack(), slot, storedStack);
-        }
+        target.trySetCalibrationAdjustment(getGauntletStack(), slot, storedStack);
     }
 
     private @NotNull ItemStack getScroll(int slot) {
@@ -518,86 +455,17 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
         return slotIndex >= SCROLL_SLOT_START && slotIndex < SCROLL_SLOT_END;
     }
 
-    private boolean hasSchoolRuneAdjustmentExcept(int excludedSlot) {
-        for (var slot = 0; slot < ScrollcasterGauntlet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (slot == excludedSlot) {
-                continue;
-            }
-            if (isSchoolRune(getAdjustment(slot))) {
+    private boolean canPlaceAdjustmentInAnySlot(@NotNull ItemStack stack) {
+        var target = getAdjustmentTarget();
+        if (target == null) {
+            return false;
+        }
+        for (var slot = 0; slot < target.getCalibrationAdjustmentSlotCount(getGauntletStack()); ++slot) {
+            if (target.canPlaceCalibrationAdjustment(getGauntletStack(), slot, stack)) {
                 return true;
             }
         }
         return false;
-    }
-
-    private boolean hasRecoveryRuneAdjustmentExcept(int excludedSlot) {
-        for (var slot = 0; slot < ScrollcasterGauntlet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (slot == excludedSlot) {
-                continue;
-            }
-            if (RevolvercastStaff.isRecoveryRune(getAdjustment(slot))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean hasFreecastStaffAdjustmentExcept(int excludedSlot) {
-        for (var slot = 0; slot < ScrollcasterGauntlet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (slot == excludedSlot) {
-                continue;
-            }
-            if (ScrollcasterGauntlet.isFreecastStaffAdjustment(getAdjustment(slot))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean hasSilverRingAdjustmentExcept(int excludedSlot) {
-        for (var slot = 0; slot < ScrollcasterGauntlet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (slot == excludedSlot) {
-                continue;
-            }
-            if (isSilverRing(getAdjustment(slot))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    static boolean isAdjustmentItem(@NotNull ItemStack stack) {
-        return isSpellSlotUpgrade(stack)
-                || isSchoolRune(stack)
-                || isEnchantmentBook(stack)
-                || isRecoveryRune(stack)
-                || isFreecastStaff(stack)
-                || isSilverRing(stack)
-                || AutocastAmulet.isWisdomShard(stack);
-    }
-
-    static boolean isSchoolRune(@NotNull ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.isSchoolRune(stack);
-    }
-
-    static boolean isSpellSlotUpgrade(@NotNull ItemStack stack) {
-        return ScrollcasterGauntlet.isCalibrationSlotUpgrade(stack);
-    }
-
-    static boolean isEnchantmentBook(@NotNull ItemStack stack) {
-        return !stack.isEmpty() && stack.is(TagRegistry.Items.SCROLLCASTER_GAUNTLET_ENCHANTMENT_BOOKS);
-    }
-
-    static boolean isRecoveryRune(@NotNull ItemStack stack) {
-        return RevolvercastStaff.isRecoveryRune(stack);
-    }
-
-    static boolean isFreecastStaff(@NotNull ItemStack stack) {
-        return ScrollcasterGauntlet.isFreecastStaffAdjustment(stack);
-    }
-
-    static boolean isSilverRing(@NotNull ItemStack stack) {
-        return MithrilFreecastStaff.isSilverRing(stack);
     }
 
     private static boolean isScroll(@NotNull ItemStack stack) {
@@ -629,15 +497,12 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
     }
 
     private static boolean isCalibrationTarget(@NotNull ItemStack stack) {
-        return isScrollcasterGauntlet(stack) || isRevolvercastStaff(stack)
-                || isMithrilFreecastStaff(stack)
-                || isMagiAgentSuit(stack)
-                || isAutocastAmulet(stack)
-                || isSatelliteFollowcastAmulet(stack)
-                || stack.getItem() instanceof BulwarkGreatshield
-                || stack.getItem() instanceof ParrycastBuckler
-                || stack.getItem() instanceof ReflectcastShield
+        return stack.getItem() instanceof SpellCalibrationAdjustmentTarget
                 || SpellCalibrationImbueHelper.isVisibleImbueTarget(stack);
+    }
+
+    private SpellCalibrationAdjustmentTarget getAdjustmentTarget() {
+        return getGauntletStack().getItem() instanceof SpellCalibrationAdjustmentTarget target ? target : null;
     }
 
     private boolean hasStoredScrollTarget() {
@@ -673,7 +538,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
         @Override
         public @NotNull ItemStack getItem(int slot) {
-            return hasStoredCalibrationTarget() ? getAdjustment(slot) : fallbackItems.get(slot);
+            return hasAdjustmentTarget() ? getAdjustment(slot) : fallbackItems.get(slot);
         }
 
         @Override
@@ -703,7 +568,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
                 storedStack.setCount(1);
             }
 
-            if (!hasStoredCalibrationTarget()) {
+            if (!hasAdjustmentTarget()) {
                 fallbackItems.set(slot, storedStack);
             } else {
                 setAdjustment(slot, storedStack);
@@ -748,7 +613,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
         @Override
         public @NotNull ItemStack getItem(int slot) {
-            if (hasStoredCalibrationTarget()) {
+            if (hasAdjustmentTarget()) {
                 return getScroll(slot);
             }
             if (hasOperationalImbueTarget()) {
@@ -842,7 +707,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
         @Override
         public boolean mayPlace(@NotNull ItemStack stack) {
-            if (!hasStoredCalibrationTarget()) {
+            if (!hasAdjustmentTarget()) {
                 return false;
             }
 
@@ -850,52 +715,14 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
                 return false;
             }
 
-            if (hasGauntlet()) {
-                return (isSpellSlotUpgrade(stack) || isSchoolRune(stack) || isEnchantmentBook(stack)
-                        || isFreecastStaff(stack) || isSilverRing(stack))
-                        && (!isSchoolRune(stack) || !hasSchoolRuneAdjustmentExcept(calibrationSlot))
-                        && (!isFreecastStaff(stack) || !hasFreecastStaffAdjustmentExcept(calibrationSlot))
-                        && (!isSilverRing(stack) || !hasSilverRingAdjustmentExcept(calibrationSlot));
-            }
-            if (hasRevolvercastStaff()) {
-                return RevolvercastStaff.isCalibrationAdjustmentItem(stack)
-                        && (!isSchoolRune(stack) || !hasSchoolRuneAdjustmentExcept(calibrationSlot))
-                        && (!isRecoveryRune(stack) || !hasRecoveryRuneAdjustmentExcept(calibrationSlot))
-                        && (!isSilverRing(stack) || !hasSilverRingAdjustmentExcept(calibrationSlot));
-            }
-            if (hasMithrilFreecastStaff()) {
-                return MithrilFreecastStaff.isCalibrationAdjustmentItem(stack)
-                        && (!isSchoolRune(stack) || !hasSchoolRuneAdjustmentExcept(calibrationSlot))
-                        && (!isSilverRing(stack) || !hasSilverRingAdjustmentExcept(calibrationSlot));
-            }
-            if (hasMagiAgentSuit()) {
-                return MagiAgentSuitItem.isCalibrationAdjustmentItem(stack)
-                        && !hasSchoolRuneAdjustmentExcept(calibrationSlot);
-            }
-            if (hasAutocastAmulet()) {
-                return AutocastAmulet.isCalibrationAdjustmentItem(stack)
-                        && (!isSilverRing(stack) || !hasSilverRingAdjustmentExcept(calibrationSlot));
-            }
-            if (hasSatelliteFollowcastAmulet()) {
-                return SatelliteFollowcastAmulet.isCalibrationAdjustmentItem(stack)
-                        && (!isSilverRing(stack) || !hasSilverRingAdjustmentExcept(calibrationSlot));
-            }
-            if (hasBulwarkGreatshield()) {
-                return BulwarkGreatshield.isCalibrationAdjustmentItem(stack);
-            }
-            if (hasParrycastBuckler()) {
-                return ParrycastBuckler.isCalibrationAdjustmentItem(stack);
-            }
-            if (hasReflectcastShield()) {
-                return ReflectcastShield.isCalibrationAdjustmentItem(stack)
-                        && (!isSilverRing(stack) || !hasSilverRingAdjustmentExcept(calibrationSlot));
-            }
-            return false;
+            var target = getAdjustmentTarget();
+            return target != null
+                    && target.canPlaceCalibrationAdjustment(getGauntletStack(), calibrationSlot, stack);
         }
 
         @Override
         public boolean mayPickup(@NotNull Player player) {
-            return hasStoredCalibrationTarget() && (isAdjustmentSlotEnabled(calibrationSlot) || hasItem());
+            return hasAdjustmentTarget() && (isAdjustmentSlotEnabled(calibrationSlot) || hasItem());
         }
 
         @Override
@@ -927,7 +754,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
         @Override
         public boolean mayPickup(@NotNull Player player) {
-            return hasStoredCalibrationTarget() && (isScrollSlotEnabled(calibrationSlot) || hasItem())
+            return hasAdjustmentTarget() && (isScrollSlotEnabled(calibrationSlot) || hasItem())
                     || hasOperationalImbueTarget() && isScrollSlotEnabled(calibrationSlot);
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchMenu.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchMenu.java
@@ -1,7 +1,5 @@
 package jp.aquafactory.apprenticecodex.block.spellcalibrationbench;
 
-import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
-import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.item.Scroll;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
 import jp.aquafactory.apprenticecodex.item.revolvercaststaff.RevolvercastStaff;
@@ -293,25 +291,10 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
         if (!isScrollSlotEnabled(slot)) {
             return false;
         }
-        if (hasRevolvercastStaff()) {
-            return RevolvercastStaff.isMismatchedCastConditionScroll(getGauntletStack(), slot);
-        }
-        if (hasParrycastBuckler()) {
-            return ((ParrycastBuckler) getGauntletStack().getItem())
-                    .isMismatchedCastConditionAt(getGauntletStack(), slot);
-        }
-        if (hasReflectcastShield()) {
-            return ((ReflectcastShield) getGauntletStack().getItem())
-                    .isMismatchedCastConditionAt(getGauntletStack(), slot);
-        }
-        if (hasAutocastAmulet()) {
-            return AutocastAmulet.isMismatchedCastConditionAt(getGauntletStack(), slot);
-        }
-        if (hasSatelliteFollowcastAmulet()) {
-            return SatelliteFollowcastAmulet.isMismatchedCastConditionAt(getGauntletStack(), slot);
-        }
-        return hasOperationalImbueTarget()
-                && SpellCalibrationImbueHelper.isMismatchedCastConditionAt(getGauntletStack(), slot);
+
+        var scrollStack = getScroll(slot);
+        return !scrollStack.isEmpty()
+                && !SpellCalibrationImbueHelper.evaluateStoredScrollAt(getGauntletStack(), slot, scrollStack).isUsable();
     }
 
     public boolean hasTargetSpellAt(int slot) {
@@ -464,6 +447,11 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
 
     private void setScroll(int slot, @NotNull ItemStack stack) {
         if (!hasCalibrationTarget()) {
+            return;
+        }
+
+        if (!stack.isEmpty()
+                && !SpellCalibrationImbueHelper.evaluateScrollAt(getGauntletStack(), slot, stack).canInsert()) {
             return;
         }
 
@@ -934,25 +922,7 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
             if (!hasCalibrationTarget() || !isScrollSlotEnabled(calibrationSlot) || !isScroll(stack)) {
                 return false;
             }
-            if (hasRevolvercastStaff()) {
-                var spellData = getScrollSpellData(stack);
-                return spellData != SpellData.EMPTY
-                        && spellData.getSpell() != null
-                        && RevolvercastStaff.canSwingCastSpell(spellData.getSpell(), true);
-            }
-            if (hasAutocastAmulet()) {
-                var spellData = getScrollSpellData(stack);
-                return spellData != SpellData.EMPTY
-                        && spellData.getSpell() != null
-                        && ((AutocastAmulet) getGauntletStack().getItem()).canImbueSpell(spellData);
-            }
-            if (hasSatelliteFollowcastAmulet()) {
-                var spellData = getScrollSpellData(stack);
-                return spellData != SpellData.EMPTY
-                        && spellData.getSpell() != null
-                        && ((SatelliteFollowcastAmulet) getGauntletStack().getItem()).canImbueSpell(spellData);
-            }
-            return hasGauntlet() || SpellCalibrationImbueHelper.canPlaceScrollAt(getGauntletStack(), calibrationSlot, stack);
+            return SpellCalibrationImbueHelper.evaluateScrollAt(getGauntletStack(), calibrationSlot, stack).canInsert();
         }
 
         @Override
@@ -978,17 +948,4 @@ public final class SpellCalibrationBenchMenu extends AbstractContainerMenu {
         }
     }
 
-    private static @NotNull SpellData getScrollSpellData(@NotNull ItemStack scrollStack) {
-        if (!isScroll(scrollStack)) {
-            return SpellData.EMPTY;
-        }
-
-        var scrollContainer = ISpellContainer.get(scrollStack);
-        if (scrollContainer == null || scrollContainer.getActiveSpellCount() != 1) {
-            return SpellData.EMPTY;
-        }
-
-        var spellData = scrollContainer.getSpellAtIndex(0);
-        return spellData == null ? SpellData.EMPTY : spellData;
-    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchScreen.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spellcalibrationbench/SpellCalibrationBenchScreen.java
@@ -2,19 +2,15 @@ package jp.aquafactory.apprenticecodex.block.spellcalibrationbench;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHint;
 import jp.aquafactory.apprenticecodex.item.scrollcastergauntlet.ScrollcasterGauntlet;
-import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
-import jp.aquafactory.apprenticecodex.registry.TagRegistry;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.player.Inventory;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -239,7 +235,7 @@ public final class SpellCalibrationBenchScreen extends AbstractContainerScreen<S
     }
 
     private int findHoveredDisabledScrollSlot(int mouseX, int mouseY) {
-        if (!menu.hasStoredCalibrationTarget()) {
+        if (!menu.hasAdjustmentTarget()) {
             return -1;
         }
 
@@ -319,7 +315,7 @@ public final class SpellCalibrationBenchScreen extends AbstractContainerScreen<S
     }
 
     private int findHoveredEmptyAdjustmentSlot(int mouseX, int mouseY) {
-        if (!menu.hasStoredCalibrationTarget()) {
+        if (!menu.hasAdjustmentTarget()) {
             return -1;
         }
 
@@ -341,94 +337,35 @@ public final class SpellCalibrationBenchScreen extends AbstractContainerScreen<S
     private List<Component> createAdjustmentItemHintTooltip() {
         var lines = new ArrayList<Component>();
         lines.add(Component.translatable("container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_title"));
-        if (menu.hasMagiAgentSuit()) {
-            lines.add(Component.translatable("container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_runes"));
-            return List.copyOf(lines);
-        }
-        if (menu.hasMithrilFreecastStaff()) {
-            lines.add(Component.translatable("container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_runes"));
-            appendSilverRingHint(lines);
-            return List.copyOf(lines);
-        }
-        if (menu.hasAutocastAmulet()) {
-            appendSlotUpgradeHints(lines);
-            appendSilverRingHint(lines);
-            appendWisdomShardHint(lines);
-            return List.copyOf(lines);
-        }
-        if (menu.hasBulwarkGreatshield()) {
-            lines.add(Component.translatable("container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_runes"));
-            appendWisdomShardHint(lines);
-            return List.copyOf(lines);
-        }
-        if (menu.hasParrycastBuckler()) {
-            lines.add(Component.translatable("container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_runes"));
-            appendSilverRingHint(lines);
-            appendWisdomShardHint(lines);
-            return List.copyOf(lines);
-        }
-        if (menu.hasReflectcastShield()) {
-            appendSilverRingHint(lines);
-            appendWisdomShardHint(lines);
-            return List.copyOf(lines);
-        }
-        appendSlotUpgradeHints(lines);
-        if (menu.hasGauntlet()) {
-            lines.add(Component.translatable("container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_enchantment_books"));
-            appendTaggedItemHintLines(
-                    lines,
-                    TagRegistry.Items.SCROLLCASTER_GAUNTLET_ENCHANTMENT_BOOKS,
-                    new ItemStack(Items.ENCHANTED_BOOK)
-            );
-            lines.add(Component.translatable(
-                    "container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_single_specific_item",
-                    new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get()).getHoverName()
-            ));
-            appendSilverRingHint(lines);
-        }
-        lines.add(Component.translatable("container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_runes"));
-        if (menu.hasRevolvercastStaff()) {
-            lines.add(Component.translatable(
-                    "container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_single_specific_item",
-                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.COOLDOWN_RUNE.get()).getHoverName()
-            ));
-            appendSilverRingHint(lines);
+        for (var rule : menu.getAdjustmentProfile().rules()) {
+            appendAdjustmentHint(lines, rule.hint());
         }
         return List.copyOf(lines);
     }
 
-    private static void appendSlotUpgradeHints(List<Component> lines) {
-        lines.add(SLOT_UPGRADE_GROUP);
-        appendTaggedItemHintLines(
-                lines,
-                TagRegistry.Items.SCROLLCASTER_GAUNTLET_SLOT_UPGRADES,
-                new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
-        );
-    }
+    private static void appendAdjustmentHint(List<Component> lines, CalibrationAdjustmentHint hint) {
+        if (hint instanceof CalibrationAdjustmentHint.Translatable translatable) {
+            lines.add(Component.translatable(translatable.translationKey()));
+            return;
+        }
+        if (hint instanceof CalibrationAdjustmentHint.SpecificItem specificItem) {
+            lines.add(Component.translatable(
+                    "container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_single_specific_item",
+                    new ItemStack(specificItem.item().get()).getHoverName()
+            ));
+            return;
+        }
 
-    private static void appendSilverRingHint(List<Component> lines) {
-        lines.add(Component.translatable(
-                "container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_single_specific_item",
-                new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get()).getHoverName()
-        ));
-    }
-
-    private static void appendWisdomShardHint(List<Component> lines) {
-        lines.add(Component.translatable(
-                "container.apprenticecodex.spell_calibration_bench.tooltip.item_hint_single_specific_item",
-                new ItemStack(ItemRegistry.WISDOM_SHARD.get()).getHoverName()
-        ));
-    }
-
-    private static void appendTaggedItemHintLines(List<Component> lines, TagKey<Item> tag, ItemStack fallbackStack) {
+        var taggedItems = (CalibrationAdjustmentHint.TaggedItems) hint;
+        lines.add(Component.translatable(taggedItems.headingTranslationKey()));
         var stacks = StreamSupport.stream(BuiltInRegistries.ITEM.spliterator(), false)
                 .map(ItemStack::new)
-                .filter(stack -> stack.is(tag))
+                .filter(stack -> stack.is(taggedItems.tag()))
                 .sorted(Comparator.comparing(stack -> stack.getHoverName().getString()))
                 .toList();
 
         if (stacks.isEmpty()) {
-            lines.add(createSpecificItemHint(fallbackStack));
+            lines.add(createSpecificItemHint(new ItemStack(taggedItems.fallbackItem().get())));
             return;
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatScrollcasterGauntletCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/bettercombat/BetterCombatScrollcasterGauntletCompat.java
@@ -39,7 +39,7 @@ public final class BetterCombatScrollcasterGauntletCompat {
         if (!(offhandStack.getItem() instanceof ScrollcasterGauntlet)) {
             return SpellData.EMPTY;
         }
-        return ScrollcasterGauntlet.getSelectedSpellData(offhandStack);
+        return ScrollcasterGauntlet.getSelectedSpellData(offhandStack, player.level().registryAccess());
     }
 
     private static boolean isTwoHandedMainHandWeapon(ItemStack mainHandStack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ElementalBowModeSelectionClientController.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ElementalBowModeSelectionClientController.java
@@ -196,6 +196,9 @@ public final class ElementalBowModeSelectionClientController {
         if (player.getMainHandItem().getItem() instanceof ElementalBow) {
             return InteractionHand.MAIN_HAND;
         }
+        if (SneakSelectionUiHandResolver.shouldSuppressOffhandSelection(player)) {
+            return null;
+        }
         if (player.getOffhandItem().getItem() instanceof ElementalBow) {
             return InteractionHand.OFF_HAND;
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ScrollcasterGauntletSelectionClientController.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ScrollcasterGauntletSelectionClientController.java
@@ -206,6 +206,9 @@ public final class ScrollcasterGauntletSelectionClientController {
         if (player.getMainHandItem().getItem() instanceof ScrollcasterGauntlet) {
             return InteractionHand.MAIN_HAND;
         }
+        if (SneakSelectionUiHandResolver.shouldSuppressOffhandSelection(player)) {
+            return null;
+        }
         if (ModList.get().isLoaded(BETTER_COMBAT_MOD_ID)
                 && BetterCombatScrollcasterGauntletCompat.isRescueActive(player)) {
             return InteractionHand.OFF_HAND;

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ScrollcasterGauntletSelectionClientController.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ScrollcasterGauntletSelectionClientController.java
@@ -6,9 +6,11 @@ import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatScrollcast
 import jp.aquafactory.apprenticecodex.item.scrollcastergauntlet.ScrollcasterGauntlet;
 import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.ClientConfirmScrollcasterGauntletIndexPacket;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.neoforged.api.distmarker.Dist;
@@ -26,6 +28,8 @@ import java.util.List;
 @EventBusSubscriber(modid = ApprenticeCodex.MODID, value = Dist.CLIENT)
 public final class ScrollcasterGauntletSelectionClientController {
     private static final String BETTER_COMBAT_MOD_ID = "bettercombat";
+    private static final String EMPTY_SELECTION_LABEL_KEY =
+            "ui.apprenticecodex.scrollcaster_gauntlet.select_ui.empty";
     private static final ResourceLocation TEXTURE =
             ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "textures/gui/scrollcaster_gauntlet.png");
     private static final int TEXTURE_SIZE = 64;
@@ -179,9 +183,15 @@ public final class ScrollcasterGauntletSelectionClientController {
             return;
         }
 
+        var selectedView = activeState.selectedView();
+        if (!selectedView.hasSpell()) {
+            clearState();
+            return;
+        }
+
         Networks.sendToServer(new ClientConfirmScrollcasterGauntletIndexPacket(
                 activeState.hand(),
-                activeState.selectedView().scrollIndex()
+                selectedView.scrollIndex()
         ));
         clearState();
     }
@@ -262,7 +272,10 @@ public final class ScrollcasterGauntletSelectionClientController {
         var rowWidth = computeRowWidth(views.size());
         var startX = screenWidth / 2 - rowWidth / 2;
         var crosshairY = screenHeight / 2;
-        var label = state.selectedView().displayName();
+        var hasSelectableView = state.selectableViewCount() > 0;
+        var label = hasSelectableView
+                ? state.selectedView().displayName()
+                : Component.translatable(EMPTY_SELECTION_LABEL_KEY).withStyle(ChatFormatting.RED);
         var labelX = screenWidth / 2 - font.width(label) / 2;
         var labelY = crosshairY + LABEL_OFFSET_FROM_CROSSHAIR;
         var rowY = labelY + SLOT_OFFSET_FROM_LABEL;
@@ -275,9 +288,11 @@ public final class ScrollcasterGauntletSelectionClientController {
             renderSlot(guiGraphics, startX, rowY, column, views.size(), views.get(column));
         }
 
-        var selectedColumn = state.selectedViewIndex();
-        var selectedContent = resolveContentPosition(startX, rowY, selectedColumn, views.size());
-        renderSelectedFrame(guiGraphics, selectedContent.x() - 4, selectedContent.y() - 4);
+        if (hasSelectableView) {
+            var selectedColumn = state.selectedViewIndex();
+            var selectedContent = resolveContentPosition(startX, rowY, selectedColumn, views.size());
+            renderSelectedFrame(guiGraphics, selectedContent.x() - 4, selectedContent.y() - 4);
+        }
         guiGraphics.pose().popPose();
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/SneakSelectionUiHandResolver.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/SneakSelectionUiHandResolver.java
@@ -1,0 +1,17 @@
+package jp.aquafactory.apprenticecodex.event.client;
+
+import jp.aquafactory.apprenticecodex.item.SneakSelectionUiItem;
+import net.minecraft.world.entity.player.Player;
+
+public final class SneakSelectionUiHandResolver {
+    private SneakSelectionUiHandResolver() {
+    }
+
+    /**
+     * スニーク開始時にオフハンド側の選択 UI を抑制するかを判定する。
+     * 表示中の持ち替えでは再評価せず、途中から別の選択 UI を開かない既存仕様を維持する。
+     */
+    public static boolean shouldSuppressOffhandSelection(Player player) {
+        return player.getMainHandItem().getItem() instanceof SneakSelectionUiItem;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/StorageStabilizerSelectionClientController.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/StorageStabilizerSelectionClientController.java
@@ -213,6 +213,9 @@ public final class StorageStabilizerSelectionClientController {
         if (player.getMainHandItem().getItem() instanceof StorageStabilizer) {
             return InteractionHand.MAIN_HAND;
         }
+        if (SneakSelectionUiHandResolver.shouldSuppressOffhandSelection(player)) {
+            return null;
+        }
         if (player.getOffhandItem().getItem() instanceof StorageStabilizer) {
             return InteractionHand.OFF_HAND;
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexCoreGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexCoreGameTests.java
@@ -111,6 +111,11 @@ public final class ApprenticeCodexCoreGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void scrollcasterGauntletEmptySelectionViewsTrackEnabledSlots(GameTestHelper helper) {
+        ApprenticeCodexGameTestScenarios.scrollcasterGauntletEmptySelectionViewsTrackEnabledSlots(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void scrollcasterGauntletSelectedScrollDrivesImbuedSpell(GameTestHelper helper) {
         ApprenticeCodexGameTestScenarios.scrollcasterGauntletSelectedScrollDrivesImbuedSpell(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -395,6 +395,12 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void spellCalibrationBenchImbueStatesSeparateInsertionFromCurrentUsability(GameTestHelper helper) {
+        SpellCalibrationEquipmentGameTestScenarios
+                .spellCalibrationBenchImbueStatesSeparateInsertionFromCurrentUsability(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void spellCalibrationBenchImbueOnlySupportsExtractableTargets(GameTestHelper helper) {
         SpellCalibrationEquipmentGameTestScenarios.spellCalibrationBenchImbueOnlySupportsExtractableTargets(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -269,8 +269,8 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
-    public static void bulwarkGreatshieldCalibrationSupportsOneRuneOrWisdomShard(GameTestHelper helper) {
-        BulwarkGreatshieldGameTestScenarios.bulwarkGreatshieldCalibrationSupportsOneRuneOrWisdomShard(helper);
+    public static void bulwarkGreatshieldCalibrationSupportsThreeDistinctSchoolRunes(GameTestHelper helper) {
+        BulwarkGreatshieldGameTestScenarios.bulwarkGreatshieldCalibrationSupportsThreeDistinctSchoolRunes(helper);
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -395,6 +395,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void spellCalibrationAdjustmentProfilesEnforceDeclaredRules(GameTestHelper helper) {
+        SpellCalibrationEquipmentGameTestScenarios.spellCalibrationAdjustmentProfilesEnforceDeclaredRules(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void spellCalibrationBenchImbueStatesSeparateInsertionFromCurrentUsability(GameTestHelper helper) {
         SpellCalibrationEquipmentGameTestScenarios
                 .spellCalibrationBenchImbueStatesSeparateInsertionFromCurrentUsability(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -3730,6 +3730,16 @@ public class ApprenticeCodexGameTestScenarios {
             menu.getSlot(1).set(createEnchantedBook(sharpness, 1));
             helper.assertTrue(getEnchantmentLevel(gauntlet, sharpness) == 1,
                     "Sharpness book should enchant the Scrollcaster Gauntlet");
+            var storedSharpnessBook = menu.getAdjustmentItem(0);
+            helper.assertTrue(storedSharpnessBook.is(Items.ENCHANTED_BOOK),
+                    "Bench should restore the stored enchanted book with the current Level registry");
+            helper.assertTrue(getEnchantmentLevel(storedSharpnessBook, sharpness) == 1,
+                    "Restored Bench book should retain its dynamic enchantment");
+
+            var syncedMenu = createSpellCalibrationBenchMenu(helper, player, new BlockPos(1, 1, 0));
+            syncedMenu.getSlot(0).set(gauntlet.copy());
+            helper.assertTrue(getEnchantmentLevel(syncedMenu.getAdjustmentItem(0), sharpness) == 1,
+                    "A newly synchronized Bench menu should restore the stored dynamic enchantment");
 
             menu.getSlot(2).set(createEnchantedBook(unbreaking, 1));
             helper.assertTrue(getEnchantmentLevel(gauntlet, unbreaking) == 0,

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -3009,6 +3009,7 @@ public class ApprenticeCodexGameTestScenarios {
                     "Scrollcaster Gauntlet freecast should cast with the gauntlet stack");
             helper.assertTrue(io.redspace.ironsspellbooks.api.magic.SpellSelectionManager.MAINHAND.equals(magicData.getCastingEquipmentSlot()),
                     "Scrollcaster Gauntlet freecast should mark the mainhand casting slot");
+            magicData.resetCastingState();
             magicData.getPlayerCooldowns().removeCooldown(magicMissile.getSpellId());
 
             ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(fireBreath));
@@ -3018,15 +3019,11 @@ public class ApprenticeCodexGameTestScenarios {
 
             ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(heal));
             ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
-            helper.assertFalse(gauntletItem.tryTriggerSpellOnSwing(player, InteractionHand.MAIN_HAND, true),
-                    "Scrollcaster Gauntlet freecast should reject long spells before a Silver Ring adjustment");
-            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
-                    gauntlet,
-                    1,
-                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
-            );
-            helper.assertTrue(ScrollcasterGauntlet.hasSilverRingAdjustment(gauntlet),
-                    "Scrollcaster Gauntlet should detect its Silver Ring adjustment");
+            player.setHealth(Math.max(1.0F, player.getMaxHealth() - 1.0F));
+            helper.assertTrue(gauntletItem.tryTriggerSpellOnSwing(player, InteractionHand.MAIN_HAND, true),
+                    "Scrollcaster Gauntlet freecast should allow long spells with only a Mithril Freecast Staff adjustment");
+            magicData.resetCastingState();
+            magicData.getPlayerCooldowns().removeCooldown(heal.getSpellId());
 
             ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(magicMissile));
             ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
@@ -3213,16 +3210,10 @@ public class ApprenticeCodexGameTestScenarios {
                     "Mithril Freecast Staff adjustment should be stored on the gauntlet");
             helper.assertFalse(menu.getSlot(2).mayPlace(freecastStaff),
                     "Scrollcaster Gauntlet should reject duplicate Mithril Freecast Staff adjustments");
-            helper.assertTrue(menu.getSlot(2).mayPlace(silverRing),
-                    "Scrollcaster Gauntlet should accept Silver Ring adjustments");
-            menu.getSlot(2).set(silverRing.copy());
-            helper.assertTrue(ScrollcasterGauntlet.hasSilverRingAdjustment(gauntlet),
-                    "Silver Ring adjustment should be stored on the gauntlet");
-            helper.assertFalse(menu.getSlot(3).mayPlace(silverRing),
-                    "Scrollcaster Gauntlet should reject duplicate Silver Ring adjustments");
+            helper.assertFalse(menu.getSlot(2).mayPlace(silverRing),
+                    "Scrollcaster Gauntlet should reject Silver Ring adjustments");
 
             menu.getSlot(1).set(ItemStack.EMPTY);
-            menu.getSlot(2).set(ItemStack.EMPTY);
             menu.getSlot(0).set(staff);
             helper.assertFalse(menu.getSlot(1).mayPlace(freecastStaff),
                     "Revolvercast Staff should not accept a Mithril Freecast Staff adjustment");

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -2995,7 +2995,7 @@ public class ApprenticeCodexGameTestScenarios {
                     "Scrollcaster Gauntlet should not be treated as swing-triggerable before freecast adjustment");
             helper.assertFalse(gauntletItem.tryTriggerSpellOnSwing(player, InteractionHand.MAIN_HAND, true),
                     "Scrollcaster Gauntlet should not swing-cast without a Mithril Freecast Staff adjustment");
-            ScrollcasterGauntlet.setCalibrationAdjustment(gauntlet, 0, new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get()));
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(gauntlet, 0, new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get()));
             helper.assertTrue(ScrollcasterGauntlet.hasFreecastStaffAdjustment(gauntlet),
                     "Scrollcaster Gauntlet should detect its Mithril Freecast Staff adjustment");
             helper.assertTrue(gauntletItem.canTriggerSpellOnSwing(player, InteractionHand.MAIN_HAND),
@@ -3020,7 +3020,7 @@ public class ApprenticeCodexGameTestScenarios {
             ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
             helper.assertFalse(gauntletItem.tryTriggerSpellOnSwing(player, InteractionHand.MAIN_HAND, true),
                     "Scrollcaster Gauntlet freecast should reject long spells before a Silver Ring adjustment");
-            ScrollcasterGauntlet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     gauntlet,
                     1,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -3135,7 +3135,7 @@ public class ApprenticeCodexGameTestScenarios {
             var magicMissile = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
             ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(magicMissile));
             ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
-            ScrollcasterGauntlet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     gauntlet,
                     0,
                     new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get())
@@ -3288,7 +3288,7 @@ public class ApprenticeCodexGameTestScenarios {
     static void revolvercastStaffSelectedScrollNormalizesAndDrivesSpellWheel(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var staff = new ItemStack(ItemRegistry.REVOLVERCAST_STAFF.get());
-            RevolvercastStaff.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     staff,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -3340,7 +3340,7 @@ public class ApprenticeCodexGameTestScenarios {
     static void revolvercastStaffCooldownFailureAdvancesOnlyInSkipMode(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var staff = new ItemStack(ItemRegistry.REVOLVERCAST_STAFF.get());
-            RevolvercastStaff.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     staff,
                     1,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -3365,7 +3365,7 @@ public class ApprenticeCodexGameTestScenarios {
             helper.assertTrue(RevolvercastStaff.getSelectedScrollIndex(staff) == 0,
                     "Normal Revolvercast Staff mode should stay on a failed cooldown spell");
 
-            RevolvercastStaff.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     staff,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.COOLDOWN_RUNE.get())
@@ -3380,7 +3380,7 @@ public class ApprenticeCodexGameTestScenarios {
 
     static void revolvercastStaffSuccessfulCastAdvancesAfterCompletionTick(GameTestHelper helper) {
         var staff = new ItemStack(ItemRegistry.REVOLVERCAST_STAFF.get());
-        RevolvercastStaff.setCalibrationAdjustment(
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                 staff,
                 0,
                 new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -3420,7 +3420,7 @@ public class ApprenticeCodexGameTestScenarios {
 
     static void revolvercastStaffPendingAdvanceSurvivesUnrelatedCastCompletion(GameTestHelper helper) {
         var staff = new ItemStack(ItemRegistry.REVOLVERCAST_STAFF.get());
-        RevolvercastStaff.setCalibrationAdjustment(
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                 staff,
                 0,
                 new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -3455,7 +3455,7 @@ public class ApprenticeCodexGameTestScenarios {
 
     static void revolvercastStaffCancelledCastDoesNotAdvancePendingSelection(GameTestHelper helper) {
         var staff = new ItemStack(ItemRegistry.REVOLVERCAST_STAFF.get());
-        RevolvercastStaff.setCalibrationAdjustment(
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                 staff,
                 0,
                 new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -3498,7 +3498,7 @@ public class ApprenticeCodexGameTestScenarios {
                     0.10D,
                     "Revolvercast Staff general spell power modifier changed"
             );
-            RevolvercastStaff.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get())
@@ -3523,7 +3523,7 @@ public class ApprenticeCodexGameTestScenarios {
                     "Revolvercast Staff should accept instant spells by default");
             helper.assertFalse(staff.canImbueSpell(heal, 1),
                     "Revolvercast Staff should reject long spells without Silver Ring");
-            RevolvercastStaff.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     1,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -3625,7 +3625,7 @@ public class ApprenticeCodexGameTestScenarios {
             menu.getSlot(1).set(fireRune);
             helper.assertTrue(!menu.getSlot(2).mayPlace(iceRune), "Only one school rune should be accepted at a time");
             helper.assertTrue(menu.getSlot(2).mayPlace(enchantedBook), "Non-rune adjustments should remain accepted after a rune is present");
-            helper.assertTrue(!ScrollcasterGauntlet.getCalibrationAdjustment(gauntlet, 0).isEmpty(),
+            helper.assertTrue(!SpellCalibrationAdjustmentGameTestSupport.getCalibrationAdjustment(gauntlet, 0).isEmpty(),
                     "Adjustment item should be stored on the gauntlet NBT");
         });
     }
@@ -3669,7 +3669,7 @@ public class ApprenticeCodexGameTestScenarios {
                     "Removing the school rune should remove the school rune tooltip");
 
             var staleGauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
-            ScrollcasterGauntlet.setCalibrationAdjustment(staleGauntlet, 0, fireRune);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(staleGauntlet, 0, fireRune);
             CustomData.update(DataComponents.CUSTOM_DATA, staleGauntlet, rootTag -> {
                 var calibrationTag = rootTag.contains("SpellCalibration")
                         ? rootTag.getCompound("SpellCalibration")
@@ -3752,9 +3752,12 @@ public class ApprenticeCodexGameTestScenarios {
             }
 
             menu.getSlot(1).set(createEnchantedBook(sharpness, 1));
-            menu.getSlot(2).set(createEnchantedBook(sharpness, 4));
-            helper.assertTrue(getEnchantmentLevel(gauntlet, sharpness) == 4,
-                    "Duplicate Bench enchantments should keep the highest level");
+            var duplicateSharpness = createEnchantedBook(sharpness, 4);
+            helper.assertFalse(menu.getSlot(2).mayPlace(duplicateSharpness),
+                    "Duplicate Bench enchantments should be rejected before insertion");
+            menu.getSlot(2).set(duplicateSharpness);
+            helper.assertTrue(getEnchantmentLevel(gauntlet, sharpness) == 1,
+                    "Rejected duplicate Bench enchantments should not replace the installed level");
 
             menu.getSlot(1).set(createEnchantedBook(sharpness, 2));
             menu.getSlot(2).set(createEnchantedBook(smite, 5));
@@ -13943,7 +13946,7 @@ public class ApprenticeCodexGameTestScenarios {
         var item = (AutocastAmulet) ItemRegistry.AUTOCAST_AMULET.get();
         var stack = item.getDefaultInstance();
         for (var slot = 0; slot < spellSlotCount - AutocastAmulet.MIN_SPELL_SLOTS; ++slot) {
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     slot,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexGameTestScenarios.java
@@ -2973,6 +2973,37 @@ public class ApprenticeCodexGameTestScenarios {
         });
     }
 
+    static void scrollcasterGauntletEmptySelectionViewsTrackEnabledSlots(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var gauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
+            var baseViews = ScrollcasterGauntlet.getSelectionViews(gauntlet);
+            helper.assertTrue(baseViews.size() == ScrollcasterGauntlet.BASE_CALIBRATION_SCROLL_SLOT_COUNT,
+                    "Empty Scrollcaster Gauntlet selection UI should expose every base slot");
+            helper.assertTrue(baseViews.stream().allMatch(view -> !view.hasSpell() && !view.currentSelection()),
+                    "Empty Scrollcaster Gauntlet selection UI should expose only unselected empty slots");
+
+            var expandedGauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
+            var lesserUpgrade = new ItemStack(
+                    io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get()
+            );
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
+                            expandedGauntlet,
+                            0,
+                            lesserUpgrade
+                    ),
+                    "Failed to add a slot upgrade to the empty Scrollcaster Gauntlet");
+
+            var expandedViews = ScrollcasterGauntlet.getSelectionViews(expandedGauntlet);
+            helper.assertTrue(expandedViews.size()
+                            == ScrollcasterGauntlet.getEnabledCalibrationScrollSlotCount(expandedGauntlet),
+                    "Empty Scrollcaster Gauntlet selection UI should track its enabled slot count");
+            helper.assertTrue(expandedViews.size() > baseViews.size(),
+                    "Slot upgrade should add empty slots to the Scrollcaster Gauntlet selection UI");
+            helper.assertTrue(expandedViews.stream().allMatch(view -> !view.hasSpell() && !view.currentSelection()),
+                    "Expanded empty Scrollcaster Gauntlet selection UI should keep every slot unselected");
+        });
+    }
+
     static void scrollcasterGauntletFreecastStaffAdjustmentEnablesSwingcast(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var gauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSatelliteFollowcastAmuletGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSatelliteFollowcastAmuletGameTests.java
@@ -124,7 +124,7 @@ public final class ApprenticeCodexSatelliteFollowcastAmuletGameTests {
 
         var upgradeStack = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get());
         for (var slot = 0; slot < SatelliteFollowcastAmulet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            SatelliteFollowcastAmulet.setCalibrationAdjustment(stack, slot, upgradeStack);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, slot, upgradeStack);
         }
         helper.assertTrue(SatelliteFollowcastAmulet.getEnabledSpellSlotCount(stack) == SatelliteFollowcastAmulet.MAX_SPELL_SLOTS,
                 "Satellite Followcast Amulet calibration upgrades should enable four spell slots.");
@@ -143,7 +143,7 @@ public final class ApprenticeCodexSatelliteFollowcastAmuletGameTests {
         helper.assertTrue(SatelliteFollowcastAmulet.getEnabledSpellSlotCount(legacyStack) == 2,
                 "Satellite Followcast Amulet legacy two-slot item should convert to one calibration upgrade.");
         helper.assertTrue(SatelliteFollowcastAmulet.isCalibrationSlotUpgrade(
-                        SatelliteFollowcastAmulet.getCalibrationAdjustment(legacyStack, 0)),
+                        SpellCalibrationAdjustmentGameTestSupport.getCalibrationAdjustment(legacyStack, 0)),
                 "Satellite Followcast Amulet legacy two-slot item should gain a slot upgrade adjustment.");
         assertSatelliteSpellData(helper, legacyStack, 0, SpellRegistry.MAGE_LIGHT.get(), 1,
                 "Satellite Followcast Amulet legacy conversion should preserve the first spell.");
@@ -580,7 +580,7 @@ public final class ApprenticeCodexSatelliteFollowcastAmuletGameTests {
         var amulet = (SatelliteFollowcastAmulet) ItemRegistry.SATELLITE_FOLLOWCAST_AMULET.get();
         var amuletStack = new ItemStack(amulet);
         for (var slot = 1; slot < spells.length && slot <= SatelliteFollowcastAmulet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            SatelliteFollowcastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     amuletStack,
                     slot - 1,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
@@ -596,10 +596,10 @@ public final class ApprenticeCodexSatelliteFollowcastAmuletGameTests {
         }
         if (needsSilverRing) {
             for (var slot = 0; slot < SatelliteFollowcastAmulet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-                if (!SatelliteFollowcastAmulet.getCalibrationAdjustment(amuletStack, slot).isEmpty()) {
+                if (!SpellCalibrationAdjustmentGameTestSupport.getCalibrationAdjustment(amuletStack, slot).isEmpty()) {
                     continue;
                 }
-                SatelliteFollowcastAmulet.setCalibrationAdjustment(
+                SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                         amuletStack,
                         slot,
                         new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/AutocastAmuletGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/AutocastAmuletGameTestScenarios.java
@@ -394,7 +394,7 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
                     "Autocast Amulet should reject continuous spells");
             helper.assertFalse(item.canAutoCastSpell(stack, apprenticeLongSpell, 1),
                     "Autocast Amulet should not auto-cast long spells without Silver Ring adjustment");
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -430,14 +430,15 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
             var silverRing = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get());
             var fireRune = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get());
 
-            helper.assertTrue(AutocastAmulet.isCalibrationAdjustmentItem(wisdomShard),
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(
+                            stack, 0, wisdomShard),
                     "Wisdom Shard should be accepted as an Autocast Amulet adjustment item");
             helper.assertFalse(AutocastAmulet.isCalibrationSlotUpgrade(wisdomShard),
                     "Wisdom Shard should not count as an Autocast Amulet slot upgrade");
             helper.assertFalse(AutocastAmulet.isSilverRing(wisdomShard),
                     "Wisdom Shard should not count as a Silver Ring adjustment");
 
-            AutocastAmulet.setCalibrationAdjustment(stack, 0, wisdomShard);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, wisdomShard);
 
             helper.assertTrue(AutocastAmulet.hasWisdomShardAdjustment(stack),
                     "Autocast Amulet should detect an installed Wisdom Shard");
@@ -477,7 +478,7 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
                     1,
                     new SpellData(spell, 1)
             );
-            AutocastAmulet.setCalibrationAdjustment(stack, 0, new ItemStack(ItemRegistry.WISDOM_SHARD.get()));
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, new ItemStack(ItemRegistry.WISDOM_SHARD.get()));
             equipNecklaceCurio(player, stack);
 
             var magicData = MagicData.getPlayerMagicData(player);
@@ -605,19 +606,19 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
                     new SpellData(apprenticeSpell, 1)
             );
 
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
             );
             AutocastAmulet.setCalibrationScroll(stack, 1, createSpellScroll(mageLight));
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     1,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
             );
             AutocastAmulet.setCalibrationScroll(stack, 2, createSpellScroll(remoteEye));
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     2,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
@@ -653,7 +654,7 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
                     new SpellData(remoteEye, 1)
             );
 
-            AutocastAmulet.setCalibrationAdjustment(stack, 1, ItemStack.EMPTY);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 1, ItemStack.EMPTY);
             helper.assertFalse(ISpellContainer.isSpellContainer(stack),
                     "Autocast Amulet should keep scroll storage outside Iron's SpellContainer after removing an upgrade");
             helper.assertTrue(AutocastAmulet.getEnabledSpellSlotCount(stack) == 2,
@@ -792,7 +793,7 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
             var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.GREATER_HEAL_SPELL.get();
             var item = (AutocastAmulet) ItemRegistry.AUTOCAST_AMULET.get();
             var stack = item.getDefaultInstance();
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -882,7 +883,7 @@ final class AutocastAmuletGameTestScenarios extends ApprenticeCodexGameTestScena
             var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.GREATER_HEAL_SPELL.get();
             var item = (AutocastAmulet) ItemRegistry.AUTOCAST_AMULET.get();
             var stack = item.getDefaultInstance();
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/BulwarkGreatshieldGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/BulwarkGreatshieldGameTestScenarios.java
@@ -105,40 +105,60 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
         });
     }
 
-    static void bulwarkGreatshieldCalibrationSupportsOneRuneOrWisdomShard(GameTestHelper helper) {
+    static void bulwarkGreatshieldCalibrationSupportsThreeDistinctSchoolRunes(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = BowGameTestSupport.createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
                     "bulwark_greatshield_calibration_test");
             var stack = new ItemStack(ItemRegistry.BULWARK_GREATSHIELD.get());
             var fireRune = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get());
+            var iceRune = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.ICE_RUNE.get());
+            var holyRune = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.HOLY_RUNE.get());
             var wisdomShard = new ItemStack(ItemRegistry.WISDOM_SHARD.get());
             var menu = new SpellCalibrationBenchMenu(0, player.getInventory());
             menu.getSlot(SpellCalibrationBenchMenu.TARGET_MENU_SLOT).set(stack);
 
             helper.assertTrue(menu.isAdjustmentSlotEnabled(0), "Bulwark adjustment slot 0 should be enabled");
-            helper.assertFalse(menu.isAdjustmentSlotEnabled(1), "Bulwark should expose only one adjustment slot");
+            helper.assertTrue(menu.isAdjustmentSlotEnabled(1), "Bulwark adjustment slot 1 should be enabled");
+            helper.assertTrue(menu.isAdjustmentSlotEnabled(2), "Bulwark adjustment slot 2 should be enabled");
+            helper.assertFalse(menu.isAdjustmentSlotEnabled(3), "Bulwark should expose exactly three adjustment slots");
             var adjustmentSlot = menu.getSlot(SpellCalibrationBenchMenu.ADJUSTMENT_MENU_SLOT_START);
             helper.assertTrue(adjustmentSlot.mayPlace(fireRune), "Bulwark should accept a school rune");
             helper.assertTrue(adjustmentSlot.mayPlace(wisdomShard), "Bulwark should accept Wisdom Shard");
 
-            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, fireRune);
-            var schoolResist = MagicTools.resolveSchoolResistAttribute(BulwarkGreatshield.getResolvedCalibrationSchool(stack));
-            helper.assertTrue(schoolResist != null, "Fire rune should resolve a school resist attribute");
-            helper.assertTrue(stack.getAttributeModifiers().modifiers().stream()
-                            .anyMatch(entry -> entry.slot().equals(EquipmentSlotGroup.OFFHAND)
-                                    && entry.attribute().value() == schoolResist
-                                    && entry.modifier().amount() == BulwarkGreatshield.SCHOOL_SPELL_RESIST
-                                    && entry.modifier().operation() == AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
-                    "School rune should add 0.5 school spell resist");
-            helper.assertTrue(stack.getAttributeModifiers().modifiers().stream()
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, fireRune),
+                    "Bulwark should store its first school rune");
+            helper.assertFalse(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(stack, 1, fireRune),
+                    "Bulwark should reject a rune for an already inserted School ID");
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 1, iceRune),
+                    "Bulwark should accept a rune for a different School ID");
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 2, holyRune),
+                    "Bulwark should fill its third slot with another School ID");
+            helper.assertTrue(BulwarkGreatshield.getResolvedCalibrationSchools(stack).size() == 3,
+                    "Bulwark should resolve all three inserted school runes");
+
+            var modifiers = stack.getAttributeModifiers().modifiers();
+            for (var school : BulwarkGreatshield.getResolvedCalibrationSchools(stack)) {
+                var schoolResist = MagicTools.resolveSchoolResistAttribute(school);
+                helper.assertTrue(schoolResist != null, "Inserted rune should resolve a school resist attribute");
+                helper.assertTrue(modifiers.stream()
+                                .anyMatch(entry -> entry.slot().equals(EquipmentSlotGroup.OFFHAND)
+                                        && entry.attribute().value() == schoolResist
+                                        && entry.modifier().amount() == BulwarkGreatshield.SCHOOL_SPELL_RESIST
+                                        && entry.modifier().operation() == AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
+                        "Each school rune should add 0.5 school spell resist");
+            }
+            helper.assertTrue(modifiers.stream()
                             .anyMatch(entry -> entry.slot().equals(EquipmentSlotGroup.OFFHAND)
                                     && entry.attribute().equals(AttributeRegistry.SPELL_RESIST)
                                     && entry.modifier().amount() == BulwarkGreatshield.GENERIC_SPELL_RESIST),
-                    "School rune must not replace generic spell resist");
+                    "School runes must not replace generic spell resist");
 
-            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, wisdomShard);
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 2, wisdomShard),
+                    "Bulwark should allow Wisdom Shard to replace a school rune");
             helper.assertTrue(BulwarkGreatshield.hasWisdomShardAdjustment(stack),
-                    "Wisdom Shard adjustment should be stored on Bulwark");
+                    "Wisdom Shard should be detected outside the first adjustment slot");
+            helper.assertFalse(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(stack, 1, wisdomShard),
+                    "Bulwark should reject a duplicate Wisdom Shard");
             var tooltipLines = new ArrayList<Component>();
             stack.getItem().appendHoverText(stack, Item.TooltipContext.of(helper.getLevel()), tooltipLines, TooltipFlag.Default.NORMAL);
             assertTooltipKeyAt(helper, tooltipLines, 0,

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/BulwarkGreatshieldGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/BulwarkGreatshieldGameTestScenarios.java
@@ -121,7 +121,7 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
             helper.assertTrue(adjustmentSlot.mayPlace(fireRune), "Bulwark should accept a school rune");
             helper.assertTrue(adjustmentSlot.mayPlace(wisdomShard), "Bulwark should accept Wisdom Shard");
 
-            BulwarkGreatshield.setCalibrationAdjustment(stack, 0, fireRune);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, fireRune);
             var schoolResist = MagicTools.resolveSchoolResistAttribute(BulwarkGreatshield.getResolvedCalibrationSchool(stack));
             helper.assertTrue(schoolResist != null, "Fire rune should resolve a school resist attribute");
             helper.assertTrue(stack.getAttributeModifiers().modifiers().stream()
@@ -136,7 +136,7 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
                                     && entry.modifier().amount() == BulwarkGreatshield.GENERIC_SPELL_RESIST),
                     "School rune must not replace generic spell resist");
 
-            BulwarkGreatshield.setCalibrationAdjustment(stack, 0, wisdomShard);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, wisdomShard);
             helper.assertTrue(BulwarkGreatshield.hasWisdomShardAdjustment(stack),
                     "Wisdom Shard adjustment should be stored on Bulwark");
             var tooltipLines = new ArrayList<Component>();
@@ -289,7 +289,7 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
                 helper, new BlockPos(2, 2, 0), "reflectcast_continuous_duration_test"
         );
         var reflectcastStack = createContinuousCastShieldStack(ItemRegistry.REFLECTCAST_SHIELD.get());
-        ReflectcastShield.setCalibrationAdjustment(
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                 reflectcastStack,
                 0,
                 new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -362,7 +362,7 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
                 helper, new BlockPos(2, 2, 0), "reflectcast_continuous_cleanup_test"
         );
         var reflectcastStack = createContinuousCastShieldStack(ItemRegistry.REFLECTCAST_SHIELD.get());
-        ReflectcastShield.setCalibrationAdjustment(
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                 reflectcastStack,
                 0,
                 new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -457,7 +457,7 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
                 helper, new BlockPos(2, 2, 0), "reflectcast_continuous_death_test"
         );
         var reflectcastStack = createContinuousCastShieldStack(ItemRegistry.REFLECTCAST_SHIELD.get());
-        ReflectcastShield.setCalibrationAdjustment(
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                 reflectcastStack,
                 0,
                 new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
@@ -525,7 +525,7 @@ final class BulwarkGreatshieldGameTestScenarios extends ApprenticeCodexGameTestS
         reflectcastPlayer.gameMode.changeGameModeForPlayer(net.minecraft.world.level.GameType.CREATIVE);
         helper.assertTrue(reflectcastPlayer.isCreative(), "Reflectcast creative cooldown test requires creative mode");
         var reflectcastStack = createContinuousCastShieldStack(ItemRegistry.REFLECTCAST_SHIELD.get());
-        ReflectcastShield.setCalibrationAdjustment(
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                 reflectcastStack,
                 0,
                 new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
@@ -1929,12 +1929,12 @@ final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodex
                                         && "item.apprenticecodex.magi_agent_suit.rune_hint".equals(contents.getKey())),
                         "Magi Agent Suit " + armorType + " should show its rune hint before calibration");
 
-                MagiAgentSuitItem.setCalibrationAdjustment(
+                SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                         stack,
                         0,
                         new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get())
                 );
-                helper.assertTrue(MagiAgentSuitItem.getCalibrationAdjustment(stack, 0)
+                helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.getCalibrationAdjustment(stack, 0)
                                 .is(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get()),
                         "Magi Agent Suit " + armorType + " should store the calibration rune");
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
@@ -457,9 +457,9 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
             helper.assertFalse(item.canUseConfiguredSpell(stack,
                             io.redspace.ironsspellbooks.api.registry.SpellRegistry.FIRE_BREATH_SPELL.get(), 1),
                     "Reflectcast Shield should require Silver Ring for continuous spells");
-            jp.aquafactory.apprenticecodex.item.shield.ReflectcastShield.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack, 0, new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get()));
-            jp.aquafactory.apprenticecodex.item.shield.ReflectcastShield.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     stack, 1, new ItemStack(ItemRegistry.WISDOM_SHARD.get()));
             helper.assertTrue(jp.aquafactory.apprenticecodex.item.shield.ReflectcastShield.hasSilverRing(stack),
                     "Reflectcast Shield should store Silver Ring calibration");
@@ -502,7 +502,7 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
             }
 
             var castStack = new ItemStack(ItemRegistry.REFLECTCAST_SHIELD.get());
-            jp.aquafactory.apprenticecodex.item.shield.ReflectcastShield.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     castStack, 0, new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get()));
             var castContainer = ISpellContainer.create(1, false, false).mutableCopy();
             castContainer.addSpellAtIndex(

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/OffhandAndBetterCombatGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/OffhandAndBetterCombatGameTestScenarios.java
@@ -902,7 +902,7 @@ final class OffhandAndBetterCombatGameTestScenarios extends ApprenticeCodexGameT
             var gauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
             ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, createSpellScroll(expectedSpell));
             ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);
-            ScrollcasterGauntlet.setCalibrationAdjustment(gauntlet, 0, new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get()));
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(gauntlet, 0, new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get()));
 
             var player = createBetterCombatHiddenOffhandPlayer(
                     helper,

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ParrycastBucklerGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ParrycastBucklerGameTestScenarios.java
@@ -85,7 +85,7 @@ final class ParrycastBucklerGameTestScenarios {
                     "Inserted long spell should warn while Silver Ring is absent");
             assertFirstRestrictionKey(helper, item.getImbueRestrictionTooltipLines(stack),
                     "item.apprenticecodex.spellgun.tooltip.restrict_restrict_instant_only");
-            ParrycastBuckler.setCalibrationAdjustment(stack, 0,
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get()));
             helper.assertTrue(item.canUseConfiguredSpell(stack, SpellRegistry.MANTIS_LEAP.get(), 1), "Silver Ring should allow long spells");
             helper.assertTrue(item.evaluateCalibrationImbue(stack, 0, new SpellData(SpellRegistry.MANTIS_LEAP.get(), 1))
@@ -105,9 +105,9 @@ final class ParrycastBucklerGameTestScenarios {
             for (int i = 0; i < 3; i++) helper.assertTrue(menu.isAdjustmentSlotEnabled(i), "Parrycast adjustment slot should be enabled: " + i);
 
             var fireRune = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get());
-            ParrycastBuckler.setCalibrationAdjustment(stack, 0, fireRune);
-            ParrycastBuckler.setCalibrationAdjustment(stack, 1, fireRune);
-            ParrycastBuckler.setCalibrationAdjustment(stack, 2, new ItemStack(ItemRegistry.WISDOM_SHARD.get()));
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 0, fireRune);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 1, fireRune);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(stack, 2, new ItemStack(ItemRegistry.WISDOM_SHARD.get()));
             helper.assertTrue(ParrycastBuckler.hasWisdomShard(stack), "Wisdom Shard should be stored");
             var tooltipLines = new ArrayList<Component>();
             stack.getItem().appendHoverText(stack, Item.TooltipContext.of(helper.getLevel()), tooltipLines, TooltipFlag.Default.NORMAL);
@@ -286,7 +286,7 @@ final class ParrycastBucklerGameTestScenarios {
     ) {
         var player = BowGameTestSupport.createEquipmentTestPlayer(helper, position, name);
         var buckler = new ItemStack(ItemRegistry.PARRYCAST_BUCKLER.get());
-        ParrycastBuckler.setCalibrationAdjustment(buckler, 0, new ItemStack(ItemRegistry.WISDOM_SHARD.get()));
+        SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(buckler, 0, new ItemStack(ItemRegistry.WISDOM_SHARD.get()));
         var gauntlet = new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get());
         ScrollcasterGauntlet.setCalibrationScroll(gauntlet, 0, BowGameTestSupport.createSpellScroll(selectedSpell));
         ScrollcasterGauntlet.setSelectedScrollIndex(gauntlet, 0);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ParrycastBucklerGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ParrycastBucklerGameTestScenarios.java
@@ -6,6 +6,7 @@ import io.redspace.ironsspellbooks.api.magic.MagicHelper;
 import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
+import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.entity.spells.blood_slash.BloodSlashProjectile;
 import io.redspace.ironsspellbooks.gui.overlays.SpellSelection;
 import jp.aquafactory.apprenticecodex.block.spellcalibrationbench.SpellCalibrationBenchMenu;
@@ -79,14 +80,16 @@ final class ParrycastBucklerGameTestScenarios {
                     "Long scroll placement should not require Silver Ring");
             helper.assertTrue(SpellCalibrationImbueHelper.setScrollAt(stack, 0, longScroll),
                     "Long scroll should be insertable without Silver Ring");
-            helper.assertTrue(item.isMismatchedCastConditionAt(stack, 0),
+            helper.assertFalse(item.evaluateCalibrationImbue(stack, 0, new SpellData(SpellRegistry.MANTIS_LEAP.get(), 1))
+                            .isUsable(),
                     "Inserted long spell should warn while Silver Ring is absent");
             assertFirstRestrictionKey(helper, item.getImbueRestrictionTooltipLines(stack),
                     "item.apprenticecodex.spellgun.tooltip.restrict_restrict_instant_only");
             ParrycastBuckler.setCalibrationAdjustment(stack, 0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get()));
             helper.assertTrue(item.canUseConfiguredSpell(stack, SpellRegistry.MANTIS_LEAP.get(), 1), "Silver Ring should allow long spells");
-            helper.assertFalse(item.isMismatchedCastConditionAt(stack, 0),
+            helper.assertTrue(item.evaluateCalibrationImbue(stack, 0, new SpellData(SpellRegistry.MANTIS_LEAP.get(), 1))
+                            .isUsable(),
                     "Silver Ring should clear the inserted long spell warning");
             assertFirstRestrictionKey(helper, item.getImbueRestrictionTooltipLines(stack),
                     "item.apprenticecodex.spellgun.tooltip.restrict_restrict_not_continuous");

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationAdjustmentGameTestSupport.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationAdjustmentGameTestSupport.java
@@ -1,0 +1,37 @@
+package jp.aquafactory.apprenticecodex.gametest;
+
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+final class SpellCalibrationAdjustmentGameTestSupport {
+    private SpellCalibrationAdjustmentGameTestSupport() {
+    }
+
+    static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return getTarget(targetStack).getCalibrationAdjustment(targetStack, slot);
+    }
+
+    static boolean setCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        return getTarget(targetStack).trySetCalibrationAdjustment(targetStack, slot, adjustment);
+    }
+
+    static boolean canPlaceCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        return getTarget(targetStack).canPlaceCalibrationAdjustment(targetStack, slot, adjustment);
+    }
+
+    private static SpellCalibrationAdjustmentTarget getTarget(@NotNull ItemStack targetStack) {
+        if (targetStack.getItem() instanceof SpellCalibrationAdjustmentTarget target) {
+            return target;
+        }
+        throw new IllegalArgumentException("ItemStack is not a spell calibration adjustment target");
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
@@ -46,6 +46,8 @@ import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserSpellPr
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserSpellValidator;
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserVariant;
 import jp.aquafactory.apprenticecodex.block.spellcasterworkbench.SpellcasterWorkbenchMenu;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHint;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat;
@@ -237,6 +239,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextColor;
 import net.minecraft.network.chat.contents.TranslatableContents;
@@ -539,7 +542,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             helper.assertTrue(suitCoatMenu.getEnabledScrollSlotCount() == 1,
                     "Magi Agent Suit coat should expose one scroll slot");
             suitCoatMenu.getSlot(SpellCalibrationBenchMenu.ADJUSTMENT_MENU_SLOT_START).set(fireRune.copy());
-            helper.assertTrue(jp.aquafactory.apprenticecodex.item.armor.MagiAgentSuitItem
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport
                             .getCalibrationAdjustment(suitCoat, 0)
                             .is(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get()),
                     "Magi Agent Suit coat should store a school rune through the Spell Calibration Bench");
@@ -609,7 +612,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
 
             var fourSlotSatellite = new ItemStack(ItemRegistry.SATELLITE_FOLLOWCAST_AMULET.get());
             for (var slot = 0; slot < SatelliteFollowcastAmulet.CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-                SatelliteFollowcastAmulet.setCalibrationAdjustment(
+                SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                         fourSlotSatellite,
                         slot,
                         new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
@@ -631,6 +634,128 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
         });
     }
 
+    static void spellCalibrationAdjustmentProfilesEnforceDeclaredRules(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var targets = new ItemStack[]{
+                    new ItemStack(ItemRegistry.SCROLLCASTER_GAUNTLET.get()),
+                    new ItemStack(ItemRegistry.REVOLVERCAST_STAFF.get()),
+                    new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get()),
+                    new ItemStack(ItemRegistry.MAGI_AGENT_SUIT_HOOD.get()),
+                    new ItemStack(ItemRegistry.AUTOCAST_AMULET.get()),
+                    new ItemStack(ItemRegistry.SATELLITE_FOLLOWCAST_AMULET.get()),
+                    new ItemStack(ItemRegistry.BULWARK_GREATSHIELD.get()),
+                    new ItemStack(ItemRegistry.PARRYCAST_BUCKLER.get()),
+                    new ItemStack(ItemRegistry.REFLECTCAST_SHIELD.get())
+            };
+            var expectedSlotCounts = new int[]{3, 3, 3, 1, 3, 3, 1, 3, 3};
+            var representativeAdjustments = new ItemStack[]{
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get()),
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.COOLDOWN_RUNE.get()),
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get()),
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get()),
+                    new ItemStack(ItemRegistry.WISDOM_SHARD.get()),
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get()),
+                    new ItemStack(ItemRegistry.WISDOM_SHARD.get()),
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.ICE_RUNE.get()),
+                    new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())
+            };
+            for (var index = 0; index < targets.length; ++index) {
+                var stack = targets[index];
+                helper.assertTrue(stack.getItem() instanceof SpellCalibrationAdjustmentTarget,
+                        "Every declared calibration target should implement SpellCalibrationAdjustmentTarget: " + index);
+                var target = (SpellCalibrationAdjustmentTarget) stack.getItem();
+                helper.assertTrue(target.getCalibrationAdjustmentSlotCount(stack) == expectedSlotCounts[index],
+                        "Calibration target should expose its declared adjustment slot count: " + index);
+                helper.assertFalse(target.getCalibrationAdjustmentProfile(stack).rules().isEmpty(),
+                        "Calibration target should expose at least one adjustment rule: " + index);
+                helper.assertTrue(target.canPlaceCalibrationAdjustment(stack, 0, representativeAdjustments[index]),
+                        "Calibration target should accept its representative adjustment: " + index);
+                helper.assertFalse(target.canPlaceCalibrationAdjustment(stack, 0, new ItemStack(Items.DIRT)),
+                        "Calibration target should reject an unrelated item: " + index);
+            }
+
+            var gauntlet = targets[0];
+            var gauntletProfile = ((SpellCalibrationAdjustmentTarget) gauntlet.getItem())
+                    .getCalibrationAdjustmentProfile(gauntlet);
+            helper.assertTrue(gauntletProfile.rules().size() == 5,
+                    "Scrollcaster Gauntlet should expose all five hint groups from its rules");
+            helper.assertTrue(gauntletProfile.rules().get(0).hint() instanceof CalibrationAdjustmentHint.TaggedItems,
+                    "Scrollcaster Gauntlet slot upgrades should use a generated tag hint");
+            helper.assertTrue(gauntletProfile.rules().get(4).hint() instanceof CalibrationAdjustmentHint.Translatable,
+                    "Scrollcaster Gauntlet school runes should use a translated category hint");
+
+            var silverRing = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get());
+            var autocast = targets[4];
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
+                            autocast, 0, silverRing),
+                    "Autocast Amulet should accept its first Silver Ring");
+            helper.assertFalse(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(
+                            autocast, 1, silverRing),
+                    "Autocast Amulet should reject a duplicate singleton adjustment");
+
+            var slotUpgrade = new ItemStack(
+                    io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get());
+            var satellite = targets[5];
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
+                            satellite, 0, slotUpgrade),
+                    "Satellite Followcast Amulet should accept a slot upgrade");
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(
+                            satellite, 1, slotUpgrade),
+                    "Repeatable slot upgrades should be accepted more than once");
+
+            var fireRune = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.FIRE_RUNE.get());
+            var iceRune = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.ICE_RUNE.get());
+            var parrycast = targets[7];
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
+                            parrycast, 0, fireRune),
+                    "Parrycast Buckler should accept its first school rune");
+            helper.assertFalse(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(
+                            parrycast, 1, fireRune),
+                    "Parrycast Buckler should reject a duplicate School ID");
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(
+                            parrycast, 1, iceRune),
+                    "Parrycast Buckler should accept a different School ID");
+
+            var enchantmentLookup = helper.getLevel().registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+            var sharpness = enchantmentLookup.getOrThrow(net.minecraft.world.item.enchantment.Enchantments.SHARPNESS);
+            var unbreaking = enchantmentLookup.getOrThrow(net.minecraft.world.item.enchantment.Enchantments.UNBREAKING);
+            var sharpnessBook = createEnchantedBook(sharpness, 1);
+            var anotherSharpnessBook = sharpnessBook.copy();
+            var unbreakingBook = createEnchantedBook(unbreaking, 1);
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
+                            gauntlet, 0, sharpnessBook),
+                    "Scrollcaster Gauntlet should accept a supported enchantment book");
+            helper.assertFalse(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(
+                            gauntlet, 1, anotherSharpnessBook),
+                    "Scrollcaster Gauntlet should reject the same first enchantment twice");
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.canPlaceCalibrationAdjustment(
+                            gauntlet, 1, unbreakingBook),
+                    "Scrollcaster Gauntlet should accept a different first enchantment");
+
+            var calibration = getCustomDataTag(autocast);
+            calibration = calibration == null ? null : calibration.getCompound("SpellCalibration");
+            helper.assertTrue(calibration != null, "Legacy duplicate test requires calibration NBT");
+            CustomData.update(DataComponents.CUSTOM_DATA, autocast, rootTag -> {
+                var storedCalibration = rootTag.getCompound("SpellCalibration");
+                var adjustments = storedCalibration.getList("Adjustments", Tag.TAG_COMPOUND);
+                var duplicate = adjustments.getCompound(0).copy();
+                duplicate.putInt("Slot", 1);
+                adjustments.add(duplicate);
+                storedCalibration.put("Adjustments", adjustments);
+                rootTag.put("SpellCalibration", storedCalibration);
+            });
+            helper.assertFalse(SpellCalibrationAdjustmentGameTestSupport
+                            .getCalibrationAdjustment(autocast, 1).isEmpty(),
+                    "Legacy duplicate adjustment should remain readable");
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
+                            autocast, 0, ItemStack.EMPTY),
+                    "Legacy duplicate adjustment should be removable from the first slot");
+            helper.assertTrue(SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
+                            autocast, 1, ItemStack.EMPTY),
+                    "Legacy duplicate adjustment should be removable from the second slot");
+        });
+    }
+
     static void spellCalibrationBenchImbueStatesSeparateInsertionFromCurrentUsability(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
@@ -648,16 +773,16 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             assertCalibrationImbueState(helper, autocast, 0, longScroll,
                     SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
                     "Autocast Amulet should accept long spells with a warning before an enabling adjustment");
-            AutocastAmulet.setCalibrationAdjustment(autocast, 0, wisdomShard);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(autocast, 0, wisdomShard);
             assertCalibrationImbueState(helper, autocast, 0, longScroll,
                     SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
                     "Wisdom Shard runtime profiles should not change Calibration Bench insertion state");
-            AutocastAmulet.setCalibrationAdjustment(autocast, 1, silverRing);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(autocast, 1, silverRing);
             assertCalibrationImbueState(helper, autocast, 0, longScroll,
                     SpellCalibrationImbueState.ACCEPTED_USABLE,
                     "Autocast Amulet should mark long spells usable after an enabling adjustment");
             autocastMenu.getSlot(SpellCalibrationBenchMenu.SCROLL_MENU_SLOT_START).set(longScroll.copy());
-            AutocastAmulet.setCalibrationAdjustment(autocast, 1, ItemStack.EMPTY);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(autocast, 1, ItemStack.EMPTY);
             helper.assertFalse(AutocastAmulet.getCalibrationScroll(autocast, 0).isEmpty(),
                     "Removing an enabling adjustment should keep an already inserted scroll");
             helper.assertTrue(autocastMenu.shouldRenderMismatchCastConditionWarning(0),
@@ -668,7 +793,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             assertCalibrationImbueState(helper, satellite, 0, profiledContinuousScroll,
                     SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
                     "Satellite Followcast Amulet should accept continuous spells with a warning before an enabling adjustment");
-            SatelliteFollowcastAmulet.setCalibrationAdjustment(satellite, 0, silverRing);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(satellite, 0, silverRing);
             assertCalibrationImbueState(helper, satellite, 0, profiledContinuousScroll,
                     SpellCalibrationImbueState.ACCEPTED_USABLE,
                     "Satellite Followcast Amulet should mark continuous spells usable after an enabling adjustment");
@@ -678,7 +803,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             assertCalibrationImbueState(helper, revolver, 0, longScroll,
                     SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
                     "Revolvercast Staff should accept long spells with a warning before an enabling adjustment");
-            RevolvercastStaff.setCalibrationAdjustment(revolver, 0, silverRing);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(revolver, 0, silverRing);
             assertCalibrationImbueState(helper, revolver, 0, longScroll,
                     SpellCalibrationImbueState.ACCEPTED_USABLE,
                     "Revolvercast Staff should mark long spells usable after an enabling adjustment");
@@ -688,7 +813,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             assertCalibrationImbueState(helper, parrycast, 0, longScroll,
                     SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
                     "Parrycast Buckler should accept long spells with a warning before an enabling adjustment");
-            ParrycastBuckler.setCalibrationAdjustment(parrycast, 0, silverRing);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(parrycast, 0, silverRing);
             assertCalibrationImbueState(helper, parrycast, 0, longScroll,
                     SpellCalibrationImbueState.ACCEPTED_USABLE,
                     "Parrycast Buckler should mark long spells usable after an enabling adjustment");
@@ -698,7 +823,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             assertCalibrationImbueState(helper, reflectcast, 0, profiledContinuousScroll,
                     SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
                     "Reflectcast Shield should accept continuous spells with a warning before an enabling adjustment");
-            ReflectcastShield.setCalibrationAdjustment(reflectcast, 0, silverRing);
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(reflectcast, 0, silverRing);
             assertCalibrationImbueState(helper, reflectcast, 0, profiledContinuousScroll,
                     SpellCalibrationImbueState.ACCEPTED_USABLE,
                     "Reflectcast Shield should mark continuous spells usable after an enabling adjustment");
@@ -731,7 +856,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
 
             var twoSlotAmulet = new ItemStack(autocastAmulet);
             autocastAmulet.initializeSpellContainer(twoSlotAmulet);
-            AutocastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     twoSlotAmulet,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
@@ -764,7 +889,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             assertSatelliteSpellData(helper, satelliteAmulet, 0, mageLight, 1,
                     "Calibration-imbued Satellite Followcast Amulet should contain mage_light");
 
-            SatelliteFollowcastAmulet.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     satelliteAmulet,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get())
@@ -915,7 +1040,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             var staff = new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get());
             var staffItem = (MithrilFreecastStaff) staff.getItem();
             staffItem.initializeSpellContainer(staff);
-            MithrilFreecastStaff.setCalibrationAdjustment(
+            SpellCalibrationAdjustmentGameTestSupport.setCalibrationAdjustment(
                     staff,
                     0,
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get())

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
@@ -192,6 +192,8 @@ import jp.aquafactory.apprenticecodex.registry.BlockRegistry;
 import jp.aquafactory.apprenticecodex.registry.CreativeTabRegistry;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
 import jp.aquafactory.apprenticecodex.registry.EntityRegistry;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
+import jp.aquafactory.apprenticecodex.item.shield.ParrycastBuckler;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.LootConditionRegistry;
 import jp.aquafactory.apprenticecodex.registry.PoiTypeRegistry;
@@ -629,6 +631,89 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
         });
     }
 
+    static void spellCalibrationBenchImbueStatesSeparateInsertionFromCurrentUsability(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "spell_calibration_imbue_state_test");
+            var silverRing = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get());
+            var wisdomShard = new ItemStack(ItemRegistry.WISDOM_SHARD.get());
+            var longScroll = createSpellScroll(SpellRegistry.MANTIS_LEAP.get());
+            var continuousScroll = createSpellScroll(SpellRegistry.MANA_CHARGE.get());
+            var profiledContinuousScroll = createSpellScroll(
+                    io.redspace.ironsspellbooks.api.registry.SpellRegistry.FIRE_BREATH_SPELL.get()
+            );
+
+            var autocast = new ItemStack(ItemRegistry.AUTOCAST_AMULET.get());
+            var autocastMenu = createSpellCalibrationBenchMenuWithTarget(player, autocast);
+            assertCalibrationImbueState(helper, autocast, 0, longScroll,
+                    SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
+                    "Autocast Amulet should accept long spells with a warning before an enabling adjustment");
+            AutocastAmulet.setCalibrationAdjustment(autocast, 0, wisdomShard);
+            assertCalibrationImbueState(helper, autocast, 0, longScroll,
+                    SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
+                    "Wisdom Shard runtime profiles should not change Calibration Bench insertion state");
+            AutocastAmulet.setCalibrationAdjustment(autocast, 1, silverRing);
+            assertCalibrationImbueState(helper, autocast, 0, longScroll,
+                    SpellCalibrationImbueState.ACCEPTED_USABLE,
+                    "Autocast Amulet should mark long spells usable after an enabling adjustment");
+            autocastMenu.getSlot(SpellCalibrationBenchMenu.SCROLL_MENU_SLOT_START).set(longScroll.copy());
+            AutocastAmulet.setCalibrationAdjustment(autocast, 1, ItemStack.EMPTY);
+            helper.assertFalse(AutocastAmulet.getCalibrationScroll(autocast, 0).isEmpty(),
+                    "Removing an enabling adjustment should keep an already inserted scroll");
+            helper.assertTrue(autocastMenu.shouldRenderMismatchCastConditionWarning(0),
+                    "Removing an enabling adjustment should restore the configured-spell warning");
+
+            var satellite = new ItemStack(ItemRegistry.SATELLITE_FOLLOWCAST_AMULET.get());
+            createSpellCalibrationBenchMenuWithTarget(player, satellite);
+            assertCalibrationImbueState(helper, satellite, 0, profiledContinuousScroll,
+                    SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
+                    "Satellite Followcast Amulet should accept continuous spells with a warning before an enabling adjustment");
+            SatelliteFollowcastAmulet.setCalibrationAdjustment(satellite, 0, silverRing);
+            assertCalibrationImbueState(helper, satellite, 0, profiledContinuousScroll,
+                    SpellCalibrationImbueState.ACCEPTED_USABLE,
+                    "Satellite Followcast Amulet should mark continuous spells usable after an enabling adjustment");
+
+            var revolver = new ItemStack(ItemRegistry.REVOLVERCAST_STAFF.get());
+            createSpellCalibrationBenchMenuWithTarget(player, revolver);
+            assertCalibrationImbueState(helper, revolver, 0, longScroll,
+                    SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
+                    "Revolvercast Staff should accept long spells with a warning before an enabling adjustment");
+            RevolvercastStaff.setCalibrationAdjustment(revolver, 0, silverRing);
+            assertCalibrationImbueState(helper, revolver, 0, longScroll,
+                    SpellCalibrationImbueState.ACCEPTED_USABLE,
+                    "Revolvercast Staff should mark long spells usable after an enabling adjustment");
+
+            var parrycast = new ItemStack(ItemRegistry.PARRYCAST_BUCKLER.get());
+            createSpellCalibrationBenchMenuWithTarget(player, parrycast);
+            assertCalibrationImbueState(helper, parrycast, 0, longScroll,
+                    SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
+                    "Parrycast Buckler should accept long spells with a warning before an enabling adjustment");
+            ParrycastBuckler.setCalibrationAdjustment(parrycast, 0, silverRing);
+            assertCalibrationImbueState(helper, parrycast, 0, longScroll,
+                    SpellCalibrationImbueState.ACCEPTED_USABLE,
+                    "Parrycast Buckler should mark long spells usable after an enabling adjustment");
+
+            var reflectcast = new ItemStack(ItemRegistry.REFLECTCAST_SHIELD.get());
+            createSpellCalibrationBenchMenuWithTarget(player, reflectcast);
+            assertCalibrationImbueState(helper, reflectcast, 0, profiledContinuousScroll,
+                    SpellCalibrationImbueState.ACCEPTED_CURRENTLY_UNUSABLE,
+                    "Reflectcast Shield should accept continuous spells with a warning before an enabling adjustment");
+            ReflectcastShield.setCalibrationAdjustment(reflectcast, 0, silverRing);
+            assertCalibrationImbueState(helper, reflectcast, 0, profiledContinuousScroll,
+                    SpellCalibrationImbueState.ACCEPTED_USABLE,
+                    "Reflectcast Shield should mark continuous spells usable after an enabling adjustment");
+
+            var rejectedAutocast = new ItemStack(ItemRegistry.AUTOCAST_AMULET.get());
+            var rejectedAutocastMenu = createSpellCalibrationBenchMenuWithTarget(player, rejectedAutocast);
+            assertCalibrationImbueState(helper, rejectedAutocast, 0, continuousScroll,
+                    SpellCalibrationImbueState.REJECTED,
+                    "Autocast Amulet should reject permanently unsupported continuous spells");
+            rejectedAutocastMenu.getSlot(SpellCalibrationBenchMenu.SCROLL_MENU_SLOT_START)
+                    .set(continuousScroll.copy());
+            helper.assertTrue(AutocastAmulet.getCalibrationScroll(rejectedAutocast, 0).isEmpty(),
+                    "Rejected Autocast Amulet spells should not be stored through direct Slot#set");
+        });
+    }
     static void spellCalibrationBenchImbueOnlySupportsExtractableTargets(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "spell_calibration_imbue_test");
@@ -777,6 +862,8 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             spellAmplifierMenu.getSlot(SpellCalibrationBenchMenu.SCROLL_MENU_SLOT_START).set(createSpellScroll(heal));
             assertStackHasSpell(helper, spellAmplifier, heal, 1,
                     "Calibration Bench should imbue generic extractable Spell Amplifiers");
+            helper.assertFalse(spellAmplifierMenu.shouldRenderMismatchCastConditionWarning(0),
+                    "A filled generic SpellContainer should not be treated as a configured-spell mismatch");
             helper.assertTrue(spellAmplifierMenu.getSlot(SpellCalibrationBenchMenu.SCROLL_MENU_SLOT_START).remove(1)
                             .is(io.redspace.ironsspellbooks.registries.ItemRegistry.SCROLL.get()),
                     "Calibration Bench should extract generic Spell Amplifier spells");
@@ -789,6 +876,17 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
         });
     }
 
+    private static void assertCalibrationImbueState(
+            GameTestHelper helper,
+            ItemStack targetStack,
+            int slot,
+            ItemStack scrollStack,
+            SpellCalibrationImbueState expected,
+            String message
+    ) {
+        var actual = SpellCalibrationImbueHelper.evaluateScrollAt(targetStack, slot, scrollStack);
+        helper.assertTrue(actual == expected, message + ": expected=" + expected + ", actual=" + actual);
+    }
     static void mithrilFreecastStaffBlocksArcaneAnvilImbueViaSpellValidator(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var stack = new ItemStack(ItemRegistry.MITHRIL_FREECAST_STAFF.get());

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
@@ -677,11 +677,11 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
             var gauntlet = targets[0];
             var gauntletProfile = ((SpellCalibrationAdjustmentTarget) gauntlet.getItem())
                     .getCalibrationAdjustmentProfile(gauntlet);
-            helper.assertTrue(gauntletProfile.rules().size() == 5,
-                    "Scrollcaster Gauntlet should expose all five hint groups from its rules");
+            helper.assertTrue(gauntletProfile.rules().size() == 4,
+                    "Scrollcaster Gauntlet should expose all four hint groups from its rules");
             helper.assertTrue(gauntletProfile.rules().get(0).hint() instanceof CalibrationAdjustmentHint.TaggedItems,
                     "Scrollcaster Gauntlet slot upgrades should use a generated tag hint");
-            helper.assertTrue(gauntletProfile.rules().get(4).hint() instanceof CalibrationAdjustmentHint.Translatable,
+            helper.assertTrue(gauntletProfile.rules().get(3).hint() instanceof CalibrationAdjustmentHint.Translatable,
                     "Scrollcaster Gauntlet school runes should use a translated category hint");
 
             var silverRing = new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get());

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellCalibrationEquipmentGameTestScenarios.java
@@ -647,7 +647,7 @@ final class SpellCalibrationEquipmentGameTestScenarios extends ApprenticeCodexGa
                     new ItemStack(ItemRegistry.PARRYCAST_BUCKLER.get()),
                     new ItemStack(ItemRegistry.REFLECTCAST_SHIELD.get())
             };
-            var expectedSlotCounts = new int[]{3, 3, 3, 1, 3, 3, 1, 3, 3};
+            var expectedSlotCounts = new int[]{3, 3, 3, 1, 3, 3, 3, 3, 3};
             var representativeAdjustments = new ItemStack[]{
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE.get()),
                     new ItemStack(io.redspace.ironsspellbooks.registries.ItemRegistry.COOLDOWN_RUNE.get()),

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentHint.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentHint.java
@@ -1,0 +1,58 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.item.Item;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * 術式調整台へ表示する候補ヘルプの意味情報。
+ *
+ * <p>Item 側へ client 専用の Component 生成を持ち込まず、表示方法は Screen 側へ委譲する。</p>
+ */
+public sealed interface CalibrationAdjustmentHint
+        permits CalibrationAdjustmentHint.Translatable,
+        CalibrationAdjustmentHint.SpecificItem,
+        CalibrationAdjustmentHint.TaggedItems {
+
+    static CalibrationAdjustmentHint translatable(String translationKey) {
+        return new Translatable(translationKey);
+    }
+
+    static CalibrationAdjustmentHint specificItem(Supplier<? extends Item> item) {
+        return new SpecificItem(item);
+    }
+
+    static CalibrationAdjustmentHint taggedItems(
+            String headingTranslationKey,
+            TagKey<Item> tag,
+            Supplier<? extends Item> fallbackItem
+    ) {
+        return new TaggedItems(headingTranslationKey, tag, fallbackItem);
+    }
+
+    record Translatable(String translationKey) implements CalibrationAdjustmentHint {
+        public Translatable {
+            Objects.requireNonNull(translationKey);
+        }
+    }
+
+    record SpecificItem(Supplier<? extends Item> item) implements CalibrationAdjustmentHint {
+        public SpecificItem {
+            Objects.requireNonNull(item);
+        }
+    }
+
+    record TaggedItems(
+            String headingTranslationKey,
+            TagKey<Item> tag,
+            Supplier<? extends Item> fallbackItem
+    ) implements CalibrationAdjustmentHint {
+        public TaggedItems {
+            Objects.requireNonNull(headingTranslationKey);
+            Objects.requireNonNull(tag);
+            Objects.requireNonNull(fallbackItem);
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentHints.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentHints.java
@@ -1,0 +1,54 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
+import jp.aquafactory.apprenticecodex.registry.TagRegistry;
+import net.minecraft.world.item.Items;
+
+/** 複数の調整対象で共有する意味的な候補ヘルプ。 */
+public final class CalibrationAdjustmentHints {
+    private static final String KEY_PREFIX =
+            "container.apprenticecodex.spell_calibration_bench.tooltip.";
+
+    private CalibrationAdjustmentHints() {
+    }
+
+    public static CalibrationAdjustmentHint schoolRunes() {
+        return CalibrationAdjustmentHint.translatable(KEY_PREFIX + "item_hint_runes");
+    }
+
+    public static CalibrationAdjustmentHint slotUpgrades() {
+        return CalibrationAdjustmentHint.taggedItems(
+                KEY_PREFIX + "item_hint_slot_upgrades",
+                TagRegistry.Items.SCROLLCASTER_GAUNTLET_SLOT_UPGRADES,
+                io.redspace.ironsspellbooks.registries.ItemRegistry.LESSER_SPELL_SLOT_UPGRADE
+        );
+    }
+
+    public static CalibrationAdjustmentHint enchantmentBooks() {
+        return CalibrationAdjustmentHint.taggedItems(
+                KEY_PREFIX + "item_hint_enchantment_books",
+                TagRegistry.Items.SCROLLCASTER_GAUNTLET_ENCHANTMENT_BOOKS,
+                () -> Items.ENCHANTED_BOOK
+        );
+    }
+
+    public static CalibrationAdjustmentHint mithrilFreecastStaff() {
+        return CalibrationAdjustmentHint.specificItem(ItemRegistry.MITHRIL_FREECAST_STAFF);
+    }
+
+    public static CalibrationAdjustmentHint recoveryRune() {
+        return CalibrationAdjustmentHint.specificItem(
+                io.redspace.ironsspellbooks.registries.ItemRegistry.COOLDOWN_RUNE
+        );
+    }
+
+    public static CalibrationAdjustmentHint silverRing() {
+        return CalibrationAdjustmentHint.specificItem(
+                io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING
+        );
+    }
+
+    public static CalibrationAdjustmentHint wisdomShard() {
+        return CalibrationAdjustmentHint.specificItem(ItemRegistry.WISDOM_SHARD);
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentProfile.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentProfile.java
@@ -1,0 +1,55 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Objects;
+
+/** 調整対象 Item が受け付ける候補ルールの順序付き宣言。 */
+public final class CalibrationAdjustmentProfile {
+    private final List<CalibrationAdjustmentRule> rules;
+
+    private CalibrationAdjustmentProfile(List<CalibrationAdjustmentRule> rules) {
+        this.rules = List.copyOf(rules);
+    }
+
+    public static CalibrationAdjustmentProfile of(CalibrationAdjustmentRule... rules) {
+        return new CalibrationAdjustmentProfile(List.of(rules));
+    }
+
+    public List<CalibrationAdjustmentRule> rules() {
+        return rules;
+    }
+
+    boolean canPlace(
+            SpellCalibrationAdjustmentTarget target,
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack candidate
+    ) {
+        Objects.requireNonNull(target);
+        if (slot < 0 || slot >= target.getCalibrationAdjustmentSlotCount(targetStack)) {
+            return false;
+        }
+        if (candidate.isEmpty()) {
+            return true;
+        }
+
+        var matchedRule = rules.stream().filter(rule -> rule.accepts(candidate)).findFirst().orElse(null);
+        if (matchedRule == null) {
+            return false;
+        }
+        for (var existingSlot = 0;
+             existingSlot < target.getCalibrationAdjustmentSlotCount(targetStack);
+             ++existingSlot) {
+            if (existingSlot == slot) {
+                continue;
+            }
+            if (matchedRule.conflicts(candidate, target.getCalibrationAdjustment(targetStack, existingSlot))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentProfile.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentProfile.java
@@ -1,10 +1,12 @@
 package jp.aquafactory.apprenticecodex.item;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.IntFunction;
 
 /** 調整対象 Item が受け付ける候補ルールの順序付き宣言。 */
 public final class CalibrationAdjustmentProfile {
@@ -28,7 +30,40 @@ public final class CalibrationAdjustmentProfile {
             int slot,
             @NotNull ItemStack candidate
     ) {
+        return canPlace(
+                target,
+                targetStack,
+                slot,
+                candidate,
+                existingSlot -> target.getCalibrationAdjustment(targetStack, existingSlot)
+        );
+    }
+
+    boolean canPlace(
+            SpellCalibrationAdjustmentTarget target,
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack candidate,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        return canPlace(
+                target,
+                targetStack,
+                slot,
+                candidate,
+                existingSlot -> target.getCalibrationAdjustment(targetStack, existingSlot, lookupProvider)
+        );
+    }
+
+    private boolean canPlace(
+            SpellCalibrationAdjustmentTarget target,
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack candidate,
+            IntFunction<ItemStack> existingAdjustment
+    ) {
         Objects.requireNonNull(target);
+        Objects.requireNonNull(existingAdjustment);
         if (slot < 0 || slot >= target.getCalibrationAdjustmentSlotCount(targetStack)) {
             return false;
         }
@@ -46,7 +81,7 @@ public final class CalibrationAdjustmentProfile {
             if (existingSlot == slot) {
                 continue;
             }
-            if (matchedRule.conflicts(candidate, target.getCalibrationAdjustment(targetStack, existingSlot))) {
+            if (matchedRule.conflicts(candidate, existingAdjustment.apply(existingSlot))) {
                 return false;
             }
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentRule.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/CalibrationAdjustmentRule.java
@@ -1,0 +1,66 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/** 候補の受理条件、重複制約、ヘルプを一か所で宣言するルール。 */
+public final class CalibrationAdjustmentRule {
+    private final Predicate<ItemStack> matcher;
+    private final BiPredicate<ItemStack, ItemStack> conflict;
+    private final CalibrationAdjustmentHint hint;
+
+    private CalibrationAdjustmentRule(
+            Predicate<ItemStack> matcher,
+            BiPredicate<ItemStack, ItemStack> conflict,
+            CalibrationAdjustmentHint hint
+    ) {
+        this.matcher = Objects.requireNonNull(matcher);
+        this.conflict = Objects.requireNonNull(conflict);
+        this.hint = Objects.requireNonNull(hint);
+    }
+
+    public static CalibrationAdjustmentRule repeatable(
+            Predicate<ItemStack> matcher,
+            CalibrationAdjustmentHint hint
+    ) {
+        return new CalibrationAdjustmentRule(matcher, (candidate, existing) -> false, hint);
+    }
+
+    public static CalibrationAdjustmentRule unique(
+            Predicate<ItemStack> matcher,
+            CalibrationAdjustmentHint hint
+    ) {
+        return new CalibrationAdjustmentRule(matcher, (candidate, existing) -> matcher.test(existing), hint);
+    }
+
+    public static <T> CalibrationAdjustmentRule uniqueBy(
+            Predicate<ItemStack> matcher,
+            Function<ItemStack, T> keyResolver,
+            CalibrationAdjustmentHint hint
+    ) {
+        Objects.requireNonNull(keyResolver);
+        return new CalibrationAdjustmentRule(
+                matcher,
+                (candidate, existing) -> matcher.test(existing)
+                        && Objects.equals(keyResolver.apply(candidate), keyResolver.apply(existing)),
+                hint
+        );
+    }
+
+    public boolean accepts(@NotNull ItemStack stack) {
+        return matcher.test(stack);
+    }
+
+    public boolean conflicts(@NotNull ItemStack candidate, @NotNull ItemStack existing) {
+        return !existing.isEmpty() && conflict.test(candidate, existing);
+    }
+
+    public CalibrationAdjustmentHint hint() {
+        return hint;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/RestrictedSpellImbuableItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/RestrictedSpellImbuableItem.java
@@ -5,11 +5,12 @@ import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public interface RestrictedSpellImbuableItem {
+public interface RestrictedSpellImbuableItem extends SpellCalibrationImbueTarget {
     boolean canImbueSpell(SpellData spellData);
 
     boolean canImbueSpell(@Nullable AbstractSpell spell, int spellLevel);
@@ -29,6 +30,13 @@ public interface RestrictedSpellImbuableItem {
 
     default boolean canRemoveWorkbenchSpell(ItemStack stack, ISpellContainer spellContainer, int spellIndex, SpellData spellData) {
         return spellData.canRemove();
+    }
+
+    @Override
+    default @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(@NotNull ItemStack targetStack, int slot, @NotNull SpellData spellData) {
+        return canImbueSpell(spellData)
+                ? SpellCalibrationImbueState.ACCEPTED_USABLE
+                : SpellCalibrationImbueState.REJECTED;
     }
 
     default List<Component> getImbueRestrictionTooltipLines() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/SneakSelectionUiItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/SneakSelectionUiItem.java
@@ -1,0 +1,8 @@
+package jp.aquafactory.apprenticecodex.item;
+
+/**
+ * スニーク開始時に選択 UI を表示するアイテムを示す。
+ * 両手に該当アイテムがある場合は、メインハンド側の選択 UI を優先する。
+ */
+public interface SneakSelectionUiItem {
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationAdjustmentTarget.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationAdjustmentTarget.java
@@ -1,0 +1,35 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+/** 術式調整台の調整スロットを持つ Item。 */
+public interface SpellCalibrationAdjustmentTarget {
+    int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack);
+
+    @NotNull
+    ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot);
+
+    /**
+     * 新しい候補は profile の論理制約を通して保存する。空スタックは旧データの取り外しを保証するため常に許可する。
+     */
+    boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    );
+
+    @NotNull
+    CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack);
+
+    default boolean canPlaceCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (targetStack.isEmpty() || targetStack.getItem() != this) {
+            return false;
+        }
+        return getCalibrationAdjustmentProfile(targetStack).canPlace(this, targetStack, slot, adjustment);
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationAdjustmentTarget.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationAdjustmentTarget.java
@@ -1,5 +1,6 @@
 package jp.aquafactory.apprenticecodex.item;
 
+import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,6 +12,17 @@ public interface SpellCalibrationAdjustmentTarget {
     ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot);
 
     /**
+     * 動的レジストリを含む ItemStack を扱う対象は、接続中 Level の lookup provider を使って復元する。
+     */
+    default @NotNull ItemStack getCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        return getCalibrationAdjustment(targetStack, slot);
+    }
+
+    /**
      * 新しい候補は profile の論理制約を通して保存する。空スタックは旧データの取り外しを保証するため常に許可する。
      */
     boolean trySetCalibrationAdjustment(
@@ -18,6 +30,18 @@ public interface SpellCalibrationAdjustmentTarget {
             int slot,
             @NotNull ItemStack adjustment
     );
+
+    /**
+     * 動的レジストリを含む ItemStack を扱う対象は、接続中 Level の lookup provider を使って保存する。
+     */
+    default boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        return trySetCalibrationAdjustment(targetStack, slot, adjustment);
+    }
 
     @NotNull
     CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack);
@@ -31,5 +55,18 @@ public interface SpellCalibrationAdjustmentTarget {
             return false;
         }
         return getCalibrationAdjustmentProfile(targetStack).canPlace(this, targetStack, slot, adjustment);
+    }
+
+    default boolean canPlaceCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        if (targetStack.isEmpty() || targetStack.getItem() != this) {
+            return false;
+        }
+        return getCalibrationAdjustmentProfile(targetStack)
+                .canPlace(this, targetStack, slot, adjustment, lookupProvider);
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationImbueState.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationImbueState.java
@@ -1,0 +1,27 @@
+package jp.aquafactory.apprenticecodex.item;
+
+public enum SpellCalibrationImbueState {
+    REJECTED(false, false),
+    ACCEPTED_USABLE(true, true),
+    ACCEPTED_CURRENTLY_UNUSABLE(true, false);
+
+    private final boolean insertable;
+    private final boolean usable;
+
+    SpellCalibrationImbueState(boolean insertable, boolean usable) {
+        this.insertable = insertable;
+        this.usable = usable;
+    }
+
+    public boolean canInsert() {
+        return insertable;
+    }
+
+    public boolean isUsable() {
+        return usable;
+    }
+
+    public static SpellCalibrationImbueState accepted(boolean usable) {
+        return usable ? ACCEPTED_USABLE : ACCEPTED_CURRENTLY_UNUSABLE;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationImbueTarget.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationImbueTarget.java
@@ -1,0 +1,14 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import io.redspace.ironsspellbooks.api.spells.SpellData;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+public interface SpellCalibrationImbueTarget {
+    @NotNull
+    SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData
+    );
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationImbueTarget.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/SpellCalibrationImbueTarget.java
@@ -1,6 +1,7 @@
 package jp.aquafactory.apprenticecodex.item;
 
 import io.redspace.ironsspellbooks.api.spells.SpellData;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -11,4 +12,13 @@ public interface SpellCalibrationImbueTarget {
             int slot,
             @NotNull SpellData spellData
     );
+
+    default @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        return evaluateCalibrationImbue(targetStack, slot, spellData);
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/StoredSpellCalibrationImbueTarget.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/StoredSpellCalibrationImbueTarget.java
@@ -1,0 +1,7 @@
+package jp.aquafactory.apprenticecodex.item;
+
+/**
+ * 術式調整台のスクロールを通常の SpellContainer ではなく独自領域へ保存する対象。
+ */
+public interface StoredSpellCalibrationImbueTarget extends SpellCalibrationImbueTarget {
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/MagiAgentSuitItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/MagiAgentSuitItem.java
@@ -6,7 +6,11 @@ import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import io.redspace.ironsspellbooks.api.spells.CastType;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.enchantment.Enchantments;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.renderer.armor.MagiAgentSuitRenderer;
 import jp.aquafactory.apprenticecodex.utility.MagicTools;
 import jp.aquafactory.apprenticecodex.utility.ScrollcasterSchoolRuneResolver;
@@ -42,8 +46,16 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 import java.util.List;
 import java.util.function.Consumer;
 
-public class MagiAgentSuitItem extends ArmorItem implements GeoItem, IPresetSpellContainer {
+public class MagiAgentSuitItem extends ArmorItem
+        implements GeoItem, IPresetSpellContainer, SpellCalibrationAdjustmentTarget {
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 1;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.unique(
+                            ScrollcasterSchoolRuneResolver::isSchoolRune,
+                            CalibrationAdjustmentHints.schoolRunes()
+                    )
+            );
 
     private static final String CALIBRATION_TAG = "MagiAgentSuitCalibration";
     private static final String ADJUSTMENT_ITEM_TAG = "AdjustmentItem";
@@ -193,7 +205,7 @@ public class MagiAgentSuitItem extends ArmorItem implements GeoItem, IPresetSpel
         return cache;
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack suitStack, int slot) {
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack suitStack, int slot) {
         if (!isValidCalibrationAccess(suitStack, slot)) {
             return ItemStack.EMPTY;
         }
@@ -211,7 +223,7 @@ public class MagiAgentSuitItem extends ArmorItem implements GeoItem, IPresetSpel
         return item == Items.AIR ? ItemStack.EMPTY : new ItemStack(item);
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack suitStack, int slot, @NotNull ItemStack stack) {
+    private static void writeCalibrationAdjustment(@NotNull ItemStack suitStack, int slot, @NotNull ItemStack stack) {
         if (!isValidCalibrationAccess(suitStack, slot)) {
             return;
         }
@@ -233,12 +245,36 @@ public class MagiAgentSuitItem extends ArmorItem implements GeoItem, IPresetSpel
         });
     }
 
-    public static boolean isCalibrationAdjustmentItem(@NotNull ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.isSchoolRune(stack);
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static @Nullable SchoolType getResolvedCalibrationSchool(ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.resolveSchool(getCalibrationAdjustment(stack, 0)).orElse(null);
+        return ScrollcasterSchoolRuneResolver.resolveSchool(readCalibrationAdjustment(stack, 0)).orElse(null);
     }
 
     private void appendSuitEffectHoverText(List<Component> lines) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmulet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmulet.java
@@ -8,7 +8,11 @@ import io.redspace.ironsspellbooks.compat.Curios;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.item.ArcaneAnvilImbueBlockItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
 import jp.aquafactory.apprenticecodex.item.StoredSpellCalibrationImbueTarget;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
@@ -42,10 +46,25 @@ import java.util.List;
 import java.util.ArrayList;
 
 public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, ArcaneAnvilImbueBlockItem,
-        StoredSpellCalibrationImbueTarget {
+        StoredSpellCalibrationImbueTarget, SpellCalibrationAdjustmentTarget {
     public static final int MIN_SPELL_SLOTS = 1;
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
     public static final int MAX_SPELL_SLOTS = MIN_SPELL_SLOTS + CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.repeatable(
+                            AutocastAmulet::isCalibrationSlotUpgrade,
+                            CalibrationAdjustmentHints.slotUpgrades()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            AutocastAmulet::isSilverRing,
+                            CalibrationAdjustmentHints.silverRing()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            AutocastAmulet::isWisdomShard,
+                            CalibrationAdjustmentHints.wisdomShard()
+                    )
+            );
 
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.autocast_amulet.desc_";
     private static final String CALIBRATION_TAG = "SpellCalibration";
@@ -267,12 +286,40 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
         return customData == null ? null : customData.copyTag();
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot) {
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot) {
         return getCalibrationItem(amuletStack, slot);
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot, @NotNull ItemStack stack) {
+    private static void writeCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot, @NotNull ItemStack stack) {
         setCalibrationItem(amuletStack, slot, stack);
+    }
+
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static @NotNull ItemStack getCalibrationScroll(@NotNull ItemStack amuletStack, int slot) {
@@ -290,15 +337,11 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
 
         var upgradeCount = 0;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isCalibrationSlotUpgrade(getCalibrationAdjustment(amuletStack, slot))) {
+            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(amuletStack, slot))) {
                 ++upgradeCount;
             }
         }
         return clampSpellSlotCount(MIN_SPELL_SLOTS + upgradeCount);
-    }
-
-    public static boolean isCalibrationAdjustmentItem(@NotNull ItemStack stack) {
-        return isCalibrationSlotUpgrade(stack) || isSilverRing(stack) || isWisdomShard(stack);
     }
 
     public static boolean isCalibrationSlotUpgrade(@NotNull ItemStack stack) {
@@ -320,7 +363,7 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isSilverRing(getCalibrationAdjustment(amuletStack, slot))) {
+            if (isSilverRing(readCalibrationAdjustment(amuletStack, slot))) {
                 return true;
             }
         }
@@ -333,7 +376,7 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isWisdomShard(getCalibrationAdjustment(amuletStack, slot))) {
+            if (isWisdomShard(readCalibrationAdjustment(amuletStack, slot))) {
                 return true;
             }
         }
@@ -392,14 +435,14 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
 
         var existingUpgradeCount = 0;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isCalibrationSlotUpgrade(getCalibrationAdjustment(amuletStack, slot))) {
+            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(amuletStack, slot))) {
                 ++existingUpgradeCount;
             }
         }
 
         var missingUpgradeCount = Math.min(CALIBRATION_ADJUSTMENT_SLOT_COUNT, legacyExtraSlots) - existingUpgradeCount;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT && missingUpgradeCount > 0; ++slot) {
-            if (!getCalibrationAdjustment(amuletStack, slot).isEmpty()) {
+            if (!readCalibrationAdjustment(amuletStack, slot).isEmpty()) {
                 continue;
             }
             setCalibrationItem(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmulet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/autocastamulet/AutocastAmulet.java
@@ -9,6 +9,8 @@ import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.item.ArcaneAnvilImbueBlockItem;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
+import jp.aquafactory.apprenticecodex.item.StoredSpellCalibrationImbueTarget;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.TagRegistry;
@@ -39,7 +41,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.ArrayList;
 
-public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, ArcaneAnvilImbueBlockItem {
+public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, ArcaneAnvilImbueBlockItem,
+        StoredSpellCalibrationImbueTarget {
     public static final int MIN_SPELL_SLOTS = 1;
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
     public static final int MAX_SPELL_SLOTS = MIN_SPELL_SLOTS + CALIBRATION_ADJUSTMENT_SLOT_COUNT;
@@ -124,6 +127,19 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
                 && spell != io.redspace.ironsspellbooks.api.registry.SpellRegistry.none()
                 && getSupportedCastTypes(stack).contains(SpellGunCastType.from(spell.getCastType()))
                 && spell.getRecastCount(spellLevel, null) <= 0;
+    }
+
+    @Override
+    public @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData
+    ) {
+        if (!isEnabledSpellSlot(targetStack, slot) || !canImbueSpell(spellData)) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+        // Wisdom Shard のプロファイルはプレイヤー状態に依存するため、ここでは対象構成だけを評価する。
+        return SpellCalibrationImbueState.accepted(canAutoCastSpell(targetStack, spellData));
     }
 
     public List<Component> getImbueRestrictionTooltipLines() {
@@ -333,17 +349,6 @@ public class AutocastAmulet extends Item implements ICurioItem, IJeiInfoItem, Ar
 
     public static boolean isEnabledSpellSlot(@NotNull ItemStack amuletStack, int slot) {
         return isValidStoredSpellAccess(amuletStack, slot) && slot < getEnabledSpellSlotCount(amuletStack);
-    }
-
-    public static boolean isMismatchedCastConditionAt(@NotNull ItemStack amuletStack, int slot) {
-        if (!isValidStoredSpellAccess(amuletStack, slot)) {
-            return false;
-        }
-
-        var spellData = getSpellDataAt(amuletStack, slot);
-        return spellData != SpellData.EMPTY
-                && spellData.getSpell() != null
-                && !isCastableConfiguredSpell(amuletStack, spellData);
     }
 
     public static @NotNull SpellData getSpellDataAt(@NotNull ItemStack amuletStack, int slot) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/satellitefollowcastamulet/SatelliteFollowcastAmulet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/satellitefollowcastamulet/SatelliteFollowcastAmulet.java
@@ -8,7 +8,11 @@ import io.redspace.ironsspellbooks.compat.Curios;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.item.ArcaneAnvilImbueBlockItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
 import jp.aquafactory.apprenticecodex.item.StoredSpellCalibrationImbueTarget;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastOrigin;
@@ -41,10 +45,21 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiInfoItem, ArcaneAnvilImbueBlockItem,
-        StoredSpellCalibrationImbueTarget {
+        StoredSpellCalibrationImbueTarget, SpellCalibrationAdjustmentTarget {
     public static final int MIN_SPELL_SLOTS = 1;
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
     public static final int MAX_SPELL_SLOTS = MIN_SPELL_SLOTS + CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.repeatable(
+                            SatelliteFollowcastAmulet::isCalibrationSlotUpgrade,
+                            CalibrationAdjustmentHints.slotUpgrades()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            SatelliteFollowcastAmulet::isSilverRing,
+                            CalibrationAdjustmentHints.silverRing()
+                    )
+            );
     public static final double CRYSTAL_ORBIT_RADIUS = 1.35D;
     public static final double CRYSTAL_ORBIT_HEIGHT = 1.05D;
     public static final double CRYSTAL_ORBIT_SPEED = Math.PI / 60.0D;
@@ -147,12 +162,40 @@ public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiI
         return MIN_SPELL_SLOTS + CALIBRATION_ADJUSTMENT_SLOT_COUNT;
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot) {
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot) {
         return getCalibrationItem(amuletStack, ADJUSTMENTS_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT);
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot, @NotNull ItemStack stack) {
+    private static void writeCalibrationAdjustment(@NotNull ItemStack amuletStack, int slot, @NotNull ItemStack stack) {
         setCalibrationItem(amuletStack, ADJUSTMENTS_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT, stack);
+    }
+
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static @NotNull ItemStack getCalibrationScroll(@NotNull ItemStack amuletStack, int slot) {
@@ -170,15 +213,11 @@ public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiI
 
         var upgradeCount = 0;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isCalibrationSlotUpgrade(getCalibrationAdjustment(amuletStack, slot))) {
+            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(amuletStack, slot))) {
                 ++upgradeCount;
             }
         }
         return clampSpellSlotCount(MIN_SPELL_SLOTS + upgradeCount);
-    }
-
-    public static boolean isCalibrationAdjustmentItem(@NotNull ItemStack stack) {
-        return isCalibrationSlotUpgrade(stack) || isSilverRing(stack);
     }
 
     public static boolean isCalibrationSlotUpgrade(@NotNull ItemStack stack) {
@@ -196,7 +235,7 @@ public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiI
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isSilverRing(getCalibrationAdjustment(amuletStack, slot))) {
+            if (isSilverRing(readCalibrationAdjustment(amuletStack, slot))) {
                 return true;
             }
         }
@@ -326,14 +365,14 @@ public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiI
 
         var existingUpgradeCount = 0;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isCalibrationSlotUpgrade(getCalibrationAdjustment(amuletStack, slot))) {
+            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(amuletStack, slot))) {
                 ++existingUpgradeCount;
             }
         }
 
         var missingUpgradeCount = Math.min(CALIBRATION_ADJUSTMENT_SLOT_COUNT, legacyExtraSlots) - existingUpgradeCount;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT && missingUpgradeCount > 0; ++slot) {
-            if (!getCalibrationAdjustment(amuletStack, slot).isEmpty()) {
+            if (!readCalibrationAdjustment(amuletStack, slot).isEmpty()) {
                 continue;
             }
             setCalibrationItem(

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/satellitefollowcastamulet/SatelliteFollowcastAmulet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/satellitefollowcastamulet/SatelliteFollowcastAmulet.java
@@ -9,6 +9,8 @@ import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.item.ArcaneAnvilImbueBlockItem;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
+import jp.aquafactory.apprenticecodex.item.StoredSpellCalibrationImbueTarget;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastOrigin;
 import jp.aquafactory.apprenticecodex.remoteownercast.RemoteOwnerCastRules;
 import jp.aquafactory.apprenticecodex.registry.TagRegistry;
@@ -38,7 +40,8 @@ import top.theillusivec4.curios.api.type.capability.ICurioItem;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiInfoItem, ArcaneAnvilImbueBlockItem {
+public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiInfoItem, ArcaneAnvilImbueBlockItem,
+        StoredSpellCalibrationImbueTarget {
     public static final int MIN_SPELL_SLOTS = 1;
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
     public static final int MAX_SPELL_SLOTS = MIN_SPELL_SLOTS + CALIBRATION_ADJUSTMENT_SLOT_COUNT;
@@ -214,19 +217,20 @@ public class SatelliteFollowcastAmulet extends Item implements ICurioItem, IJeiI
                 && getSupportedCastTypes(stack).contains(spellData.getSpell().getCastType());
     }
 
-    public static boolean isEnabledSpellSlot(@NotNull ItemStack amuletStack, int slot) {
-        return isValidStoredSpellAccess(amuletStack, slot) && slot < getEnabledSpellSlotCount(amuletStack);
+    @Override
+    public @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData
+    ) {
+        if (!isEnabledSpellSlot(targetStack, slot) || !canImbueSpell(spellData)) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+        return SpellCalibrationImbueState.accepted(canFollowcastSpell(targetStack, spellData));
     }
 
-    public static boolean isMismatchedCastConditionAt(@NotNull ItemStack amuletStack, int slot) {
-        if (!isValidStoredSpellAccess(amuletStack, slot)) {
-            return false;
-        }
-
-        var spellData = getSpellDataAt(amuletStack, slot);
-        return spellData != SpellData.EMPTY
-                && spellData.getSpell() != null
-                && !isCastableConfiguredSpell(amuletStack, spellData);
+    public static boolean isEnabledSpellSlot(@NotNull ItemStack amuletStack, int slot) {
+        return isValidStoredSpellAccess(amuletStack, slot) && slot < getEnabledSpellSlotCount(amuletStack);
     }
 
     public static List<SpellData> getImbuedSpells(ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
@@ -9,6 +9,7 @@ import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
+import jp.aquafactory.apprenticecodex.item.SneakSelectionUiItem;
 import jp.aquafactory.apprenticecodex.item.ammo.BowCastAmmoResolver;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiver;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiverBowAmmoResolver;
@@ -71,7 +72,7 @@ import jp.aquafactory.apprenticecodex.item.ArcaneAnvilImbueBlockItem;
 import jp.aquafactory.apprenticecodex.item.TriggeredSpellCastHelper;
 
 public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContainer, ArcaneAnvilImbueBlockItem,
-        IJeiInfoItem {
+        IJeiInfoItem, SneakSelectionUiItem {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.elemental_bow.desc_";
 
     public static final int READY_DRAW_TICKS = 20;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/magicitem/StorageStabilizer.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/magicitem/StorageStabilizer.java
@@ -8,6 +8,7 @@ import io.redspace.ironsspellbooks.api.spells.IPresetSpellContainer;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.item.UniqueItem;
+import jp.aquafactory.apprenticecodex.item.SneakSelectionUiItem;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import net.minecraft.ChatFormatting;
@@ -31,7 +32,7 @@ import net.minecraft.world.level.Level;
 import java.util.ArrayList;
 import java.util.List;
 
-public final class StorageStabilizer extends Item implements IPresetSpellContainer, UniqueItem {
+public final class StorageStabilizer extends Item implements IPresetSpellContainer, UniqueItem, SneakSelectionUiItem {
     private static final String SELECTED_SPELL_INDEX_TAG = "SelectedStorageSpellIndex";
     private static final int DEFAULT_SPELL_INDEX = 0;
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/mithrilfreecaststaff/MithrilFreecastStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/mithrilfreecaststaff/MithrilFreecastStaff.java
@@ -60,18 +60,34 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import jp.aquafactory.apprenticecodex.item.AbstractRightClickMagicWeaponItem;
 import jp.aquafactory.apprenticecodex.item.ArcaneAnvilImbueBlockItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.CastAnimationOverrideItem;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
 import jp.aquafactory.apprenticecodex.item.TriggeredSpellCastHelper;
 import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
 
 public class MithrilFreecastStaff extends AbstractRightClickMagicWeaponItem
-        implements GeoItem, CastAnimationOverrideItem, IJeiInfoItem, SwingTriggeredMagicItem, ArcaneAnvilImbueBlockItem {
+        implements GeoItem, CastAnimationOverrideItem, IJeiInfoItem, SwingTriggeredMagicItem,
+        ArcaneAnvilImbueBlockItem, SpellCalibrationAdjustmentTarget {
     private static final String ITEM_KEY = "mithril_freecast_staff";
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.mithril_freecast_staff.desc_";
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.unique(
+                            ScrollcasterSchoolRuneResolver::isSchoolRune,
+                            CalibrationAdjustmentHints.schoolRunes()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            MithrilFreecastStaff::isSilverRing,
+                            CalibrationAdjustmentHints.silverRing()
+                    )
+            );
     private static final String MAIN_CONTROLLER = "main";
     private static final String CALIBRATION_TAG = "SpellCalibration";
     private static final String ADJUSTMENTS_TAG = "Adjustments";
@@ -357,13 +373,41 @@ public class MithrilFreecastStaff extends AbstractRightClickMagicWeaponItem
                 : EnumSet.of(SpellGunCastType.INSTANT);
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack staffStack, int slot) {
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack staffStack, int slot) {
         return getCalibrationItem(staffStack, slot);
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack staffStack, int slot, @NotNull ItemStack stack) {
+    private static void writeCalibrationAdjustment(@NotNull ItemStack staffStack, int slot, @NotNull ItemStack stack) {
         setCalibrationItem(staffStack, slot, stack);
         refreshResolvedCalibrationSchool(staffStack);
+    }
+
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static void refreshResolvedCalibrationSchool(@NotNull ItemStack staffStack) {
@@ -372,7 +416,7 @@ public class MithrilFreecastStaff extends AbstractRightClickMagicWeaponItem
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            var school = ScrollcasterSchoolRuneResolver.resolveSchool(getCalibrationAdjustment(staffStack, slot));
+            var school = ScrollcasterSchoolRuneResolver.resolveSchool(readCalibrationAdjustment(staffStack, slot));
             if (school.isPresent()) {
                 setResolvedCalibrationSchoolId(staffStack, school.get().getId());
                 return;
@@ -387,10 +431,6 @@ public class MithrilFreecastStaff extends AbstractRightClickMagicWeaponItem
         return schoolId == null ? null : SchoolRegistry.getSchool(schoolId);
     }
 
-    public static boolean isCalibrationAdjustmentItem(@NotNull ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.isSchoolRune(stack) || isSilverRing(stack);
-    }
-
     public static boolean isSilverRing(@NotNull ItemStack stack) {
         return !stack.isEmpty() && stack.getItem() == io.redspace.ironsspellbooks.registries.ItemRegistry.SILVER_RING.get();
     }
@@ -401,7 +441,7 @@ public class MithrilFreecastStaff extends AbstractRightClickMagicWeaponItem
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isSilverRing(getCalibrationAdjustment(staffStack, slot))) {
+            if (isSilverRing(readCalibrationAdjustment(staffStack, slot))) {
                 return true;
             }
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/revolvercaststaff/RevolvercastStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/revolvercaststaff/RevolvercastStaff.java
@@ -69,9 +69,15 @@ import java.util.List;
 import java.util.function.Consumer;
 import jp.aquafactory.apprenticecodex.item.AbstractRightClickMagicWeaponItem;
 import jp.aquafactory.apprenticecodex.item.ArcaneAnvilImbueBlockItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.CastAnimationOverrideItem;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
 import jp.aquafactory.apprenticecodex.item.RestrictedSpellImbuableItem;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
+import jp.aquafactory.apprenticecodex.item.StoredSpellCalibrationImbueTarget;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
 import jp.aquafactory.apprenticecodex.item.TriggeredSpellCastHelper;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
@@ -79,13 +85,33 @@ import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
 
 public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
         implements GeoItem, CastAnimationOverrideItem, IJeiInfoItem, SwingTriggeredMagicItem,
-        RestrictedSpellImbuableItem, ArcaneAnvilImbueBlockItem, StoredSpellCalibrationImbueTarget {
+        RestrictedSpellImbuableItem, ArcaneAnvilImbueBlockItem, StoredSpellCalibrationImbueTarget,
+        SpellCalibrationAdjustmentTarget {
     private static final String ITEM_KEY = "revolvercast_staff";
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.revolvercast_staff.desc_";
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
     public static final int CALIBRATION_SCROLL_SLOT_COUNT = 10;
     public static final int BASE_CALIBRATION_SCROLL_SLOT_COUNT = 4;
     public static final int CALIBRATION_SCROLL_SLOTS_PER_UPGRADE = 2;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.repeatable(
+                            RevolvercastStaff::isCalibrationSlotUpgrade,
+                            CalibrationAdjustmentHints.slotUpgrades()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            ScrollcasterSchoolRuneResolver::isSchoolRune,
+                            CalibrationAdjustmentHints.schoolRunes()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            RevolvercastStaff::isRecoveryRune,
+                            CalibrationAdjustmentHints.recoveryRune()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            RevolvercastStaff::isSilverRing,
+                            CalibrationAdjustmentHints.silverRing()
+                    )
+            );
 
     private static final HolderLookup.Provider FALLBACK_SERIALIZATION_LOOKUP =
             RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
@@ -460,14 +486,42 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
                 : EnumSet.of(SpellGunCastType.INSTANT);
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack staffStack, int slot) {
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack staffStack, int slot) {
         return getCalibrationItem(staffStack, ADJUSTMENTS_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT);
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack staffStack, int slot, @NotNull ItemStack stack) {
+    private static void writeCalibrationAdjustment(@NotNull ItemStack staffStack, int slot, @NotNull ItemStack stack) {
         setCalibrationItem(staffStack, ADJUSTMENTS_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT, stack);
         refreshResolvedCalibrationSchool(staffStack);
         refreshSelectedSpellContainer(staffStack);
+    }
+
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static @NotNull ItemStack getCalibrationScroll(@NotNull ItemStack staffStack, int slot) {
@@ -490,7 +544,7 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
 
         var upgradeCount = 0;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isCalibrationSlotUpgrade(getCalibrationAdjustment(staffStack, slot))) {
+            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(staffStack, slot))) {
                 ++upgradeCount;
             }
         }
@@ -608,7 +662,7 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            var school = ScrollcasterSchoolRuneResolver.resolveSchool(getCalibrationAdjustment(staffStack, slot));
+            var school = ScrollcasterSchoolRuneResolver.resolveSchool(readCalibrationAdjustment(staffStack, slot));
             if (school.isPresent()) {
                 setResolvedCalibrationSchoolId(staffStack, school.get().getId());
                 return;
@@ -621,13 +675,6 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
     public static @Nullable SchoolType getResolvedCalibrationSchool(ItemStack stack) {
         var schoolId = getResolvedCalibrationSchoolId(stack);
         return schoolId == null ? null : SchoolRegistry.getSchool(schoolId);
-    }
-
-    public static boolean isCalibrationAdjustmentItem(@NotNull ItemStack stack) {
-        return isCalibrationSlotUpgrade(stack)
-                || ScrollcasterSchoolRuneResolver.isSchoolRune(stack)
-                || isRecoveryRune(stack)
-                || isSilverRing(stack);
     }
 
     public static boolean isCalibrationSlotUpgrade(@NotNull ItemStack stack) {
@@ -644,7 +691,7 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
 
     public static boolean hasRecoveryRune(@NotNull ItemStack staffStack) {
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isRecoveryRune(getCalibrationAdjustment(staffStack, slot))) {
+            if (isRecoveryRune(readCalibrationAdjustment(staffStack, slot))) {
                 return true;
             }
         }
@@ -653,7 +700,7 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
 
     public static boolean hasSilverRingAdjustment(@NotNull ItemStack staffStack) {
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isSilverRing(getCalibrationAdjustment(staffStack, slot))) {
+            if (isSilverRing(readCalibrationAdjustment(staffStack, slot))) {
                 return true;
             }
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/revolvercaststaff/RevolvercastStaff.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/revolvercaststaff/RevolvercastStaff.java
@@ -79,7 +79,7 @@ import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
 
 public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
         implements GeoItem, CastAnimationOverrideItem, IJeiInfoItem, SwingTriggeredMagicItem,
-        RestrictedSpellImbuableItem, ArcaneAnvilImbueBlockItem {
+        RestrictedSpellImbuableItem, ArcaneAnvilImbueBlockItem, StoredSpellCalibrationImbueTarget {
     private static final String ITEM_KEY = "revolvercast_staff";
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.revolvercast_staff.desc_";
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
@@ -233,6 +233,20 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
     @Override
     public boolean canImbueSpell(@Nullable AbstractSpell spell, int spellLevel) {
         return canSwingCastSpell(spell);
+    }
+
+    @Override
+    public @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData
+    ) {
+        if (slot < 0 || slot >= getEnabledCalibrationScrollSlotCount(targetStack)
+                || spellData == SpellData.EMPTY || spellData.getSpell() == null
+                || !canSwingCastSpell(spellData.getSpell(), true)) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+        return SpellCalibrationImbueState.accepted(canSwingCastSpell(targetStack, spellData.getSpell()));
     }
 
     @Override
@@ -570,17 +584,6 @@ public final class RevolvercastStaff extends AbstractRightClickMagicWeaponItem
         }
 
         return getScrollSpellData(getCalibrationScroll(staffStack, selectedIndex));
-    }
-
-    public static boolean isMismatchedCastConditionScroll(@NotNull ItemStack staffStack, int slot) {
-        if (!isValidCalibrationAccess(staffStack, slot, CALIBRATION_SCROLL_SLOT_COUNT)) {
-            return false;
-        }
-
-        var spellData = getScrollSpellData(getCalibrationScroll(staffStack, slot));
-        return spellData != SpellData.EMPTY
-                && spellData.getSpell() != null
-                && !canSwingCastSpell(staffStack, spellData.getSpell());
     }
 
     public static void refreshSelectedSpellContainer(@NotNull ItemStack staffStack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
@@ -94,7 +94,8 @@ import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
 
 public final class ScrollcasterGauntlet extends Item implements GeoItem, IPresetSpellContainer, UniqueItem,
         ItemTransformPreservingCastAnimationItem,
-        BetterCombatOffhandDualWieldingPolicyItem, SwingTriggeredMagicItem, PriorityOffhandUseDeferringItem, IJeiInfoItem {
+        BetterCombatOffhandDualWieldingPolicyItem, SwingTriggeredMagicItem, PriorityOffhandUseDeferringItem, IJeiInfoItem,
+        SneakSelectionUiItem {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.scrollcaster_gauntlet.desc_";
 
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
@@ -144,7 +144,17 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
             int slot,
             @NotNull SpellData spellData
     ) {
-        if (slot < 0 || slot >= getEnabledCalibrationScrollSlotCount(targetStack)
+        return evaluateCalibrationImbue(targetStack, slot, spellData, serializationLookup());
+    }
+
+    @Override
+    public @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        if (slot < 0 || slot >= getEnabledCalibrationScrollSlotCount(targetStack, lookupProvider)
                 || spellData == SpellData.EMPTY || spellData.getSpell() == null) {
             return SpellCalibrationImbueState.REJECTED;
         }
@@ -234,7 +244,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
             return InteractionResultHolder.pass(stack);
         }
 
-        var spellData = getSelectedSpellData(stack);
+        var spellData = getSelectedSpellData(stack, level.registryAccess());
         if (spellData == SpellData.EMPTY || spellData.getSpell() == null || spellData.getSpell() == SpellRegistry.none()) {
             return InteractionResultHolder.pass(stack);
         }
@@ -268,8 +278,10 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     @Override
     public void inventoryTick(@NotNull ItemStack stack, @NotNull Level level, @NotNull Entity entity, int slotId, boolean isSelected) {
         super.inventoryTick(stack, level, entity, slotId, isSelected);
-        if (hasAnyCalibrationScroll(stack) && !isCurrentSelectedSpellContainer(stack)) {
-            refreshSelectedSpellContainer(stack);
+        var lookupProvider = level.registryAccess();
+        if (hasAnyCalibrationScroll(stack, lookupProvider)
+                && !isCurrentSelectedSpellContainer(stack, lookupProvider)) {
+            refreshSelectedSpellContainer(stack, lookupProvider);
         }
     }
 
@@ -297,7 +309,8 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
                     resolvedSchool.getDisplayName()
             ).withStyle(ChatFormatting.GRAY));
         }
-        if (hasFreecastStaffAdjustment(stack)) {
+        var lookupProvider = context.registries();
+        if (lookupProvider != null && hasFreecastStaffAdjustment(stack, lookupProvider)) {
             lines.add(Component.translatable("item.apprenticecodex.freecast.common.desc")
                     .withStyle(ChatFormatting.GRAY));
         }
@@ -307,7 +320,8 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     @Override
     public boolean canTriggerSpellOnSwing(Player player, InteractionHand hand) {
         var stack = player.getItemInHand(hand);
-        return stack.getItem() == this && hasFreecastStaffAdjustment(stack);
+        return stack.getItem() == this
+                && hasFreecastStaffAdjustment(stack, player.level().registryAccess());
     }
 
     @Override
@@ -322,8 +336,9 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
             return false;
         }
 
-        refreshSelectedSpellContainer(stack);
-        var spellData = getSelectedSpellData(stack);
+        var lookupProvider = player.level().registryAccess();
+        refreshSelectedSpellContainer(stack, lookupProvider);
+        var spellData = getSelectedSpellData(stack, lookupProvider);
         if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
             return false;
         }
@@ -621,8 +636,12 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
         );
     }
 
-    private static void writeCalibrationAdjustment(@NotNull ItemStack gauntletStack, int slot, @NotNull ItemStack stack) {
-        var lookupProvider = serializationLookup();
+    private static void writeCalibrationAdjustment(
+            @NotNull ItemStack gauntletStack,
+            int slot,
+            @NotNull ItemStack stack,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
         setCalibrationItem(
                 gauntletStack,
                 ADJUSTMENTS_TAG,
@@ -647,15 +666,34 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     }
 
     @Override
+    public @NotNull ItemStack getCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        return readCalibrationAdjustment(targetStack, slot, lookupProvider);
+    }
+
+    @Override
     public boolean trySetCalibrationAdjustment(
             @NotNull ItemStack targetStack,
             int slot,
             @NotNull ItemStack adjustment
     ) {
-        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+        return trySetCalibrationAdjustment(targetStack, slot, adjustment, serializationLookup());
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment, lookupProvider)) {
             return false;
         }
-        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        writeCalibrationAdjustment(targetStack, slot, adjustment, lookupProvider);
         return true;
     }
 
@@ -691,16 +729,30 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     }
 
     public static boolean hasAnyCalibrationScroll(@NotNull ItemStack gauntletStack) {
-        return findFirstValidScrollIndex(gauntletStack) >= 0;
+        return hasAnyCalibrationScroll(gauntletStack, serializationLookup());
+    }
+
+    public static boolean hasAnyCalibrationScroll(
+            @NotNull ItemStack gauntletStack,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        return findFirstValidScrollIndex(gauntletStack, lookupProvider) >= 0;
     }
 
     public static boolean hasFreecastStaffAdjustment(@NotNull ItemStack gauntletStack) {
+        return hasFreecastStaffAdjustment(gauntletStack, serializationLookup());
+    }
+
+    public static boolean hasFreecastStaffAdjustment(
+            @NotNull ItemStack gauntletStack,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
         if (!isValidCalibrationAccess(gauntletStack, 0, 1)) {
             return false;
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isFreecastStaffAdjustment(readCalibrationAdjustment(gauntletStack, slot))) {
+            if (isFreecastStaffAdjustment(readCalibrationAdjustment(gauntletStack, slot, lookupProvider))) {
                 return true;
             }
         }
@@ -765,7 +817,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
         var upgradeCount = 0;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(gauntletStack, slot))) {
+            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(gauntletStack, slot, lookupProvider))) {
                 ++upgradeCount;
             }
         }
@@ -791,17 +843,25 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     }
 
     public static void setSelectedScrollIndex(@NotNull ItemStack gauntletStack, int selectedScrollIndex) {
+        setSelectedScrollIndex(gauntletStack, selectedScrollIndex, serializationLookup());
+    }
+
+    public static void setSelectedScrollIndex(
+            @NotNull ItemStack gauntletStack,
+            int selectedScrollIndex,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
         if (!isValidCalibrationAccess(gauntletStack, 0, 1)) {
             return;
         }
 
-        if (!isSelectableScrollIndex(gauntletStack, selectedScrollIndex)) {
-            refreshSelectedSpellContainer(gauntletStack);
+        if (!isSelectableScrollIndex(gauntletStack, selectedScrollIndex, lookupProvider)) {
+            refreshSelectedSpellContainer(gauntletStack, lookupProvider);
             return;
         }
 
         setStoredSelectedScrollIndex(gauntletStack, selectedScrollIndex);
-        refreshSelectedSpellContainer(gauntletStack);
+        refreshSelectedSpellContainer(gauntletStack, lookupProvider);
     }
 
     public static boolean isSelectableScrollIndex(@NotNull ItemStack gauntletStack, int selectedScrollIndex) {
@@ -931,7 +991,14 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
     }
 
     private static boolean isCurrentSelectedSpellContainer(@NotNull ItemStack gauntletStack) {
-        var spellData = getSelectedSpellData(gauntletStack);
+        return isCurrentSelectedSpellContainer(gauntletStack, serializationLookup());
+    }
+
+    private static boolean isCurrentSelectedSpellContainer(
+            @NotNull ItemStack gauntletStack,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        var spellData = getSelectedSpellData(gauntletStack, lookupProvider);
         return spellData != SpellData.EMPTY
                 && spellData.getSpell() != null
                 && isCurrentSelectedSpellContainer(gauntletStack, spellData);
@@ -1067,7 +1134,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
             return magicData.getCastingSpellLevel();
         }
 
-        var spellData = getSelectedSpellData(stack);
+        var spellData = getSelectedSpellData(stack, player.level().registryAccess());
         if (spellData != SpellData.EMPTY && spell.equals(spellData.getSpell())) {
             return spell.getLevelFor(spellData.getLevel(), player);
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
@@ -876,10 +876,6 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
         }
 
         var selectedIndex = normalizeSelectedScrollIndex(gauntletStack, lookupProvider);
-        if (selectedIndex < 0) {
-            return List.of();
-        }
-
         var enabledSlotCount = getEnabledCalibrationScrollSlotCount(gauntletStack, lookupProvider);
         var views = new ArrayList<ScrollSelectionView>();
         for (var slot = 0; slot < enabledSlotCount; ++slot) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
@@ -95,7 +95,7 @@ import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
 public final class ScrollcasterGauntlet extends Item implements GeoItem, IPresetSpellContainer, UniqueItem,
         ItemTransformPreservingCastAnimationItem,
         BetterCombatOffhandDualWieldingPolicyItem, SwingTriggeredMagicItem, PriorityOffhandUseDeferringItem, IJeiInfoItem,
-        SneakSelectionUiItem {
+        SneakSelectionUiItem, StoredSpellCalibrationImbueTarget {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.scrollcaster_gauntlet.desc_";
 
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
@@ -105,6 +105,27 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
     private static final HolderLookup.Provider FALLBACK_SERIALIZATION_LOOKUP =
             RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
+
+    @Override
+    public @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData
+    ) {
+        if (slot < 0 || slot >= getEnabledCalibrationScrollSlotCount(targetStack)
+                || spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+        return SpellCalibrationImbueState.ACCEPTED_USABLE;
+    }
+
+    private static final String MALUM_NAMESPACE = "malum";
+    private static final ResourceLocation MALUM_SPIRIT_PLUNDER =
+            ResourceLocation.fromNamespaceAndPath(MALUM_NAMESPACE, "spirit_plunder");
+    private static final TagKey<Item> MALUM_SOUL_HUNTER_WEAPON = TagKey.create(
+            Registries.ITEM,
+            ResourceLocation.fromNamespaceAndPath(MALUM_NAMESPACE, "soul_hunter_weapon")
+    );
     private static final String MAIN_CONTROLLER = "main";
     private static final String CALIBRATION_TAG = "SpellCalibration";
     private static final String ADJUSTMENTS_TAG = "Adjustments";

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
@@ -130,10 +130,6 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
                             CalibrationAdjustmentHints.mithrilFreecastStaff()
                     ),
                     CalibrationAdjustmentRule.unique(
-                            ScrollcasterGauntlet::isSilverRingAdjustment,
-                            CalibrationAdjustmentHints.silverRing()
-                    ),
-                    CalibrationAdjustmentRule.unique(
                             ScrollcasterSchoolRuneResolver::isSchoolRune,
                             CalibrationAdjustmentHints.schoolRunes()
                     )
@@ -333,7 +329,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
         }
 
         var spell = spellData.getSpell();
-        if (!MithrilFreecastStaff.canSwingCastSpell(spell, hasSilverRingAdjustment(stack))) {
+        if (!MithrilFreecastStaff.canSwingCastSpell(spell, true)) {
             player.displayClientMessage(
                     Component.translatable(
                             "ui.apprenticecodex.swingcast.cannot_swing_cast",
@@ -372,7 +368,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
                     spell,
                     magicData,
                     slotId,
-                    spell.getCastType() == CastType.LONG && hasSilverRingAdjustment(stack) ? 0 : null
+                    spell.getCastType() == CastType.LONG ? 0 : null
             );
             if (player instanceof ServerPlayer serverPlayer) {
                 triggerCastAnimation(serverPlayer, stack);
@@ -705,19 +701,6 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
             if (isFreecastStaffAdjustment(readCalibrationAdjustment(gauntletStack, slot))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public static boolean hasSilverRingAdjustment(@NotNull ItemStack gauntletStack) {
-        if (!isValidCalibrationAccess(gauntletStack, 0, 1)) {
-            return false;
-        }
-
-        for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isSilverRingAdjustment(readCalibrationAdjustment(gauntletStack, slot))) {
                 return true;
             }
         }
@@ -1078,10 +1061,6 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
     public static boolean isFreecastStaffAdjustment(@NotNull ItemStack stack) {
         return !stack.isEmpty() && stack.getItem() instanceof MithrilFreecastStaff;
-    }
-
-    public static boolean isSilverRingAdjustment(@NotNull ItemStack stack) {
-        return MithrilFreecastStaff.isSilverRing(stack);
     }
 
     private static int resolveEffectiveSpellLevel(Player player, ItemStack stack, AbstractSpell spell) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/scrollcastergauntlet/ScrollcasterGauntlet.java
@@ -33,6 +33,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -40,6 +41,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
@@ -81,11 +83,18 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import jp.aquafactory.apprenticecodex.item.AbstractRightClickMagicWeaponItem;
 import jp.aquafactory.apprenticecodex.item.BetterCombatOffhandDualWieldingPolicyItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
 import jp.aquafactory.apprenticecodex.item.ItemTransformPreservingCastAnimationItem;
 import jp.aquafactory.apprenticecodex.item.OffhandUsePriorityHelper;
 import jp.aquafactory.apprenticecodex.item.PriorityOffhandUseDeferringItem;
 import jp.aquafactory.apprenticecodex.item.RightClickSpellItemHelper;
+import jp.aquafactory.apprenticecodex.item.SneakSelectionUiItem;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
+import jp.aquafactory.apprenticecodex.item.StoredSpellCalibrationImbueTarget;
 import jp.aquafactory.apprenticecodex.item.SwingTriggeredMagicItem;
 import jp.aquafactory.apprenticecodex.item.TriggeredSpellCastHelper;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
@@ -95,13 +104,40 @@ import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
 public final class ScrollcasterGauntlet extends Item implements GeoItem, IPresetSpellContainer, UniqueItem,
         ItemTransformPreservingCastAnimationItem,
         BetterCombatOffhandDualWieldingPolicyItem, SwingTriggeredMagicItem, PriorityOffhandUseDeferringItem, IJeiInfoItem,
-        SneakSelectionUiItem, StoredSpellCalibrationImbueTarget {
+        SneakSelectionUiItem, StoredSpellCalibrationImbueTarget, SpellCalibrationAdjustmentTarget {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.scrollcaster_gauntlet.desc_";
 
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
     public static final int CALIBRATION_SCROLL_SLOT_COUNT = 10;
     public static final int BASE_CALIBRATION_SCROLL_SLOT_COUNT = 4;
     public static final int CALIBRATION_SCROLL_SLOTS_PER_UPGRADE = 2;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.repeatable(
+                            ScrollcasterGauntlet::isCalibrationSlotUpgrade,
+                            CalibrationAdjustmentHints.slotUpgrades()
+                    ),
+                    CalibrationAdjustmentRule.uniqueBy(
+                            stack -> stack.is(TagRegistry.Items.SCROLLCASTER_GAUNTLET_ENCHANTMENT_BOOKS),
+                            stack -> {
+                                var candidate = readFirstBookEnchantment(stack);
+                                return candidate == null ? null : candidate.enchantment();
+                            },
+                            CalibrationAdjustmentHints.enchantmentBooks()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            ScrollcasterGauntlet::isFreecastStaffAdjustment,
+                            CalibrationAdjustmentHints.mithrilFreecastStaff()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            ScrollcasterGauntlet::isSilverRingAdjustment,
+                            CalibrationAdjustmentHints.silverRing()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            ScrollcasterSchoolRuneResolver::isSchoolRune,
+                            CalibrationAdjustmentHints.schoolRunes()
+                    )
+            );
 
     private static final HolderLookup.Provider FALLBACK_SERIALIZATION_LOOKUP =
             RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
@@ -571,32 +607,65 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
         return school == null ? ItemStack.EMPTY : SchoolAffinityRegistry.createIconStack(school);
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack gauntletStack, int slot) {
-        return getCalibrationAdjustment(gauntletStack, slot, serializationLookup());
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack gauntletStack, int slot) {
+        return readCalibrationAdjustment(gauntletStack, slot, serializationLookup());
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(
+    private static @NotNull ItemStack readCalibrationAdjustment(
             @NotNull ItemStack gauntletStack,
             int slot,
             @NotNull HolderLookup.Provider lookupProvider
     ) {
-        return getCalibrationItem(gauntletStack, ADJUSTMENTS_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT, lookupProvider);
+        return getCalibrationItem(
+                gauntletStack,
+                ADJUSTMENTS_TAG,
+                slot,
+                CALIBRATION_ADJUSTMENT_SLOT_COUNT,
+                lookupProvider
+        );
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack gauntletStack, int slot, @NotNull ItemStack stack) {
-        setCalibrationAdjustment(gauntletStack, slot, stack, serializationLookup());
-    }
-
-    public static void setCalibrationAdjustment(
-            @NotNull ItemStack gauntletStack,
-            int slot,
-            @NotNull ItemStack stack,
-            @NotNull HolderLookup.Provider lookupProvider
-    ) {
-        setCalibrationItem(gauntletStack, ADJUSTMENTS_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT, stack, lookupProvider);
+    private static void writeCalibrationAdjustment(@NotNull ItemStack gauntletStack, int slot, @NotNull ItemStack stack) {
+        var lookupProvider = serializationLookup();
+        setCalibrationItem(
+                gauntletStack,
+                ADJUSTMENTS_TAG,
+                slot,
+                CALIBRATION_ADJUSTMENT_SLOT_COUNT,
+                stack,
+                lookupProvider
+        );
         refreshCalibrationEnchantments(gauntletStack, lookupProvider);
         refreshResolvedCalibrationSchool(gauntletStack, lookupProvider);
         refreshSelectedSpellContainer(gauntletStack, lookupProvider);
+    }
+
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static @NotNull ItemStack getCalibrationScroll(@NotNull ItemStack gauntletStack, int slot) {
@@ -635,7 +704,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isFreecastStaffAdjustment(getCalibrationAdjustment(gauntletStack, slot))) {
+            if (isFreecastStaffAdjustment(readCalibrationAdjustment(gauntletStack, slot))) {
                 return true;
             }
         }
@@ -648,7 +717,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isSilverRingAdjustment(getCalibrationAdjustment(gauntletStack, slot))) {
+            if (isSilverRingAdjustment(readCalibrationAdjustment(gauntletStack, slot))) {
                 return true;
             }
         }
@@ -669,7 +738,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
         var candidatesByEnchantment = new LinkedHashMap<Holder<Enchantment>, CalibrationEnchantmentCandidate>();
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            var candidate = readFirstBookEnchantment(getCalibrationAdjustment(gauntletStack, slot, lookupProvider));
+            var candidate = readFirstBookEnchantment(readCalibrationAdjustment(gauntletStack, slot, lookupProvider));
             if (candidate == null || !isSupportedCalibrationEnchantment(gauntletStack, candidate.enchantment())) {
                 continue;
             }
@@ -713,7 +782,7 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
 
         var upgradeCount = 0;
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            if (isCalibrationSlotUpgrade(getCalibrationAdjustment(gauntletStack, slot))) {
+            if (isCalibrationSlotUpgrade(readCalibrationAdjustment(gauntletStack, slot))) {
                 ++upgradeCount;
             }
         }
@@ -917,7 +986,9 @@ public final class ScrollcasterGauntlet extends Item implements GeoItem, IPreset
         }
 
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
-            var school = ScrollcasterSchoolRuneResolver.resolveSchool(getCalibrationAdjustment(gauntletStack, slot, lookupProvider));
+            var school = ScrollcasterSchoolRuneResolver.resolveSchool(
+                    readCalibrationAdjustment(gauntletStack, slot, lookupProvider)
+            );
             if (school.isPresent()) {
                 setResolvedCalibrationSchoolId(gauntletStack, school.get().getId());
                 return;

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/BulwarkGreatshield.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/BulwarkGreatshield.java
@@ -9,8 +9,11 @@ import io.redspace.ironsspellbooks.api.spells.CastType;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
-import jp.aquafactory.apprenticecodex.item.shield.AbstractImbueShieldItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.utility.MagicTools;
 import jp.aquafactory.apprenticecodex.utility.ScrollcasterSchoolRuneResolver;
@@ -41,12 +44,24 @@ import software.bernie.geckolib.util.GeckoLibUtil;
 
 import java.util.List;
 
-public class BulwarkGreatshield extends AbstractImbueShieldItem implements GeoItem, IJeiInfoItem {
+public class BulwarkGreatshield extends AbstractImbueShieldItem
+        implements GeoItem, IJeiInfoItem, SpellCalibrationAdjustmentTarget {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.bulwark_greatshield.desc_";
 
     public static final int DURABILITY = 2031;
     public static final int ENCHANTMENT_VALUE = 15;
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 1;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.unique(
+                            ScrollcasterSchoolRuneResolver::isSchoolRune,
+                            CalibrationAdjustmentHints.schoolRunes()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            BulwarkGreatshield::isWisdomShard,
+                            CalibrationAdjustmentHints.wisdomShard()
+                    )
+            );
     public static final int DURABILITY_SUPPRESSION_TICKS = 20;
     public static final int CONTINUOUS_CAST_DELAY_TICKS = 20;
     public static final int MANA_RECOVERY_COOLDOWN_TICKS = 20;
@@ -195,22 +210,46 @@ public class BulwarkGreatshield extends AbstractImbueShieldItem implements GeoIt
                 .allMatch(enchantment -> supportsEnchantment(stack, enchantment));
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot) {
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot) {
         if (!isValidCalibrationAccess(shieldStack, slot)) {
             return ItemStack.EMPTY;
         }
         return ShieldCalibrationData.get(shieldStack, CALIBRATION_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT);
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot, @NotNull ItemStack adjustment) {
+    private static void writeCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot, @NotNull ItemStack adjustment) {
         if (!isValidCalibrationAccess(shieldStack, slot)) {
             return;
         }
         ShieldCalibrationData.set(shieldStack, CALIBRATION_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT, adjustment);
     }
 
-    public static boolean isCalibrationAdjustmentItem(@NotNull ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.isSchoolRune(stack) || isWisdomShard(stack);
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static boolean isWisdomShard(@NotNull ItemStack stack) {
@@ -218,11 +257,11 @@ public class BulwarkGreatshield extends AbstractImbueShieldItem implements GeoIt
     }
 
     public static boolean hasWisdomShardAdjustment(ItemStack stack) {
-        return isWisdomShard(getCalibrationAdjustment(stack, 0));
+        return isWisdomShard(readCalibrationAdjustment(stack, 0));
     }
 
     public static @Nullable io.redspace.ironsspellbooks.api.spells.SchoolType getResolvedCalibrationSchool(ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.resolveSchool(getCalibrationAdjustment(stack, 0)).orElse(null);
+        return ScrollcasterSchoolRuneResolver.resolveSchool(readCalibrationAdjustment(stack, 0)).orElse(null);
     }
 
     @Nullable

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/BulwarkGreatshield.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/BulwarkGreatshield.java
@@ -6,6 +6,7 @@ import io.redspace.ironsspellbooks.api.registry.AttributeRegistry;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.CastType;
+import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
@@ -42,6 +43,7 @@ import software.bernie.geckolib.animatable.instance.AnimatableInstanceCache;
 import software.bernie.geckolib.animation.AnimatableManager;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class BulwarkGreatshield extends AbstractImbueShieldItem
@@ -50,11 +52,13 @@ public class BulwarkGreatshield extends AbstractImbueShieldItem
 
     public static final int DURABILITY = 2031;
     public static final int ENCHANTMENT_VALUE = 15;
-    public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 1;
+    public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
     private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
             CalibrationAdjustmentProfile.of(
-                    CalibrationAdjustmentRule.unique(
+                    CalibrationAdjustmentRule.uniqueBy(
                             ScrollcasterSchoolRuneResolver::isSchoolRune,
+                            stack -> ScrollcasterSchoolRuneResolver.resolveSchool(stack)
+                                    .map(SchoolType::getId),
                             CalibrationAdjustmentHints.schoolRunes()
                     ),
                     CalibrationAdjustmentRule.unique(
@@ -163,13 +167,15 @@ public class BulwarkGreatshield extends AbstractImbueShieldItem
                 GENERIC_SPELL_RESIST,
                 AttributeModifier.Operation.ADD_MULTIPLIED_BASE
         ), net.minecraft.world.entity.EquipmentSlotGroup.OFFHAND);
-        var schoolResist = MagicTools.resolveSchoolResistAttribute(getResolvedCalibrationSchool(stack));
-        if (schoolResist != null) {
-            builder.add(BuiltInRegistries.ATTRIBUTE.wrapAsHolder(schoolResist), new AttributeModifier(
-                    SCHOOL_RESIST_MODIFIER_ID,
-                    SCHOOL_SPELL_RESIST,
-                    AttributeModifier.Operation.ADD_MULTIPLIED_BASE
-            ), net.minecraft.world.entity.EquipmentSlotGroup.OFFHAND);
+        for (var school : getResolvedCalibrationSchools(stack)) {
+            var schoolResist = MagicTools.resolveSchoolResistAttribute(school);
+            if (schoolResist != null) {
+                builder.add(BuiltInRegistries.ATTRIBUTE.wrapAsHolder(schoolResist), new AttributeModifier(
+                        SCHOOL_RESIST_MODIFIER_ID,
+                        SCHOOL_SPELL_RESIST,
+                        AttributeModifier.Operation.ADD_MULTIPLIED_BASE
+                ), net.minecraft.world.entity.EquipmentSlotGroup.OFFHAND);
+            }
         }
         return builder.build();
     }
@@ -257,11 +263,26 @@ public class BulwarkGreatshield extends AbstractImbueShieldItem
     }
 
     public static boolean hasWisdomShardAdjustment(ItemStack stack) {
-        return isWisdomShard(readCalibrationAdjustment(stack, 0));
+        for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
+            if (isWisdomShard(readCalibrationAdjustment(stack, slot))) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    public static @Nullable io.redspace.ironsspellbooks.api.spells.SchoolType getResolvedCalibrationSchool(ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.resolveSchool(readCalibrationAdjustment(stack, 0)).orElse(null);
+    public static @NotNull List<SchoolType> getResolvedCalibrationSchools(ItemStack stack) {
+        var schools = new ArrayList<SchoolType>();
+        for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; ++slot) {
+            ScrollcasterSchoolRuneResolver.resolveSchool(readCalibrationAdjustment(stack, slot))
+                    .ifPresent(schools::add);
+        }
+        return List.copyOf(schools);
+    }
+
+    public static @Nullable SchoolType getResolvedCalibrationSchool(ItemStack stack) {
+        var schools = getResolvedCalibrationSchools(stack);
+        return schools.isEmpty() ? null : schools.get(0);
     }
 
     @Nullable
@@ -290,7 +311,8 @@ public class BulwarkGreatshield extends AbstractImbueShieldItem
     }
 
     private static boolean isValidCalibrationAccess(ItemStack stack, int slot) {
-        return slot == 0 && !stack.isEmpty() && stack.getItem() instanceof BulwarkGreatshield;
+        return slot >= 0 && slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT
+                && !stack.isEmpty() && stack.getItem() instanceof BulwarkGreatshield;
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ParrycastBuckler.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ParrycastBuckler.java
@@ -18,6 +18,7 @@ import jp.aquafactory.apprenticecodex.item.ItemManaBypassCastEvent;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
 import jp.aquafactory.apprenticecodex.item.offhand.OffhandMagicModifierHelper;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.item.TriggeredSpellCastHelper;
 import jp.aquafactory.apprenticecodex.mixin.LivingEntityAccessor;
@@ -210,15 +211,18 @@ public class ParrycastBuckler extends AbstractImbueShieldItem implements GeoItem
                 && spell.getRecastCount(spellLevel, null) <= 0;
     }
 
-    public boolean isMismatchedCastConditionAt(ItemStack targetStack, int slot) {
-        if (slot != 0) {
-            return false;
+    @Override
+    public @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData
+    ) {
+        if (slot != 0 || !canImbueSpell(spellData)) {
+            return SpellCalibrationImbueState.REJECTED;
         }
-        var spellData = getPrimarySpellData(targetStack);
-        return spellData != SpellData.EMPTY
-                && spellData != null
-                && spellData.getSpell() != null
-                && !canUseConfiguredSpell(targetStack, spellData.getSpell(), spellData.getLevel());
+        return SpellCalibrationImbueState.accepted(
+                canUseConfiguredSpell(targetStack, spellData.getSpell(), spellData.getLevel())
+        );
     }
 
     public List<Component> getImbueRestrictionTooltipLines(ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ParrycastBuckler.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ParrycastBuckler.java
@@ -5,20 +5,20 @@ import com.google.common.collect.Multimap;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.magic.SpellSelectionManager;
 import io.redspace.ironsspellbooks.api.registry.SpellRegistry;
-import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
-import io.redspace.ironsspellbooks.api.spells.CastSource;
-import io.redspace.ironsspellbooks.api.spells.CastType;
-import io.redspace.ironsspellbooks.api.spells.SpellData;
+import io.redspace.ironsspellbooks.api.spells.*;
 import io.redspace.ironsspellbooks.capabilities.magic.CooldownInstance;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
-import jp.aquafactory.apprenticecodex.item.shield.AbstractImbueShieldItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.ItemManaBypassCastEvent;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
 import jp.aquafactory.apprenticecodex.item.offhand.OffhandMagicModifierHelper;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
 import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.item.TriggeredSpellCastHelper;
 import jp.aquafactory.apprenticecodex.mixin.LivingEntityAccessor;
@@ -67,11 +67,29 @@ import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 
-public class ParrycastBuckler extends AbstractImbueShieldItem implements GeoItem, IJeiInfoItem {
+public class ParrycastBuckler extends AbstractImbueShieldItem
+        implements GeoItem, IJeiInfoItem, SpellCalibrationAdjustmentTarget {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.parrycast_buckler.desc_";
     public static final int DURABILITY = 1561;
     public static final int ENCHANTMENT_VALUE = 22;
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.uniqueBy(
+                            ScrollcasterSchoolRuneResolver::isSchoolRune,
+                            stack -> ScrollcasterSchoolRuneResolver.resolveSchool(stack)
+                                    .map(SchoolType::getId),
+                            CalibrationAdjustmentHints.schoolRunes()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            MithrilFreecastStaff::isSilverRing,
+                            CalibrationAdjustmentHints.silverRing()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            stack -> stack.is(ItemRegistry.WISDOM_SHARD.get()),
+                            CalibrationAdjustmentHints.wisdomShard()
+                    )
+            );
     private static final double SCHOOL_POWER_BONUS = 0.1D;
     private static final String CALIBRATION_TAG = "ParrycastBucklerCalibration";
     private static final String USE_START_TICK_TAG = "ApprenticeCodexParrycastBucklerUseStart";
@@ -291,7 +309,7 @@ public class ParrycastBuckler extends AbstractImbueShieldItem implements GeoItem
         }
         Set<net.minecraft.resources.ResourceLocation> seen = new HashSet<>();
         for (int i = 0; i < CALIBRATION_ADJUSTMENT_SLOT_COUNT; i++) {
-            var school = ScrollcasterSchoolRuneResolver.resolveSchool(getCalibrationAdjustment(stack, i)).orElse(null);
+            var school = ScrollcasterSchoolRuneResolver.resolveSchool(readCalibrationAdjustment(stack, i)).orElse(null);
             if (school == null || !seen.add(school.getId())) continue;
             var attribute = MagicTools.resolveSchoolPowerAttribute(school);
             if (attribute != null) {
@@ -440,23 +458,46 @@ public class ParrycastBuckler extends AbstractImbueShieldItem implements GeoItem
         return true;
     }
 
-    public static ItemStack getCalibrationAdjustment(ItemStack stack, int slot) {
+    private static ItemStack readCalibrationAdjustment(ItemStack stack, int slot) {
         return ShieldCalibrationData.get(stack, CALIBRATION_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT);
     }
 
-    public static void setCalibrationAdjustment(ItemStack stack, int slot, ItemStack adjustment) {
+    private static void writeCalibrationAdjustment(ItemStack stack, int slot, ItemStack adjustment) {
         ShieldCalibrationData.set(stack, CALIBRATION_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT, adjustment);
     }
 
-    public static boolean isCalibrationAdjustmentItem(ItemStack stack) {
-        return ScrollcasterSchoolRuneResolver.isSchoolRune(stack) || MithrilFreecastStaff.isSilverRing(stack)
-                || stack.is(ItemRegistry.WISDOM_SHARD.get());
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static boolean hasSilverRing(ItemStack stack) { return hasAdjustment(stack, MithrilFreecastStaff::isSilverRing); }
     public static boolean hasWisdomShard(ItemStack stack) { return hasAdjustment(stack, s -> s.is(ItemRegistry.WISDOM_SHARD.get())); }
     private static boolean hasAdjustment(ItemStack stack, java.util.function.Predicate<ItemStack> predicate) {
-        for (int i = 0; i < CALIBRATION_ADJUSTMENT_SLOT_COUNT; i++) if (predicate.test(getCalibrationAdjustment(stack, i))) return true;
+        for (int i = 0; i < CALIBRATION_ADJUSTMENT_SLOT_COUNT; i++) if (predicate.test(readCalibrationAdjustment(stack, i))) return true;
         return false;
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ReflectcastShield.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ReflectcastShield.java
@@ -10,6 +10,7 @@ import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.item.shield.AbstractImbueShieldItem;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
@@ -100,13 +101,18 @@ public class ReflectcastShield extends AbstractImbueShieldItem implements GeoIte
                 || spell.getCastType() == CastType.CONTINUOUS);
     }
 
-    public boolean isMismatchedCastConditionAt(ItemStack targetStack, int slot) {
-        if (slot != 0) {
-            return false;
+    @Override
+    public @NotNull SpellCalibrationImbueState evaluateCalibrationImbue(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull SpellData spellData
+    ) {
+        if (slot != 0 || !canImbueSpell(spellData)) {
+            return SpellCalibrationImbueState.REJECTED;
         }
-        var spellData = getPrimarySpellData(targetStack);
-        return spellData != null && spellData != SpellData.EMPTY
-                && !canUseConfiguredSpell(targetStack, spellData.getSpell(), spellData.getLevel());
+        return SpellCalibrationImbueState.accepted(
+                canUseConfiguredSpell(targetStack, spellData.getSpell(), spellData.getLevel())
+        );
     }
 
     public List<Component> getImbueRestrictionTooltipLines(ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ReflectcastShield.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/shield/ReflectcastShield.java
@@ -8,8 +8,11 @@ import io.redspace.ironsspellbooks.api.spells.CastType;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
-import jp.aquafactory.apprenticecodex.item.shield.AbstractImbueShieldItem;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentHints;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentProfile;
+import jp.aquafactory.apprenticecodex.item.CalibrationAdjustmentRule;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationAdjustmentTarget;
 import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
 import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastStaff;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellGunCastType;
@@ -37,7 +40,8 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-public class ReflectcastShield extends AbstractImbueShieldItem implements GeoItem, IJeiInfoItem {
+public class ReflectcastShield extends AbstractImbueShieldItem
+        implements GeoItem, IJeiInfoItem, SpellCalibrationAdjustmentTarget {
     private static final String JEI_INFO_KEY_PREFIX = "jei.apprenticecodex.reflectcast_shield.desc_";
 
     public static final int DURABILITY = 1561;
@@ -45,6 +49,17 @@ public class ReflectcastShield extends AbstractImbueShieldItem implements GeoIte
     public static final int SPELL_TRIGGER_SUPPRESSION_TICKS = 10;
     public static final int ENCHANTMENT_VALUE = 22;
     public static final int CALIBRATION_ADJUSTMENT_SLOT_COUNT = 3;
+    private static final CalibrationAdjustmentProfile CALIBRATION_ADJUSTMENT_PROFILE =
+            CalibrationAdjustmentProfile.of(
+                    CalibrationAdjustmentRule.unique(
+                            MithrilFreecastStaff::isSilverRing,
+                            CalibrationAdjustmentHints.silverRing()
+                    ),
+                    CalibrationAdjustmentRule.unique(
+                            stack -> stack.is(ItemRegistry.WISDOM_SHARD.get()),
+                            CalibrationAdjustmentHints.wisdomShard()
+                    )
+            );
     private static final float MINIMUM_DURABILITY_DAMAGE = 3.0F;
     private static final String CALIBRATION_TAG = "ReflectcastShieldCalibration";
     private static final ItemStack SHIELD_ENCHANTMENT_PROBE = new ItemStack(Items.SHIELD);
@@ -217,22 +232,46 @@ public class ReflectcastShield extends AbstractImbueShieldItem implements GeoIte
                 .allMatch(enchantment -> supportsEnchantment(stack, enchantment));
     }
 
-    public static @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot) {
+    private static @NotNull ItemStack readCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot) {
         if (!isValidCalibrationAccess(shieldStack, slot)) {
             return ItemStack.EMPTY;
         }
         return ShieldCalibrationData.get(shieldStack, CALIBRATION_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT);
     }
 
-    public static void setCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot, @NotNull ItemStack adjustment) {
+    private static void writeCalibrationAdjustment(@NotNull ItemStack shieldStack, int slot, @NotNull ItemStack adjustment) {
         if (!isValidCalibrationAccess(shieldStack, slot)) {
             return;
         }
         ShieldCalibrationData.set(shieldStack, CALIBRATION_TAG, slot, CALIBRATION_ADJUSTMENT_SLOT_COUNT, adjustment);
     }
 
-    public static boolean isCalibrationAdjustmentItem(ItemStack stack) {
-        return MithrilFreecastStaff.isSilverRing(stack) || stack.is(ItemRegistry.WISDOM_SHARD.get());
+    @Override
+    public int getCalibrationAdjustmentSlotCount(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_SLOT_COUNT;
+    }
+
+    @Override
+    public @NotNull ItemStack getCalibrationAdjustment(@NotNull ItemStack targetStack, int slot) {
+        return readCalibrationAdjustment(targetStack, slot);
+    }
+
+    @Override
+    public boolean trySetCalibrationAdjustment(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack adjustment
+    ) {
+        if (!canPlaceCalibrationAdjustment(targetStack, slot, adjustment)) {
+            return false;
+        }
+        writeCalibrationAdjustment(targetStack, slot, adjustment);
+        return true;
+    }
+
+    @Override
+    public @NotNull CalibrationAdjustmentProfile getCalibrationAdjustmentProfile(@NotNull ItemStack targetStack) {
+        return CALIBRATION_ADJUSTMENT_PROFILE;
     }
 
     public static boolean hasSilverRing(ItemStack stack) {
@@ -264,7 +303,7 @@ public class ReflectcastShield extends AbstractImbueShieldItem implements GeoIte
 
     private static boolean hasAdjustment(ItemStack stack, java.util.function.Predicate<ItemStack> predicate) {
         for (var slot = 0; slot < CALIBRATION_ADJUSTMENT_SLOT_COUNT; slot++) {
-            if (predicate.test(getCalibrationAdjustment(stack, slot))) {
+            if (predicate.test(readCalibrationAdjustment(stack, slot))) {
                 return true;
             }
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientConfirmScrollcasterGauntletIndexPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientConfirmScrollcasterGauntletIndexPacket.java
@@ -57,13 +57,18 @@ public record ClientConfirmScrollcasterGauntletIndexPacket(
             }
 
             var stack = resolveHeldGauntletStack(sender, packet.hand());
+            var lookupProvider = sender.level().registryAccess();
             if (!(stack.getItem() instanceof ScrollcasterGauntlet)
-                    || !ScrollcasterGauntlet.isSelectableScrollIndex(stack, packet.selectedIndex())) {
+                    || !ScrollcasterGauntlet.isSelectableScrollIndex(
+                            stack,
+                            packet.selectedIndex(),
+                            lookupProvider
+                    )) {
                 return;
             }
 
             var previousIndex = ScrollcasterGauntlet.getSelectedScrollIndex(stack);
-            ScrollcasterGauntlet.setSelectedScrollIndex(stack, packet.selectedIndex());
+            ScrollcasterGauntlet.setSelectedScrollIndex(stack, packet.selectedIndex(), lookupProvider);
             if (previousIndex != packet.selectedIndex()) {
                 sender.level().playSound(
                         null,

--- a/src/main/java/jp/aquafactory/apprenticecodex/renderer/item/ScrollcasterGauntletRenderer.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/renderer/item/ScrollcasterGauntletRenderer.java
@@ -101,7 +101,11 @@ public final class ScrollcasterGauntletRenderer extends GeoItemRenderer<Scrollca
     }
 
     private static boolean hasVisibleScrollSocket(ItemStack stack) {
-        return stack != null && !stack.isEmpty() && ScrollcasterGauntlet.hasAnyCalibrationScroll(stack);
+        var level = Minecraft.getInstance().level;
+        return stack != null
+                && !stack.isEmpty()
+                && level != null
+                && ScrollcasterGauntlet.hasAnyCalibrationScroll(stack, level.registryAccess());
     }
 
     private static float pulse(float partialTick, float periodTicks, float minBrightness, float maxBrightness) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/RightClickSpellResolver.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/RightClickSpellResolver.java
@@ -62,7 +62,7 @@ public final class RightClickSpellResolver {
         }
         if (mainHandStack.getItem() instanceof ScrollcasterGauntlet) {
             return createResolvedSpell(
-                    ScrollcasterGauntlet.getSelectedSpellData(mainHandStack),
+                    ScrollcasterGauntlet.getSelectedSpellData(mainHandStack, player.level().registryAccess()),
                     player,
                     InteractionHand.MAIN_HAND,
                     "scrollcaster_gauntlet_selected"
@@ -96,7 +96,7 @@ public final class RightClickSpellResolver {
         }
         if (offHandStack.getItem() instanceof ScrollcasterGauntlet) {
             return createResolvedSpell(
-                    ScrollcasterGauntlet.getSelectedSpellData(offHandStack),
+                    ScrollcasterGauntlet.getSelectedSpellData(offHandStack, player.level().registryAccess()),
                     player,
                     InteractionHand.OFF_HAND,
                     "scrollcaster_gauntlet_selected"

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/SpellCalibrationImbueHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/SpellCalibrationImbueHelper.java
@@ -23,6 +23,7 @@ import jp.aquafactory.apprenticecodex.item.curios.satellitefollowcastamulet.Sate
 import jp.aquafactory.apprenticecodex.item.flask.AlchemistsFlask;
 import jp.aquafactory.apprenticecodex.item.offhand.PhotonSiphon;
 import jp.aquafactory.apprenticecodex.registry.TagRegistry;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -151,6 +152,31 @@ public final class SpellCalibrationImbueHelper {
         return SpellCalibrationImbueState.ACCEPTED_USABLE;
     }
 
+    public static @NotNull SpellCalibrationImbueState evaluateScrollAt(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack scrollStack,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        var spellData = getScrollSpellData(scrollStack);
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+
+        var item = targetStack.getItem();
+        if (item instanceof StoredSpellCalibrationImbueTarget storedTarget) {
+            return storedTarget.evaluateCalibrationImbue(targetStack, slot, spellData, lookupProvider);
+        }
+
+        if (!canPlaceScrollAt(targetStack, slot, scrollStack)) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+        if (item instanceof SpellCalibrationImbueTarget imbueTarget) {
+            return imbueTarget.evaluateCalibrationImbue(targetStack, slot, spellData, lookupProvider);
+        }
+        return SpellCalibrationImbueState.ACCEPTED_USABLE;
+    }
+
     public static @NotNull SpellCalibrationImbueState evaluateStoredScrollAt(
             @NotNull ItemStack targetStack,
             int slot,
@@ -163,6 +189,25 @@ public final class SpellCalibrationImbueHelper {
 
         if (targetStack.getItem() instanceof SpellCalibrationImbueTarget imbueTarget) {
             return imbueTarget.evaluateCalibrationImbue(targetStack, slot, spellData);
+        }
+        return isSupportedTarget(targetStack) && isValidSpellSlot(targetStack, slot)
+                ? SpellCalibrationImbueState.ACCEPTED_USABLE
+                : SpellCalibrationImbueState.REJECTED;
+    }
+
+    public static @NotNull SpellCalibrationImbueState evaluateStoredScrollAt(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack scrollStack,
+            @NotNull HolderLookup.Provider lookupProvider
+    ) {
+        var spellData = getScrollSpellData(scrollStack);
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+
+        if (targetStack.getItem() instanceof SpellCalibrationImbueTarget imbueTarget) {
+            return imbueTarget.evaluateCalibrationImbue(targetStack, slot, spellData, lookupProvider);
         }
         return isSupportedTarget(targetStack) && isValidSpellSlot(targetStack, slot)
                 ? SpellCalibrationImbueState.ACCEPTED_USABLE

--- a/src/main/java/jp/aquafactory/apprenticecodex/utility/SpellCalibrationImbueHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/utility/SpellCalibrationImbueHelper.java
@@ -13,6 +13,9 @@ import jp.aquafactory.apprenticecodex.item.AbstractRightClickMagicWeaponItem;
 import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.item.AbstractSwingMagicItem;
 import jp.aquafactory.apprenticecodex.item.RestrictedSpellImbuableItem;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueState;
+import jp.aquafactory.apprenticecodex.item.SpellCalibrationImbueTarget;
+import jp.aquafactory.apprenticecodex.item.StoredSpellCalibrationImbueTarget;
 import jp.aquafactory.apprenticecodex.item.armor.MagiAgentSuitItem;
 import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmulet;
 import jp.aquafactory.apprenticecodex.item.curios.jumpcastcharm.JumpcastCharm;
@@ -117,22 +120,53 @@ public final class SpellCalibrationImbueHelper {
         return getSpellDataAt(targetStack, slot) != SpellData.EMPTY;
     }
 
-    public static boolean isMismatchedCastConditionAt(@NotNull ItemStack targetStack, int slot) {
-        if (!(targetStack.getItem() instanceof RestrictedSpellImbuableItem spellImbueItem)) {
-            return false;
-        }
-
-        var spellData = getSpellDataAt(targetStack, slot);
-        return spellData != SpellData.EMPTY
-                && spellData.getSpell() != null
-                && !spellImbueItem.canImbueSpell(spellData);
-    }
-
     public static @NotNull List<Component> getImbueRestrictionTooltipLines(@NotNull ItemStack targetStack) {
         if (targetStack.getItem() instanceof RestrictedSpellImbuableItem spellImbueItem) {
             return spellImbueItem.getImbueRestrictionTooltipLines();
         }
         return List.of();
+    }
+
+    public static @NotNull SpellCalibrationImbueState evaluateScrollAt(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack scrollStack
+    ) {
+        var spellData = getScrollSpellData(scrollStack);
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+
+        var item = targetStack.getItem();
+        if (item instanceof StoredSpellCalibrationImbueTarget storedTarget) {
+            return storedTarget.evaluateCalibrationImbue(targetStack, slot, spellData);
+        }
+
+        if (!canPlaceScrollAt(targetStack, slot, scrollStack)) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+        if (item instanceof SpellCalibrationImbueTarget imbueTarget) {
+            return imbueTarget.evaluateCalibrationImbue(targetStack, slot, spellData);
+        }
+        return SpellCalibrationImbueState.ACCEPTED_USABLE;
+    }
+
+    public static @NotNull SpellCalibrationImbueState evaluateStoredScrollAt(
+            @NotNull ItemStack targetStack,
+            int slot,
+            @NotNull ItemStack scrollStack
+    ) {
+        var spellData = getScrollSpellData(scrollStack);
+        if (spellData == SpellData.EMPTY || spellData.getSpell() == null) {
+            return SpellCalibrationImbueState.REJECTED;
+        }
+
+        if (targetStack.getItem() instanceof SpellCalibrationImbueTarget imbueTarget) {
+            return imbueTarget.evaluateCalibrationImbue(targetStack, slot, spellData);
+        }
+        return isSupportedTarget(targetStack) && isValidSpellSlot(targetStack, slot)
+                ? SpellCalibrationImbueState.ACCEPTED_USABLE
+                : SpellCalibrationImbueState.REJECTED;
     }
 
     public static boolean canPlaceScrollAt(@NotNull ItemStack targetStack, int slot, @NotNull ItemStack scrollStack) {

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -951,7 +951,7 @@
   "ui.apprenticecodex.spell_calibration_bench.hint_default_spell": "Default imbued spells cannot be extracted",
   "ui.apprenticecodex.spell_calibration_bench.cant_remove_not_allow": "Scrolls cannot be extracted from this item",
   "ui.apprenticecodex.spell_calibration_bench.cant_imbue_unsupported_equipment": "Use an Arcane Anvil to imbue this item",
-  "ui.apprenticecodex.spell_calibration_bench.warning_restrict_imbue_condition": "Only scrolls matching these conditions can be imbued",
+  "ui.apprenticecodex.spell_calibration_bench.warning_restrict_imbue_condition": "Only spell scrolls meeting the following conditions can be cast",
   "ui.apprenticecodex.spell_calibration_bench.warning_mismatch_cast_condition": "This spell does not meet the target item's cast condition",
   "ui.apprenticecodex.spellcaster_workbench.warning_max_slot_reached": "This item has already been upgraded to its maximum",
   "ui.apprenticecodex.spellcaster_workbench.cant_imbue_to_card": "This spell cannot be imbued into cards",

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -955,6 +955,7 @@
   "ui.apprenticecodex.spell_calibration_bench.warning_mismatch_cast_condition": "This spell does not meet the target item's cast condition",
   "ui.apprenticecodex.spellcaster_workbench.warning_max_slot_reached": "This item has already been upgraded to its maximum",
   "ui.apprenticecodex.spellcaster_workbench.cant_imbue_to_card": "This spell cannot be imbued into cards",
+  "ui.apprenticecodex.scrollcaster_gauntlet.select_ui.empty": "No selectable spells",
   "ui.apprenticecodex.spell_throwable_cards.not_imbued": "This card has no imbued spell!",
 
   "effect.apprenticecodex.arcane_charge": "Arcane Charge",

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -452,7 +452,7 @@
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_5": "- Slot upgrade items: Increase the gauntlet's scroll slots by 2.",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_6": "- School Rune: Changes the spell power bonus from general spell power to that rune's school.",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_7": "- Enchantment book items: Applies the first enchantment listed on the item to the gauntlet.",
-  "jei.apprenticecodex.scrollcaster_gauntlet.desc_8": "- Mithril Freecast Staff: Lets the gauntlet swing-cast the selected spell like a Mithril Freecast Staff. A Silver Ring adjustment also applies.",
+  "jei.apprenticecodex.scrollcaster_gauntlet.desc_8": "- Mithril Freecast Staff: Lets the gauntlet swing-cast the selected spell when attacking. Spells that require casting time are supported, but continuous-cast spells are not.",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_9": "Only one mutually incompatible enchantment is applied; enchantments for swords, pickaxes, or spellcasting aids are supported.",
   "jei.apprenticecodex.spell_calibration_bench.desc_1": "A workstation for adjusting some equipment's performance with adjustment items and configuring imbued spells.",
   "jei.apprenticecodex.spell_calibration_bench.desc_2": "It cannot handle items whose imbued spells cannot be removed; use an Arcane Anvil for those.",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -958,7 +958,7 @@
   "ui.apprenticecodex.spell_calibration_bench.hint_default_spell": "最初から注入されている魔法は取り出せない",
   "ui.apprenticecodex.spell_calibration_bench.cant_remove_not_allow": "このアイテムからはスクロールは取り出せない",
   "ui.apprenticecodex.spell_calibration_bench.cant_imbue_unsupported_equipment": "このアイテムへの注入は秘術の金床を使う必要がある",
-  "ui.apprenticecodex.spell_calibration_bench.warning_restrict_imbue_condition": "以下を満たした魔法のスクロールのみ注入できる",
+  "ui.apprenticecodex.spell_calibration_bench.warning_restrict_imbue_condition": "以下を満たした魔法のスクロールのみ発動できる",
   "ui.apprenticecodex.spell_calibration_bench.warning_mismatch_cast_condition": "対象のアイテムの詠唱可能条件を満たしていない",
   "ui.apprenticecodex.spellcaster_workbench.warning_max_slot_reached": "このアイテムは既に最大まで拡張されている",
   "ui.apprenticecodex.spellcaster_workbench.cant_imbue_to_card": "この魔法は札に注入できない",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -453,7 +453,7 @@
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_5": "- スロット数増加アイテム：ガントレットのスクロールのスロット数を2増加させる。",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_6": "- 系統のルーン：魔法力のボーナスを全属性から系統のルーンに特化させる。",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_7": "- エンチャント本系アイテム：アイテムの一番上に記載されているエンチャントをガントレットに適用する。",
-  "jei.apprenticecodex.scrollcaster_gauntlet.desc_8": "- ミスリルの自在詠唱杖：攻撃時に選択している魔法をミスリルの自在詠唱杖のように打撃詠唱する。銀のリングの状態を反映する。",
+  "jei.apprenticecodex.scrollcaster_gauntlet.desc_8": "- ミスリルの自在詠唱杖：攻撃時に選択している魔法をミスリルの自在詠唱杖のように打撃詠唱する。詠唱を伴うものも発動できるが、継続的に詠唱する必要のあるものは不可能。",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_9": "エンチャントは同時に付呪できないものは一つのみが適用され、剣・ツルハシ・魔法詠唱補助具のいずれかに付呪できるものが適用できる。",
   "jei.apprenticecodex.spell_calibration_bench.desc_1": "術式装填ガントレットや一部アイテムの調整アイテムによる性能の調整や注入魔法の調整を行える装置。",
   "jei.apprenticecodex.spell_calibration_bench.desc_2": "アイテムの魔法の注入については取り外す事ができないアイテムの操作は行えず、そちらは秘術の鉄床を使う必要がある。",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -962,6 +962,7 @@
   "ui.apprenticecodex.spell_calibration_bench.warning_mismatch_cast_condition": "対象のアイテムの詠唱可能条件を満たしていない",
   "ui.apprenticecodex.spellcaster_workbench.warning_max_slot_reached": "このアイテムは既に最大まで拡張されている",
   "ui.apprenticecodex.spellcaster_workbench.cant_imbue_to_card": "この魔法は札に注入できない",
+  "ui.apprenticecodex.scrollcaster_gauntlet.select_ui.empty": "選択候補無し",
 
   "effect.apprenticecodex.arcane_charge": "アルケインチャージ",
   "effect.apprenticecodex.casting_mobility": "詠唱移動補助",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -949,6 +949,7 @@
   "ui.apprenticecodex.spell_calibration_bench.warning_mismatch_cast_condition": "该法术不符合目标物品的施法条件",
   "ui.apprenticecodex.spellcaster_workbench.warning_max_slot_reached": "该物品已扩展至最大",
   "ui.apprenticecodex.spellcaster_workbench.cant_imbue_to_card": "该法术无法注入符卡",
+  "ui.apprenticecodex.scrollcaster_gauntlet.select_ui.empty": "无可选法术",
   "ui.apprenticecodex.spell_throwable_cards.not_imbued": "这张符卡尚未注入法术！",
 
   "effect.apprenticecodex.arcane_charge": "奥术充能",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -452,7 +452,7 @@
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_5": "- 槽位升级物品：使臂铠的卷轴槽位数增加2个。",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_6": "- 学派符文：将法术强度加成从全属性改为对应学派专精。",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_7": "- 附魔书类物品：将物品中最上方列出的附魔应用到臂铠。",
-  "jei.apprenticecodex.scrollcaster_gauntlet.desc_8": "- 秘银制自由施法杖：使臂铠在挥击时像秘银制自由施法杖一样释放当前选中的法术。银戒指的调整也会生效。",
+  "jei.apprenticecodex.scrollcaster_gauntlet.desc_8": "- 秘银制自由施法杖：攻击时，使臂铠像秘银制自由施法杖一样挥击释放当前选中的法术。可以发动需要施法时间的法术，但无法发动需要持续施法的法术。",
   "jei.apprenticecodex.scrollcaster_gauntlet.desc_9": "互斥附魔同时存在时只会应用一个；可应用于剑、镐或魔法施法辅助具的附魔可以生效。",
   "jei.apprenticecodex.spell_calibration_bench.desc_1": "用于通过调整物品改变部分装备性能，并设定注入法术的装置。",
   "jei.apprenticecodex.spell_calibration_bench.desc_2": "无法处理注入法术不可取下的物品；这类物品需要使用奥术铁砧。",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -945,7 +945,7 @@
   "ui.apprenticecodex.spell_calibration_bench.hint_default_spell": "默认注入的法术无法提取",
   "ui.apprenticecodex.spell_calibration_bench.cant_remove_not_allow": "无法从该物品中提取卷轴",
   "ui.apprenticecodex.spell_calibration_bench.cant_imbue_unsupported_equipment": "需要使用奥术铁砧为该物品注入法术",
-  "ui.apprenticecodex.spell_calibration_bench.warning_restrict_imbue_condition": "只能注入满足以下条件的法术卷轴",
+  "ui.apprenticecodex.spell_calibration_bench.warning_restrict_imbue_condition": "只有满足以下条件的法术卷轴才能施放",
   "ui.apprenticecodex.spell_calibration_bench.warning_mismatch_cast_condition": "该法术不符合目标物品的施法条件",
   "ui.apprenticecodex.spellcaster_workbench.warning_max_slot_reached": "该物品已扩展至最大",
   "ui.apprenticecodex.spellcaster_workbench.cant_imbue_to_card": "该法术无法注入符卡",


### PR DESCRIPTION
## 概要

PR #707 の変更を `main`（Minecraft 1.20.1）から `1.21.1-main` へ、元の6コミットを個別に `cherry-pick -x` してforward-portします。

- スニーク選択UIの手判定を共通化
- 術式調整台のスクロール・調整アイテム処理を各対象Itemへ移譲
- 術式装填ガントレットの打撃詠唱と選択UIを調整
- 術式防壁の大盾の調整スロットを拡張
- 調整ルール、表示ヒント、GameTestを追加・更新

## 1.21.1向け追加修正

専用サーバーへ接続したクライアントでは `ServerLifecycleHooks.getCurrentServer()` が `null` となり、組み込みレジストリへfallbackしていました。1.21.1のenchantmentは動的レジストリのため、術式装填ガントレットの調整枠でエンチャント本を保存・同期するとクラッシュする問題がありました。

調整枠の保存・復元・配置判定、および関連する描画・詠唱・選択packet経路へ、接続中Levelの `registryAccess()` を明示的に伝播するよう修正しています。エンチャント本の保存直後とMenu再同期後に動的エンチャントが保持される回帰テストも追加しました。

## 影響

- 専用サーバー接続クライアントで、エンチャント本を含むガントレットの調整枠を安全に操作できます。
- 既存のproviderなしAPIは互換用fallbackとして維持しています。
- コンテンツIDや既存データ形式の変更はありません。

## 検証

- `./gradlew.bat build`: 成功
- `./gradlew.bat runGameTestServer`: 796/796 成功
- `./gradlew.bat runGameTestServerBetterCombat`: 796/796 成功
- `./gradlew.bat runGameTestServerEpicFight`: 796/796 成功
- `./gradlew.bat runGameTestServerCompat`: 成功
- `./gradlew.bat runClient`: 専用サーバー接続を含め、依頼者環境で問題なし