### PR TITLE
[1.21.1] PR #726をforward-port: Epic Fight詠唱銃入力対応

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@
 ./gradlew.bat runClientEasyMagic
 ./gradlew.bat runClientBetterCombat
 ./gradlew.bat runClientEpicFight
+./gradlew.bat runClientEpicFightController
 ./gradlew.bat runClientCompatEasyBetter
 ```
 - 一時的な optional MOD 追加:
@@ -86,6 +87,7 @@ Get-ChildItem build\libs\*.jar
 - `runGameTestServerEasyMagic` は Puzzles Lib / Easy Magic 連携の確認に使う。
 - `runGameTestServerBetterCombat` は Cloth Config / Better Combat 連携の確認に使う。
 - `runGameTestServerEpicFight` は Epic Fight 連携の確認に使う。
+- `runClientEpicFightController` は Epic Fight / Controlify / YACL を入れ、実機コントローラー入力を確認する。
 - `runClientCompatEasyBetter` は compat + Easy Magic + Better Combat を入れた実環境寄りの手動バランス確認用。Epic Fight は含めず、自動テスト対象にも含めない。
 - IntelliJ IDEA から client 構成を起動して `Unsupported major.minor version 65.0` が出る場合は、Project SDK / Gradle JVM / 古い実行構成が Java 17 を参照している。IDEA 側を JDK 21 にそろえ、`neoForgeIdeSync` を再実行し、必要なら古い Minecraft run configuration を削除して再生成する。
 - Botania は 1.21.1 側で API 依存を置いていないため、optional MOD profile には含めない。

--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
   - `runClientEasyMagic`
   - `runClientBetterCombat`
   - `runClientEpicFight`
+  - `runClientEpicFightController`
   - `runClientCompatEasyBetter`
+- `runClientEpicFightController` は Epic Fight / Controlify / YACL を入れ、実機コントローラー入力を確認する構成です。
 - `runClientCompatEasyBetter` は compat + Easy Magic + Better Combat を入れた実環境寄りの手動バランス確認用です。Epic Fight は含めず、自動テスト対象にもしていません。
 - 一時的な組み合わせ確認では Gradle プロパティでも追加できます。
 
@@ -114,7 +116,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 ./gradlew.bat runClient "-PdevRuntimeMods=epic_fight"
 ```
 
-- `devRuntimeMods` には `compat`, `easy_magic`, `better_combat`, `epic_fight`, `compat_easy_better` または個別名（`create`, `lodestone`, `malum` など）をカンマ区切りで指定できます。
+- `devRuntimeMods` には `compat`, `easy_magic`, `better_combat`, `epic_fight`, `epic_fight_controller`, `compat_easy_better` または個別名（`create`, `lodestone`, `malum`, `controlify` など）をカンマ区切りで指定できます。
 - Botania は 1.21.1 側で API 依存を置いていないため、optional MOD profile には含めていません。
 - Better Combat と Epic Fight は干渉が大きいため、同時投入は通常確認では避けます。
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,8 @@ def optionalRuntimeModuleConfigurations = [
         cloth_config   : 'clothConfigRuntimeOnly',
         better_combat  : 'betterCombatRuntimeOnly',
         epic_fight     : 'epicFightRuntimeOnly',
+        controlify     : 'controlifyRuntimeOnly',
+        yacl           : 'yaclRuntimeOnly',
         lodestone      : 'lodestoneRuntimeOnly',
         malum          : 'malumRuntimeOnly',
 ]
@@ -86,11 +88,12 @@ def clientRuntimeModuleConfigurations = [
 ]
 
 def optionalRuntimeProfileModules = [
-        compat            : ['create', 'lodestone', 'malum'],
-        easy_magic        : ['puzzles_lib', 'easy_magic'],
-        better_combat     : ['cloth_config', 'better_combat'],
-        epic_fight        : ['epic_fight'],
-        compat_easy_better: ['create', 'lodestone', 'malum', 'puzzles_lib', 'easy_magic', 'cloth_config', 'better_combat'],
+        compat              : ['create', 'lodestone', 'malum'],
+        easy_magic          : ['puzzles_lib', 'easy_magic'],
+        better_combat       : ['cloth_config', 'better_combat'],
+        epic_fight          : ['epic_fight'],
+        epic_fight_controller: ['epic_fight', 'yacl', 'controlify'],
+        compat_easy_better  : ['create', 'lodestone', 'malum', 'puzzles_lib', 'easy_magic', 'cloth_config', 'better_combat'],
 ]
 
 def optionalRuntimeSelectorModules = optionalRuntimeProfileModules + [
@@ -98,6 +101,8 @@ def optionalRuntimeSelectorModules = optionalRuntimeProfileModules + [
         easymagic     : ['puzzles_lib', 'easy_magic'],
         bettercombat  : ['cloth_config', 'better_combat'],
         epicfight     : ['epic_fight'],
+        epicfightcontroller: ['epic_fight', 'yacl', 'controlify'],
+        controlify    : ['yacl', 'controlify'],
         create        : ['create'],
         lodestone     : ['lodestone'],
         malum         : ['lodestone', 'malum'],
@@ -186,6 +191,11 @@ neoForge {
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
         }
 
+        clientEpicFightController {
+            client()
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+        }
+
         clientCompatEasyBetter {
             client()
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
@@ -267,7 +277,7 @@ configurations {
     }
 }
 
-['client', 'clientCompat', 'clientEasyMagic', 'clientBetterCombat', 'clientEpicFight', 'clientCompatEasyBetter'].each {
+['client', 'clientCompat', 'clientEasyMagic', 'clientBetterCombat', 'clientEpicFight', 'clientEpicFightController', 'clientCompatEasyBetter'].each {
     extendRunJavaClasspathWithClientRuntimeModules(it)
 }
 
@@ -275,6 +285,7 @@ extendRunJavaClasspathWithOptionalRuntimeModules('clientCompat', expandOptionalR
 extendRunJavaClasspathWithOptionalRuntimeModules('clientEasyMagic', expandOptionalRuntimeModules(['easy_magic']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientBetterCombat', expandOptionalRuntimeModules(['better_combat']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientEpicFight', expandOptionalRuntimeModules(['epic_fight']))
+extendRunJavaClasspathWithOptionalRuntimeModules('clientEpicFightController', expandOptionalRuntimeModules(['epic_fight_controller']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientCompatEasyBetter', expandOptionalRuntimeModules(['compat_easy_better']))
 extendRunJavaClasspathWithOptionalRuntimeModules('gameTestServerCompat', expandOptionalRuntimeModules(['compat']))
 extendRunJavaClasspathWithOptionalRuntimeModules('gameTestServerEasyMagic', expandOptionalRuntimeModules(['easy_magic']))
@@ -330,6 +341,11 @@ dependencies {
     // ランタイムは epic_fight profile から読み込む.
     compileOnly "maven.modrinth:epic-fight:${epicfight_version}"
     add(optionalRuntimeModuleConfigurations.epic_fight, "maven.modrinth:epic-fight:${epicfight_version}")
+    // Epic Fight が対応する Controlify と必須設定ライブラリを、専用 client profile だけで検証する。
+    add(optionalRuntimeModuleConfigurations.yacl,
+            "maven.modrinth:${yacl_modrinth_project_id}:${yacl_modrinth_version_id}")
+    add(optionalRuntimeModuleConfigurations.controlify,
+            "maven.modrinth:${controlify_modrinth_project_id}:${controlify_modrinth_version_id}")
 
     // Lootr.
     // TreasureDivination が Lootr の個人開封済み判定へ接続するためのコンパイル用.

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,3 +39,7 @@ lootr_version=1.21.1-1.11.37.118
 patchouli_version=1.21.1-93-NEOFORGE
 epicfight_version=21.17.3.1-mc1.21.1-neoforge
 epicfight_mod_version=21.17.3.1
+controlify_modrinth_project_id=DOUdJVEm
+controlify_modrinth_version_id=d40mkzoo
+yacl_modrinth_project_id=1eAoo2KR
+yacl_modrinth_version_id=7TVdVtxF

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
@@ -1,8 +1,12 @@
 package jp.aquafactory.apprenticecodex.compat.epicfight;
 
 import com.mojang.blaze3d.platform.InputConstants;
+import jp.aquafactory.apprenticecodex.event.client.ClientSpellgunInputEvent;
 import jp.aquafactory.apprenticecodex.item.multipurposestaffrifle.MultipurposeStaffrifle;
+import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
 import net.minecraft.client.KeyMapping;
+import net.minecraft.client.Minecraft;
+import yesman.epicfight.api.client.input.InputManager;
 import yesman.epicfight.api.client.input.action.EpicFightInputAction;
 import yesman.epicfight.api.event.EpicFightEventHooks;
 import yesman.epicfight.api.event.IdentifierProvider;
@@ -16,8 +20,12 @@ public final class EpicFightClientCompat {
     private static final IdentifierProvider SMASHCAST_SCEPTER_CLIENT_EVENT_ID = IdentifierProvider.constant(
             "apprenticecodex:smashcast_scepter_client"
     );
+    private static final IdentifierProvider SPELLGUN_BASIC_ATTACK_CLIENT_EVENT_ID = IdentifierProvider.constant(
+            "apprenticecodex:spellgun_basic_attack_client"
+    );
 
     private static java.util.UUID installedSmashcastScepterPlayerId;
+    private static java.util.UUID installedSpellgunPlayerId;
 
     private EpicFightClientCompat() {
     }
@@ -28,19 +36,29 @@ public final class EpicFightClientCompat {
     }
 
     public static void register() {
-        ItemsPreferenceScreen.registerWeaponCategorizedItemClasses(MultipurposeStaffrifle.class);
+        // RangedWeaponCapability は Find Weapon の自動判定対象外なので、アイテムクラスを明示登録する。
+        ItemsPreferenceScreen.registerWeaponCategorizedItemClasses(
+                MultipurposeStaffrifle.class,
+                AbstractSpellGunItem.class
+        );
     }
 
     public static void tick() {
         installSmashcastScepterEvents();
+        installSpellgunEvents();
     }
 
     public static void clear() {
         installedSmashcastScepterPlayerId = null;
+        installedSpellgunPlayerId = null;
     }
 
     public static boolean matchesAttackInput(InputConstants.Type type, int value) {
         return matchesKey(EpicFightInputAction.ATTACK.keyMapping(), type, value);
+    }
+
+    public static boolean isAttackActive() {
+        return InputManager.isActionActive(EpicFightInputAction.ATTACK);
     }
 
     private static void installSmashcastScepterEvents() {
@@ -63,6 +81,28 @@ public final class EpicFightClientCompat {
         installedSmashcastScepterPlayerId = playerId;
     }
 
+    private static void installSpellgunEvents() {
+        var player = Minecraft.getInstance().player;
+        var playerpatch = player != null ? EpicFightCapabilities.getLocalPlayerPatch(player) : null;
+        if (playerpatch == null || playerpatch.getOriginal() == null || !playerpatch.getOriginal().isAlive()) {
+            installedSpellgunPlayerId = null;
+            return;
+        }
+
+        var playerId = playerpatch.getOriginal().getUUID();
+        if (playerId.equals(installedSpellgunPlayerId)) {
+            return;
+        }
+
+        playerpatch.getEventListener().registerContextAwareEvent(
+                EpicFightEventHooks.Player.CAST_SKILL,
+                (event, context) -> EpicFightClientCompat.onSpellgunSkillCast(event),
+                SPELLGUN_BASIC_ATTACK_CLIENT_EVENT_ID,
+                -1
+        );
+        installedSpellgunPlayerId = playerId;
+    }
+
     private static void onSkillCast(SkillCastEvent event) {
         if (EpicFightSmashcastScepterCompat.shouldAllowDescendingBasicAttack(
                 event.getSkillContainer(),
@@ -70,6 +110,18 @@ public final class EpicFightClientCompat {
         )) {
             event.setStateExecutable(true);
         }
+    }
+
+    private static void onSpellgunSkillCast(SkillCastEvent event) {
+        if (!EpicFightSpellgunCompat.isMainhandSpellgunBasicAttack(
+                event.getPlayerPatch(),
+                event.getSkillContainer()
+        ) || event.isCanceled() || !event.isExecutable()) {
+            return;
+        }
+
+        // ComboAttacks を成功扱いのまま通し、サーバー側の COMBO_ATTACK で発射を合流させる。
+        ClientSpellgunInputEvent.trySendEpicFightMainhandCast();
     }
 
     private static boolean matchesKey(KeyMapping keyMapping, InputConstants.Type type, int value) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
@@ -63,6 +63,12 @@ public final class EpicFightClientCompat {
         return InputManager.isActionActive(EpicFightInputAction.ATTACK);
     }
 
+    public static boolean canHandleAttackInput() {
+        var player = Minecraft.getInstance().player;
+        var playerpatch = player != null ? EpicFightCapabilities.getLocalPlayerPatch(player) : null;
+        return playerpatch != null && playerpatch.canPlayAttackAnimation();
+    }
+
     private static void installSmashcastScepterEvents() {
         var playerpatch = EpicFightCapabilities.getCachedLocalPlayerPatch();
         if (playerpatch == null || playerpatch.getOriginal() == null || !playerpatch.getOriginal().isAlive()) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightClientCompat.java
@@ -13,6 +13,7 @@ import yesman.epicfight.api.event.IdentifierProvider;
 import yesman.epicfight.api.event.types.player.SkillCastEvent;
 import yesman.epicfight.client.ClientEngine;
 import yesman.epicfight.client.gui.screen.config.ItemsPreferenceScreen;
+import yesman.epicfight.client.world.capabilites.entitypatch.player.LocalPlayerPatch;
 import yesman.epicfight.world.capabilities.EpicFightCapabilities;
 
 public final class EpicFightClientCompat {
@@ -24,8 +25,9 @@ public final class EpicFightClientCompat {
             "apprenticecodex:spellgun_basic_attack_client"
     );
 
-    private static java.util.UUID installedSmashcastScepterPlayerId;
-    private static java.util.UUID installedSpellgunPlayerId;
+    // ディメンション移動では UUID が同じまま Patch が再生成されるため、登録済み Patch の同一性を追跡する。
+    private static LocalPlayerPatch installedSmashcastScepterPlayerPatch;
+    private static LocalPlayerPatch installedSpellgunPlayerPatch;
 
     private EpicFightClientCompat() {
     }
@@ -49,8 +51,8 @@ public final class EpicFightClientCompat {
     }
 
     public static void clear() {
-        installedSmashcastScepterPlayerId = null;
-        installedSpellgunPlayerId = null;
+        installedSmashcastScepterPlayerPatch = null;
+        installedSpellgunPlayerPatch = null;
     }
 
     public static boolean matchesAttackInput(InputConstants.Type type, int value) {
@@ -64,12 +66,11 @@ public final class EpicFightClientCompat {
     private static void installSmashcastScepterEvents() {
         var playerpatch = EpicFightCapabilities.getCachedLocalPlayerPatch();
         if (playerpatch == null || playerpatch.getOriginal() == null || !playerpatch.getOriginal().isAlive()) {
-            installedSmashcastScepterPlayerId = null;
+            installedSmashcastScepterPlayerPatch = null;
             return;
         }
 
-        var playerId = playerpatch.getOriginal().getUUID();
-        if (playerId.equals(installedSmashcastScepterPlayerId)) {
+        if (playerpatch == installedSmashcastScepterPlayerPatch) {
             return;
         }
 
@@ -78,19 +79,18 @@ public final class EpicFightClientCompat {
                 EpicFightClientCompat::onSkillCast,
                 SMASHCAST_SCEPTER_CLIENT_EVENT_ID
         );
-        installedSmashcastScepterPlayerId = playerId;
+        installedSmashcastScepterPlayerPatch = playerpatch;
     }
 
     private static void installSpellgunEvents() {
         var player = Minecraft.getInstance().player;
         var playerpatch = player != null ? EpicFightCapabilities.getLocalPlayerPatch(player) : null;
         if (playerpatch == null || playerpatch.getOriginal() == null || !playerpatch.getOriginal().isAlive()) {
-            installedSpellgunPlayerId = null;
+            installedSpellgunPlayerPatch = null;
             return;
         }
 
-        var playerId = playerpatch.getOriginal().getUUID();
-        if (playerId.equals(installedSpellgunPlayerId)) {
+        if (playerpatch == installedSpellgunPlayerPatch) {
             return;
         }
 
@@ -100,7 +100,7 @@ public final class EpicFightClientCompat {
                 SPELLGUN_BASIC_ATTACK_CLIENT_EVENT_ID,
                 -1
         );
-        installedSpellgunPlayerId = playerId;
+        installedSpellgunPlayerPatch = playerpatch;
     }
 
     private static void onSkillCast(SkillCastEvent event) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightCompat.java
@@ -1,6 +1,8 @@
 package jp.aquafactory.apprenticecodex.compat.epicfight;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.utility.BlockTargetData;
+import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModList;
 
@@ -16,6 +18,8 @@ public final class EpicFightCompat {
             "jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightScrollcasterGauntletCompat";
     private static final String SPELLCHARGED_GREATSWORD_COMPAT_CLASS =
             "jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightSpellchargedGreatswordCompat";
+    private static final String SPELLGUN_COMPAT_CLASS =
+            "jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightSpellgunCompat";
 
     private EpicFightCompat() {
     }
@@ -31,6 +35,7 @@ public final class EpicFightCompat {
             registerCompat(SMASHCAST_SCEPTER_COMPAT_CLASS, modEventBus);
             registerCompat(SCROLLCASTER_GAUNTLET_COMPAT_CLASS, modEventBus);
             registerCompat(SPELLCHARGED_GREATSWORD_COMPAT_CLASS, modEventBus);
+            registerCompat(SPELLGUN_COMPAT_CLASS, modEventBus);
         } catch (ReflectiveOperationException exception) {
             throw new IllegalStateException("Epic Fight 互換の初期化に失敗しました", exception);
         }
@@ -41,5 +46,33 @@ public final class EpicFightCompat {
     private static void registerCompat(String className, IEventBus modEventBus) throws ReflectiveOperationException {
         var compatClass = Class.forName(className);
         compatClass.getMethod("register", IEventBus.class).invoke(null, modEventBus);
+    }
+
+    public static boolean canUseOffhandSpellgun(ServerPlayer player) {
+        if (!ModList.get().isLoaded(MOD_ID)) {
+            return true;
+        }
+
+        try {
+            var compatClass = Class.forName(SPELLGUN_COMPAT_CLASS);
+            return (boolean) compatClass.getMethod("canUseOffhandSpellgun", ServerPlayer.class).invoke(null, player);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Epic Fight のSpellgunオフハンド判定に失敗しました", exception);
+        }
+    }
+
+    public static boolean queueMainhandSpellgunCast(ServerPlayer player, BlockTargetData targetData) {
+        if (!ModList.get().isLoaded(MOD_ID)) {
+            return false;
+        }
+
+        try {
+            var compatClass = Class.forName(SPELLGUN_COMPAT_CLASS);
+            return (boolean) compatClass
+                    .getMethod("queueMainhandCast", ServerPlayer.class, BlockTargetData.class)
+                    .invoke(null, player, targetData);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Epic Fight のSpellgunメインハンド発動保留に失敗しました", exception);
+        }
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCapability.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCapability.java
@@ -1,0 +1,42 @@
+package jp.aquafactory.apprenticecodex.compat.epicfight;
+
+import net.minecraft.world.item.UseAnim;
+import yesman.epicfight.api.animation.AnimationManager;
+import yesman.epicfight.api.animation.types.AttackAnimation;
+import yesman.epicfight.world.capabilities.entitypatch.LivingEntityPatch;
+import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
+import yesman.epicfight.world.capabilities.item.CapabilityItem;
+import yesman.epicfight.world.capabilities.item.RangedWeaponCapability;
+import yesman.epicfight.world.capabilities.item.Style;
+
+import java.util.List;
+
+public final class EpicFightSpellgunCapability extends RangedWeaponCapability {
+    public EpicFightSpellgunCapability(RangedWeaponCapability.Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public Style getStyle(LivingEntityPatch<?> entityPatch) {
+        return CapabilityItem.Styles.ONE_HAND;
+    }
+
+    @Override
+    public boolean canBePlacedOffhand() {
+        return true;
+    }
+
+    @Override
+    public List<AnimationManager.AnimationAccessor<? extends AttackAnimation>> getAutoAttackMotion(
+            PlayerPatch<?> playerPatch
+    ) {
+        // ComboAttacks は COMBO_ATTACK 発火後に null を受け取るとモーション選択前に終了するため、
+        // オフハンド同様に Iron's の詠唱表示だけを残す。
+        return null;
+    }
+
+    @Override
+    public UseAnim getUseAnimation(LivingEntityPatch<?> entityPatch) {
+        return UseAnim.NONE;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCompat.java
@@ -162,6 +162,16 @@ public final class EpicFightSpellgunCompat {
         return playerPatch.isEpicFightMode();
     }
 
+    public static boolean enterVanillaMode(ServerPlayer player) {
+        var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+        if (playerPatch == null) {
+            return false;
+        }
+
+        playerPatch.toVanillaMode(false);
+        return playerPatch.isVanillaMode();
+    }
+
     public static boolean hasExpectedSpellgunCapability(ServerPlayer player, ItemStack stack) {
         var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
         var capability = EpicFightCapabilities.getItemStackCapability(stack);

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCompat.java
@@ -1,0 +1,203 @@
+package jp.aquafactory.apprenticecodex.compat.epicfight;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
+import jp.aquafactory.apprenticecodex.utility.BlockTargetData;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.UseAnim;
+import net.neoforged.bus.api.IEventBus;
+import yesman.epicfight.api.event.EpicFightEventHooks;
+import yesman.epicfight.api.event.IdentifierProvider;
+import yesman.epicfight.api.event.types.player.ComboAttackEvent;
+import yesman.epicfight.api.event.types.registry.WeaponCapabilityPresetRegistryEvent;
+import yesman.epicfight.registry.entries.EpicFightSkills;
+import yesman.epicfight.skill.SkillContainer;
+import yesman.epicfight.skill.SkillSlots;
+import yesman.epicfight.world.capabilities.EpicFightCapabilities;
+import yesman.epicfight.world.capabilities.entitypatch.player.PlayerPatch;
+import yesman.epicfight.world.capabilities.entitypatch.player.ServerPlayerPatch;
+import yesman.epicfight.world.capabilities.item.CapabilityItem;
+import yesman.epicfight.world.capabilities.item.RangedWeaponCapability;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+// リフレクションで参照するため、IDE側の未使用検知を無効化.
+@SuppressWarnings("unused")
+public final class EpicFightSpellgunCompat {
+    public static final String MOD_ID = "epicfight";
+    public static final ResourceLocation WEAPON_TYPE_ID =
+            ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "spellgun");
+    private static final IdentifierProvider COMBO_ATTACK_EVENT_ID = IdentifierProvider.constant(
+            "apprenticecodex:spellgun_combo_attack"
+    );
+    private static final int PENDING_CAST_LIFETIME_TICKS = 4;
+    private static final Set<UUID> INSTALLED_PLAYERS = ConcurrentHashMap.newKeySet();
+    private static final Map<UUID, PendingCast> PENDING_CASTS = new ConcurrentHashMap<>();
+
+    private EpicFightSpellgunCompat() {
+    }
+
+    public static void register(IEventBus modEventBus) {
+        EpicFightEventHooks.Registry.WEAPON_CAPABILITY_PRESET.registerEvent(
+                EpicFightSpellgunCompat::onWeaponCapabilityPresetRegistry,
+                "apprenticecodex:spellgun"
+        );
+    }
+
+    private static void onWeaponCapabilityPresetRegistry(WeaponCapabilityPresetRegistryEvent event) {
+        event.getTypeEntry().put(WEAPON_TYPE_ID, EpicFightSpellgunCompat::buildCapability);
+    }
+
+    private static RangedWeaponCapability.Builder buildCapability(Item item) {
+        var builder = RangedWeaponCapability.builder()
+                .zoomInType(CapabilityItem.ZoomInType.NONE);
+        builder.constructor(EpicFightSpellgunCapability::new);
+        return builder;
+    }
+
+    public static void install(ServerPlayer player) {
+        if (!player.isAlive() || INSTALLED_PLAYERS.contains(player.getUUID())) {
+            return;
+        }
+
+        EpicFightCapabilities.getUnparameterizedEntityPatch(player, ServerPlayerPatch.class).ifPresent(playerPatch -> {
+            // ComboAttacks の検証後、他の通常 priority リスナーが攻撃を取り消していない場合だけ発射する。
+            playerPatch.getEventListener().registerContextAwareEvent(
+                    EpicFightEventHooks.Player.COMBO_ATTACK,
+                    (event, context) -> EpicFightSpellgunCompat.onComboAttack(event),
+                    COMBO_ATTACK_EVENT_ID,
+                    -1
+            );
+            INSTALLED_PLAYERS.add(player.getUUID());
+        });
+    }
+
+    public static void tick(ServerPlayer player) {
+        var pendingCast = PENDING_CASTS.get(player.getUUID());
+        if (pendingCast != null && pendingCast.isExpired(player.level().getGameTime())) {
+            PENDING_CASTS.remove(player.getUUID(), pendingCast);
+        }
+    }
+
+    public static void clear(ServerPlayer player) {
+        INSTALLED_PLAYERS.remove(player.getUUID());
+        PENDING_CASTS.remove(player.getUUID());
+    }
+
+    public static boolean queueMainhandCast(ServerPlayer player, BlockTargetData targetData) {
+        if (!isMainhandSpellgunBasicAttack(player)) {
+            return false;
+        }
+
+        PENDING_CASTS.put(
+                player.getUUID(),
+                new PendingCast(
+                        targetData == null ? new BlockTargetData() : targetData.copy(),
+                        player.level().getGameTime() + PENDING_CAST_LIFETIME_TICKS
+                )
+        );
+        return true;
+    }
+
+    private static void onComboAttack(ComboAttackEvent event) {
+        var player = event.getPlayerPatch().getOriginal();
+        var pendingCast = PENDING_CASTS.remove(player.getUUID());
+        if (pendingCast == null
+                || event.isCanceled()
+                || pendingCast.isExpired(player.level().getGameTime())
+                || !isMainhandSpellgunBasicAttack(player)) {
+            return;
+        }
+
+        if (player.getMainHandItem().getItem() instanceof AbstractSpellGunItem spellgun) {
+            // 発射失敗を ComboAttacks の成否へ戻さない。Capability 側はモーションを返さないが、
+            // このイベントまで到達させることでクライアントの成功扱いと入力解放を維持する。
+            spellgun.tryTriggerImbuedSpell(player, InteractionHand.MAIN_HAND, pendingCast.targetData());
+        }
+    }
+
+    public static boolean canUseOffhandSpellgun(ServerPlayer player) {
+        var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+        return playerPatch == null || playerPatch.isVanillaMode() || playerPatch.isOffhandItemValid();
+    }
+
+    public static boolean shouldPrioritizeOffhandSpellgun(PlayerPatch<?> playerPatch) {
+        return playerPatch != null
+                && playerPatch.isEpicFightMode()
+                && playerPatch.getOriginal().getOffhandItem().getItem() instanceof AbstractSpellGunItem
+                && playerPatch.isOffhandItemValid();
+    }
+
+    public static boolean isMainhandSpellgunBasicAttack(
+            PlayerPatch<?> playerPatch,
+            SkillContainer skillContainer
+    ) {
+        return playerPatch != null
+                && skillContainer != null
+                && skillContainer.getSlot() == SkillSlots.COMBO_ATTACKS
+                && playerPatch.isEpicFightMode()
+                && playerPatch.getOriginal().getMainHandItem().getItem() instanceof AbstractSpellGunItem;
+    }
+
+    public static boolean isMainhandSpellgunBasicAttack(ServerPlayer player) {
+        var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+        return playerPatch != null
+                && isMainhandSpellgunBasicAttack(playerPatch, playerPatch.getSkill(SkillSlots.COMBO_ATTACKS));
+    }
+
+    public static boolean enterBattleMode(ServerPlayer player) {
+        var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+        if (playerPatch == null) {
+            return false;
+        }
+
+        playerPatch.toEpicFightMode(false);
+        return playerPatch.isEpicFightMode();
+    }
+
+    public static boolean hasExpectedSpellgunCapability(ServerPlayer player, ItemStack stack) {
+        var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+        var capability = EpicFightCapabilities.getItemStackCapability(stack);
+        return playerPatch != null
+                && capability instanceof EpicFightSpellgunCapability
+                && capability.getStyle(playerPatch) == CapabilityItem.Styles.ONE_HAND
+                && capability.canBePlacedOffhand()
+                && capability.canHoldInOffhandAlone()
+                && capability.getUseAnimation(playerPatch) == UseAnim.NONE
+                && capability.getInnateSkill(playerPatch, stack) == null;
+    }
+
+    public static boolean hasNoSpellgunAttackMotion(ServerPlayer player, ItemStack stack) {
+        var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+        var capability = EpicFightCapabilities.getItemStackCapability(stack);
+        if (playerPatch == null || !(capability instanceof EpicFightSpellgunCapability)) {
+            return false;
+        }
+
+        return capability.getAutoAttackMotion(playerPatch) == null;
+    }
+
+    public static boolean canExecuteGuard(ServerPlayer player) {
+        var playerPatch = EpicFightCapabilities.getEntityPatch(player, PlayerPatch.class);
+        if (playerPatch == null) {
+            return false;
+        }
+
+        var guardContainer = playerPatch.getSkill(SkillSlots.GUARD);
+        guardContainer.setSkill(EpicFightSkills.GUARD.get());
+        return EpicFightSkills.GUARD.get().canExecute(guardContainer);
+    }
+
+    private record PendingCast(BlockTargetData targetData, long expiresAt) {
+        private boolean isExpired(long gameTime) {
+            return gameTime > expiresAt;
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/epicfight/EpicFightSpellgunCompat.java
@@ -128,7 +128,7 @@ public final class EpicFightSpellgunCompat {
         return playerPatch == null || playerPatch.isVanillaMode() || playerPatch.isOffhandItemValid();
     }
 
-    public static boolean shouldPrioritizeOffhandSpellgun(PlayerPatch<?> playerPatch) {
+    public static boolean isGuardDisabledByOffhandSpellgun(PlayerPatch<?> playerPatch) {
         return playerPatch != null
                 && playerPatch.isEpicFightMode()
                 && playerPatch.getOriginal().getOffhandItem().getItem() instanceof AbstractSpellGunItem

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
@@ -28,8 +28,11 @@ public final class ClientSpellgunInputEvent {
         }
 
         // Epic Fight 20.14.17 は非 LivingEntity を照準すると BasicAttack を開始しないため、
-        // 処理可能な入力だけを委譲する。1.21.1 側では canPlayAttackAnimation の判定条件を再確認する。
-        if (isEpicFightBattleMode() && EpicFightClientCompat.canHandleAttackInput()) {
+        // Epic Fight Attack が実際に押され、且つ処理可能な入力だけを委譲する。
+        // 通常攻撃と別割り当てなら Forge 側で処理する。1.21.1 側では入力 API と判定条件を再確認する。
+        if (isEpicFightBattleMode()
+                && EpicFightClientCompat.isAttackActive()
+                && EpicFightClientCompat.canHandleAttackInput()) {
             return;
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
@@ -1,6 +1,7 @@
 package jp.aquafactory.apprenticecodex.event.client;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightClientCompat;
 import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.ClientSpellgunCastPacket;
@@ -8,6 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ClientTickEvent;
 import net.neoforged.neoforge.client.event.InputEvent;
@@ -21,33 +23,62 @@ public final class ClientSpellgunInputEvent {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onInteractionKeyMappingTriggered(InputEvent.InteractionKeyMappingTriggered event) {
-        if (!event.isAttack()) {
+        if (!event.isAttack() || isEpicFightBattleMode()) {
             return;
         }
 
         var minecraft = Minecraft.getInstance();
         var player = minecraft.player;
         if (minecraft.screen != null || player == null || player.isSpectator()
-                || !(player.getMainHandItem().getItem() instanceof AbstractSpellGunItem spellgun)) {
+                || !(player.getMainHandItem().getItem() instanceof AbstractSpellGunItem)) {
             return;
         }
 
         event.setCanceled(true);
         event.setSwingHand(false);
+        trySendMainhandCast();
+    }
+
+    public static void trySendMainhandCast() {
+        trySendMainhandCast(false);
+    }
+
+    public static void trySendEpicFightMainhandCast() {
+        trySendMainhandCast(true);
+    }
+
+    private static void trySendMainhandCast(boolean deferToEpicFightAttack) {
         if (attackLocked) {
+            return;
+        }
+
+        var player = Minecraft.getInstance().player;
+        if (player == null || player.isSpectator()
+                || !(player.getMainHandItem().getItem() instanceof AbstractSpellGunItem spellgun)) {
             return;
         }
 
         attackLocked = true;
         var spellData = spellgun.getImbuedSpellData(player.getMainHandItem());
         var targetData = ClientBlockTargetSyncService.captureForEmbeddedCast(spellData);
-        Networks.sendToServer(new ClientSpellgunCastPacket(targetData));
+        Networks.sendToServer(new ClientSpellgunCastPacket(targetData, deferToEpicFightAttack));
     }
 
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
-        if (!Minecraft.getInstance().options.keyAttack.isDown()) {
+        if (!isAttackActive()) {
             attackLocked = false;
         }
+    }
+
+    private static boolean isAttackActive() {
+        if (isEpicFightBattleMode()) {
+            return EpicFightClientCompat.isAttackActive();
+        }
+        return Minecraft.getInstance().options.keyAttack.isDown();
+    }
+
+    private static boolean isEpicFightBattleMode() {
+        return ModList.get().isLoaded(EpicFightClientCompat.MOD_ID) && EpicFightClientCompat.isBattleMode();
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
@@ -23,7 +23,13 @@ public final class ClientSpellgunInputEvent {
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onInteractionKeyMappingTriggered(InputEvent.InteractionKeyMappingTriggered event) {
-        if (!event.isAttack() || isEpicFightBattleMode()) {
+        if (!event.isAttack()) {
+            return;
+        }
+
+        // Epic Fight 20.14.17 は非 LivingEntity を照準すると BasicAttack を開始しないため、
+        // 処理可能な入力だけを委譲する。1.21.1 側では canPlayAttackAnimation の判定条件を再確認する。
+        if (isEpicFightBattleMode() && EpicFightClientCompat.canHandleAttackInput()) {
             return;
         }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
@@ -72,16 +72,28 @@ public final class ClientSpellgunInputEvent {
 
     @SubscribeEvent
     public static void onClientTick(ClientTickEvent.Post event) {
-        if (!isAttackActive()) {
+        var epicFightBattleMode = isEpicFightBattleMode();
+        var attackActive = epicFightBattleMode
+                ? EpicFightClientCompat.isAttackActive()
+                : Minecraft.getInstance().options.keyAttack.isDown();
+
+        if (epicFightBattleMode && attackActive) {
+            trySendUnhandledEpicFightAttackCast();
+        } else if (!attackActive) {
             attackLocked = false;
         }
     }
 
-    private static boolean isAttackActive() {
-        if (isEpicFightBattleMode()) {
-            return EpicFightClientCompat.isAttackActive();
+    private static void trySendUnhandledEpicFightAttackCast() {
+        var minecraft = Minecraft.getInstance();
+        if (minecraft.screen != null || EpicFightClientCompat.canHandleAttackInput()) {
+            return;
         }
-        return Minecraft.getInstance().options.keyAttack.isDown();
+
+        // Controlify 2.1.7 では Epic Fight の攻撃アクションと通常攻撃が個別に再割り当てできる。
+        // 前者だけが押されると Forge の InteractionKeyMappingTriggered を経由しないため、
+        // Epic Fight が処理できない攻撃入力を tick 側で補足する。1.21.1 側では入力 API と実行順を再確認する。
+        trySendMainhandCast();
     }
 
     private static boolean isEpicFightBattleMode() {

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientSpellgunInputEvent.java
@@ -27,9 +27,9 @@ public final class ClientSpellgunInputEvent {
             return;
         }
 
-        // Epic Fight 20.14.17 は非 LivingEntity を照準すると BasicAttack を開始しないため、
+        // Epic Fight 21.17.3.1 は非 LivingEntity を照準すると ComboAttacks を開始しないため、
         // Epic Fight Attack が実際に押され、且つ処理可能な入力だけを委譲する。
-        // 通常攻撃と別割り当てなら Forge 側で処理する。1.21.1 側では入力 API と判定条件を再確認する。
+        // 通常攻撃と別割り当てなら NeoForge 側で処理する。
         if (isEpicFightBattleMode()
                 && EpicFightClientCompat.isAttackActive()
                 && EpicFightClientCompat.canHandleAttackInput()) {
@@ -93,9 +93,9 @@ public final class ClientSpellgunInputEvent {
             return;
         }
 
-        // Controlify 2.1.7 では Epic Fight の攻撃アクションと通常攻撃が個別に再割り当てできる。
-        // 前者だけが押されると Forge の InteractionKeyMappingTriggered を経由しないため、
-        // Epic Fight が処理できない攻撃入力を tick 側で補足する。1.21.1 側では入力 API と実行順を再確認する。
+        // Controlify 2.5.0 では Epic Fight の攻撃アクションと通常攻撃が個別に再割り当てできる。
+        // 前者だけが押されると NeoForge の InteractionKeyMappingTriggered を経由しないため、
+        // Epic Fight が処理できない攻撃入力を tick 側で補足する。
         trySendMainhandCast();
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -425,6 +425,16 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void spellgunsUseOneHandRangedEpicFightCapabilityWithoutInnate(GameTestHelper helper) {
+        EquipmentSpellGunGameTestScenarios.spellgunsUseOneHandRangedEpicFightCapabilityWithoutInnate(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellgunEpicFightOffhandPolicyUsesOnlyValidOneHandMainhands(GameTestHelper helper) {
+        EquipmentSpellGunGameTestScenarios.spellgunEpicFightOffhandPolicyUsesOnlyValidOneHandMainhands(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void spellcasterGunTooltipsUseCommonOperationDescriptions(GameTestHelper helper) {
         EquipmentSpellGunGameTestScenarios.spellcasterGunTooltipsUseCommonOperationDescriptions(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
@@ -46,6 +46,7 @@ import jp.aquafactory.apprenticecodex.block.spellcasterworkbench.SpellcasterWork
 import jp.aquafactory.apprenticecodex.capability.Capabilities;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.compat.bettercombat.BetterCombatOffhandAttributeRescueCompat;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.ArchivistsGrimoireServerConfig;
 import jp.aquafactory.apprenticecodex.config.item.SpellgunServerConfig;
@@ -1178,6 +1179,165 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
             helper.assertTrue(offhandUse.getResult().consumesAction(),
                     "Selected offhand Spellgun should consume right-click even when it is not imbued");
         });
+    }
+
+    static void spellgunsUseOneHandRangedEpicFightCapabilityWithoutInnate(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            if (!ModList.get().isLoaded(EpicFightCompat.MOD_ID)) {
+                return;
+            }
+
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "spellgun_epicfight_capability_test");
+            for (var spellgun : List.of(
+                    new ItemStack(ItemRegistry.IRON_SPELLCASTER_GUN.get()),
+                    new ItemStack(ItemRegistry.COPPER_SPELLCASTER_GUN.get()),
+                    new ItemStack(ItemRegistry.GOLD_SPELLCASTER_GUN.get()),
+                    new ItemStack(ItemRegistry.DIAMOND_SPELLCASTER_GUN.get())
+            )) {
+                helper.assertTrue(hasExpectedEpicFightSpellgunCapability(player, spellgun),
+                        spellgun.getDescriptionId()
+                                + " should use the one-hand ranged Epic Fight capability without an innate skill");
+            }
+
+            player.setItemInHand(
+                    InteractionHand.MAIN_HAND,
+                    new ItemStack(ItemRegistry.COPPER_SPELLCASTER_GUN.get())
+            );
+            helper.assertTrue(enterEpicFightBattleMode(player),
+                    "Spellgun basic attack integration test should enter Epic Fight battle mode");
+            helper.assertTrue(isEpicFightMainhandSpellgunBasicAttack(player),
+                    "Epic Fight basic attack should recognize a mainhand Spellgun");
+            helper.assertTrue(hasNoEpicFightSpellgunAttackMotion(player, player.getMainHandItem()),
+                    "Epic Fight basic attack should leave Spellgun casting without an Epic Fight motion");
+
+            player.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIAMOND_SWORD));
+            helper.assertFalse(isEpicFightMainhandSpellgunBasicAttack(player),
+                    "Epic Fight Spellgun basic attack handling should not affect non-Spellgun weapons");
+        });
+    }
+
+    static void spellgunEpicFightOffhandPolicyUsesOnlyValidOneHandMainhands(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            if (!ModList.get().isLoaded(EpicFightCompat.MOD_ID)) {
+                return;
+            }
+
+            var spellgun = new ItemStack(ItemRegistry.DIAMOND_SPELLCASTER_GUN.get());
+            var swordPlayer = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "spellgun_epicfight_sword_offhand_test");
+            helper.assertTrue(enterEpicFightBattleMode(swordPlayer),
+                    "Spellgun sword offhand test should enter Epic Fight battle mode");
+            swordPlayer.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIAMOND_SWORD));
+            helper.assertTrue(canExecuteEpicFightGuard(swordPlayer),
+                    "A one-hand Epic Fight sword should allow Guard while the offhand is empty");
+            swordPlayer.setItemInHand(InteractionHand.OFF_HAND, spellgun.copy());
+            helper.assertTrue(canUseEpicFightOffhandSpellgun(swordPlayer),
+                    "A one-hand Epic Fight sword should allow the offhand Spellgun");
+            helper.assertFalse(canExecuteEpicFightGuard(swordPlayer),
+                    "Guard should not execute while a valid offhand Spellgun has right-click priority");
+
+            var axePlayer = createEquipmentTestPlayer(helper, new BlockPos(2, 2, 0),
+                    "spellgun_epicfight_axe_offhand_test");
+            helper.assertTrue(enterEpicFightBattleMode(axePlayer),
+                    "Spellgun axe offhand test should enter Epic Fight battle mode");
+            axePlayer.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIAMOND_AXE));
+            helper.assertTrue(canExecuteEpicFightGuard(axePlayer),
+                    "A one-hand Epic Fight axe should allow Guard while the offhand is empty");
+            axePlayer.setItemInHand(InteractionHand.OFF_HAND, spellgun.copy());
+            helper.assertTrue(canUseEpicFightOffhandSpellgun(axePlayer),
+                    "A one-hand Epic Fight axe should allow the offhand Spellgun");
+            helper.assertFalse(canExecuteEpicFightGuard(axePlayer),
+                    "Guard should not execute for an axe while a valid offhand Spellgun has right-click priority");
+
+            var spear = BuiltInRegistries.ITEM.get(
+                    ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "iron_spear")
+            );
+            helper.assertTrue(spear != Items.AIR, "Missing epicfight:iron_spear for the Spellgun offhand policy test");
+            var spearPlayer = createEquipmentTestPlayer(helper, new BlockPos(4, 2, 0),
+                    "spellgun_epicfight_spear_offhand_test");
+            spearPlayer.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(spear));
+            spearPlayer.setItemInHand(InteractionHand.OFF_HAND, spellgun.copy());
+            helper.assertTrue(canUseEpicFightOffhandSpellgun(spearPlayer),
+                    "Epic Fight vanilla mode should keep vanilla offhand Spellgun use behavior");
+            helper.assertTrue(enterEpicFightBattleMode(spearPlayer),
+                    "Spellgun spear offhand test should enter Epic Fight battle mode");
+            helper.assertFalse(canUseEpicFightOffhandSpellgun(spearPlayer),
+                    "Epic Fight spear should not gain its shield-only one-hand behavior from an offhand Spellgun");
+
+            var rejectedUse = spellgun.getItem().use(
+                    helper.getLevel(),
+                    spearPlayer,
+                    InteractionHand.OFF_HAND
+            );
+            helper.assertFalse(rejectedUse.getResult().consumesAction(),
+                    "An invalid Epic Fight offhand Spellgun use should pass without casting");
+        });
+    }
+
+    private static boolean hasExpectedEpicFightSpellgunCapability(Object player, ItemStack stack) {
+        return invokeEpicFightSpellgunBoolean(
+                "hasExpectedSpellgunCapability",
+                new Class<?>[]{net.minecraft.server.level.ServerPlayer.class, ItemStack.class},
+                player,
+                stack
+        );
+    }
+
+    private static boolean enterEpicFightBattleMode(Object player) {
+        return invokeEpicFightSpellgunBoolean(
+                "enterBattleMode",
+                new Class<?>[]{net.minecraft.server.level.ServerPlayer.class},
+                player
+        );
+    }
+
+    private static boolean isEpicFightMainhandSpellgunBasicAttack(Object player) {
+        return invokeEpicFightSpellgunBoolean(
+                "isMainhandSpellgunBasicAttack",
+                new Class<?>[]{net.minecraft.server.level.ServerPlayer.class},
+                player
+        );
+    }
+
+    private static boolean hasNoEpicFightSpellgunAttackMotion(Object player, ItemStack stack) {
+        return invokeEpicFightSpellgunBoolean(
+                "hasNoSpellgunAttackMotion",
+                new Class<?>[]{net.minecraft.server.level.ServerPlayer.class, ItemStack.class},
+                player,
+                stack
+        );
+    }
+
+    private static boolean canUseEpicFightOffhandSpellgun(Object player) {
+        return invokeEpicFightSpellgunBoolean(
+                "canUseOffhandSpellgun",
+                new Class<?>[]{net.minecraft.server.level.ServerPlayer.class},
+                player
+        );
+    }
+
+    private static boolean canExecuteEpicFightGuard(Object player) {
+        return invokeEpicFightSpellgunBoolean(
+                "canExecuteGuard",
+                new Class<?>[]{net.minecraft.server.level.ServerPlayer.class},
+                player
+        );
+    }
+
+    private static boolean invokeEpicFightSpellgunBoolean(
+            String methodName,
+            Class<?>[] parameterTypes,
+            Object... arguments
+    ) {
+        try {
+            var compatClass = Class.forName(
+                    "jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightSpellgunCompat"
+            );
+            return (boolean) compatClass.getMethod(methodName, parameterTypes).invoke(null, arguments);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to inspect Spellgun Epic Fight compatibility", exception);
+        }
     }
 
     static void invalidSpellgunSpellUsesDedicatedError(GameTestHelper helper) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
@@ -1255,13 +1255,11 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
             helper.assertTrue(enterEpicFightBattleMode(axePlayer),
                     "Spellgun axe offhand test should enter Epic Fight battle mode");
             axePlayer.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(Items.DIAMOND_AXE));
-            helper.assertTrue(canExecuteEpicFightGuard(axePlayer),
-                    "A one-hand Epic Fight axe should allow Guard while the offhand is empty");
             axePlayer.setItemInHand(InteractionHand.OFF_HAND, spellgun.copy());
             helper.assertTrue(canUseEpicFightOffhandSpellgun(axePlayer),
                     "A one-hand Epic Fight axe should allow the offhand Spellgun");
-            helper.assertFalse(canExecuteEpicFightGuard(axePlayer),
-                    "Guard should be intentionally disabled for an axe while a valid offhand Spellgun provides ranged attacks");
+            // Epic Fight 21.17.3.1 の axe preset は単体でも Guard 実行条件を満たさないため、
+            // Guard 無効化の差分は sword で検証し、axe では one-hand のオフハンド可否だけを検証する。
 
             var spear = BuiltInRegistries.ITEM.get(
                     ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "iron_spear")
@@ -1271,6 +1269,8 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
                     "spellgun_epicfight_spear_offhand_test");
             spearPlayer.setItemInHand(InteractionHand.MAIN_HAND, new ItemStack(spear));
             spearPlayer.setItemInHand(InteractionHand.OFF_HAND, spellgun.copy());
+            helper.assertTrue(enterEpicFightVanillaMode(spearPlayer),
+                    "Spellgun spear offhand test should enter Epic Fight vanilla mode");
             helper.assertTrue(canUseEpicFightOffhandSpellgun(spearPlayer),
                     "Epic Fight vanilla mode should keep vanilla offhand Spellgun use behavior");
             helper.assertTrue(enterEpicFightBattleMode(spearPlayer),
@@ -1300,6 +1300,14 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
     private static boolean enterEpicFightBattleMode(Object player) {
         return invokeEpicFightSpellgunBoolean(
                 "enterBattleMode",
+                new Class<?>[]{net.minecraft.server.level.ServerPlayer.class},
+                player
+        );
+    }
+
+    private static boolean enterEpicFightVanillaMode(Object player) {
+        return invokeEpicFightSpellgunBoolean(
+                "enterVanillaMode",
                 new Class<?>[]{net.minecraft.server.level.ServerPlayer.class},
                 player
         );

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellGunGameTestScenarios.java
@@ -500,6 +500,19 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
                         item.getDescriptionId() + " should show the common offhand operation tooltip second");
                 assertTooltipKeyArgument(helper, stack, 1, "key.use",
                         item.getDescriptionId() + " should use the configured use key name");
+                if (ModList.get().isLoaded(EpicFightCompat.MOD_ID)) {
+                    assertTooltipKeyAt(helper, stack, 2,
+                            "item.apprenticecodex.common.spellgun.epicfight.offhand_warning",
+                            item.getDescriptionId() + " should show the Epic Fight offhand Guard warning third");
+                } else {
+                    var lines = new ArrayList<Component>();
+                    item.appendHoverText(
+                            stack, Item.TooltipContext.of(helper.getLevel()), lines, TooltipFlag.Default.NORMAL
+                    );
+                    helper.assertFalse(containsTranslatableKey(lines,
+                                    "item.apprenticecodex.common.spellgun.epicfight.offhand_warning"),
+                            item.getDescriptionId() + " should hide the Epic Fight offhand Guard warning without Epic Fight");
+                }
             }
         });
     }
@@ -1235,7 +1248,7 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
             helper.assertTrue(canUseEpicFightOffhandSpellgun(swordPlayer),
                     "A one-hand Epic Fight sword should allow the offhand Spellgun");
             helper.assertFalse(canExecuteEpicFightGuard(swordPlayer),
-                    "Guard should not execute while a valid offhand Spellgun has right-click priority");
+                    "Guard should be intentionally disabled while a valid offhand Spellgun provides ranged attacks");
 
             var axePlayer = createEquipmentTestPlayer(helper, new BlockPos(2, 2, 0),
                     "spellgun_epicfight_axe_offhand_test");
@@ -1248,7 +1261,7 @@ final class EquipmentSpellGunGameTestScenarios extends ApprenticeCodexGameTestSc
             helper.assertTrue(canUseEpicFightOffhandSpellgun(axePlayer),
                     "A one-hand Epic Fight axe should allow the offhand Spellgun");
             helper.assertFalse(canExecuteEpicFightGuard(axePlayer),
-                    "Guard should not execute for an axe while a valid offhand Spellgun has right-click priority");
+                    "Guard should be intentionally disabled for an axe while a valid offhand Spellgun provides ranged attacks");
 
             var spear = BuiltInRegistries.ITEM.get(
                     ResourceLocation.fromNamespaceAndPath(EpicFightCompat.MOD_ID, "iron_spear")

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/AbstractSpellGunItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/AbstractSpellGunItem.java
@@ -12,6 +12,7 @@ import io.redspace.ironsspellbooks.api.spells.SpellAnimations;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.util.AnimationHolder;
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.enchantment.AttributeEnchantmentPolicy;
 import jp.aquafactory.apprenticecodex.enchantment.AttributeEnchantmentResolver;
@@ -223,6 +224,10 @@ public abstract class AbstractSpellGunItem extends Item implements IPresetSpellC
         }
 
         if (player instanceof ServerPlayer serverPlayer) {
+            // Epic Fight が両手武器として扱う組み合わせでは、非表示のオフハンドから発射させない。
+            if (!EpicFightCompat.canUseOffhandSpellgun(serverPlayer)) {
+                return InteractionResultHolder.pass(stack);
+            }
             tryTriggerImbuedSpell(serverPlayer, usedHand, null);
         }
         // オフハンド Spellgun が選ばれた後の失敗をメインハンドへフォールバックさせない。

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/AbstractSpellGunItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/AbstractSpellGunItem.java
@@ -60,6 +60,7 @@ import net.minecraft.world.item.component.ItemAttributeModifiers;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.Level;
 import net.minecraft.tags.TagKey;
+import net.neoforged.fml.ModList;
 import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -275,6 +276,11 @@ public abstract class AbstractSpellGunItem extends Item implements IPresetSpellC
                 "item." + ApprenticeCodex.MODID + ".common.spellgun.desc_2",
                 ImbueTooltipHelper.getUseKeyName()
         ).withStyle(ChatFormatting.GRAY));
+        if (ModList.get().isLoaded(EpicFightCompat.MOD_ID)) {
+            lines.add(Component.translatable(
+                    "item." + ApprenticeCodex.MODID + ".common.spellgun.epicfight.offhand_warning"
+            ).withStyle(ChatFormatting.YELLOW));
+        }
         appendSpellGunHelpTooltip(stack, lines);
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/SpellgunEpicFightEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/spellgun/SpellgunEpicFightEvents.java
@@ -1,0 +1,45 @@
+package jp.aquafactory.apprenticecodex.item.spellgun;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightSpellgunCompat;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.tick.PlayerTickEvent;
+
+@EventBusSubscriber(modid = ApprenticeCodex.MODID)
+public final class SpellgunEpicFightEvents {
+    private SpellgunEpicFightEvents() {
+    }
+
+    @SubscribeEvent
+    public static void onPlayerTick(PlayerTickEvent.Post event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) {
+            return;
+        }
+        if (!ModList.get().isLoaded(EpicFightSpellgunCompat.MOD_ID)) {
+            return;
+        }
+
+        EpicFightSpellgunCompat.install(player);
+        EpicFightSpellgunCompat.tick(player);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (event.getEntity() instanceof ServerPlayer player
+                && ModList.get().isLoaded(EpicFightSpellgunCompat.MOD_ID)) {
+            EpicFightSpellgunCompat.clear(player);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerClone(PlayerEvent.Clone event) {
+        if (event.getOriginal() instanceof ServerPlayer player
+                && ModList.get().isLoaded(EpicFightSpellgunCompat.MOD_ID)) {
+            EpicFightSpellgunCompat.clear(player);
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/EpicFightGuardSkillMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/EpicFightGuardSkillMixin.java
@@ -1,0 +1,23 @@
+package jp.aquafactory.apprenticecodex.mixin;
+
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightSpellgunCompat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import yesman.epicfight.skill.SkillContainer;
+import yesman.epicfight.skill.guard.GuardSkill;
+
+@Mixin(value = GuardSkill.class, remap = false)
+public abstract class EpicFightGuardSkillMixin {
+    @Inject(method = "canExecute", at = @At("HEAD"), cancellable = true)
+    private void apprenticecodex$prioritizeValidOffhandSpellgun(
+            SkillContainer container,
+            CallbackInfoReturnable<Boolean> callback
+    ) {
+        // 同じ右入力でガードと使用を同時実行せず、有効なオフハンドSpellgunを優先する。
+        if (EpicFightSpellgunCompat.shouldPrioritizeOffhandSpellgun(container.getExecutor())) {
+            callback.setReturnValue(false);
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/EpicFightGuardSkillMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/EpicFightGuardSkillMixin.java
@@ -11,12 +11,14 @@ import yesman.epicfight.skill.guard.GuardSkill;
 @Mixin(value = GuardSkill.class, remap = false)
 public abstract class EpicFightGuardSkillMixin {
     @Inject(method = "canExecute", at = @At("HEAD"), cancellable = true)
-    private void apprenticecodex$prioritizeValidOffhandSpellgun(
+    private void apprenticecodex$disableGuardForValidOffhandSpellgun(
             SkillContainer container,
             CallbackInfoReturnable<Boolean> callback
     ) {
-        // 同じ右入力でガードと使用を同時実行せず、有効なオフハンドSpellgunを優先する。
-        if (EpicFightSpellgunCompat.shouldPrioritizeOffhandSpellgun(container.getExecutor())) {
+        // 遠距離攻撃手段をオフハンドに維持したままガードも併用できないよう、
+        // 入力割り当てにかかわらず、使用可能なオフハンドSpellgun装備中は意図的にガードを無効化する。
+        // 1.21.1 側では GuardSkill.canExecute の呼び出し経路を再確認する。
+        if (EpicFightSpellgunCompat.isGuardDisabledByOffhandSpellgun(container.getExecutor())) {
             callback.setReturnValue(false);
         }
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/EpicFightGuardSkillMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/EpicFightGuardSkillMixin.java
@@ -17,7 +17,6 @@ public abstract class EpicFightGuardSkillMixin {
     ) {
         // 遠距離攻撃手段をオフハンドに維持したままガードも併用できないよう、
         // 入力割り当てにかかわらず、使用可能なオフハンドSpellgun装備中は意図的にガードを無効化する。
-        // 1.21.1 側では GuardSkill.canExecute の呼び出し経路を再確認する。
         if (EpicFightSpellgunCompat.isGuardDisabledByOffhandSpellgun(container.getExecutor())) {
             callback.setReturnValue(false);
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -62,7 +62,7 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "57";
+    private static final String PROTOCOL_VERSION = "58";
 
     private Networks() {
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientSpellgunCastPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/ClientSpellgunCastPacket.java
@@ -1,6 +1,7 @@
 package jp.aquafactory.apprenticecodex.network.packet;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
 import jp.aquafactory.apprenticecodex.item.spellgun.AbstractSpellGunItem;
 import jp.aquafactory.apprenticecodex.utility.BlockTargetData;
 import net.minecraft.network.FriendlyByteBuf;
@@ -12,12 +13,18 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
-public record ClientSpellgunCastPacket(BlockTargetData targetData) implements CustomPacketPayload {
+public record ClientSpellgunCastPacket(
+        BlockTargetData targetData,
+        boolean deferToEpicFightAttack
+) implements CustomPacketPayload {
     public static final Type<ClientSpellgunCastPacket> TYPE =
             new Type<>(ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "client_spellgun_cast"));
     public static final StreamCodec<RegistryFriendlyByteBuf, ClientSpellgunCastPacket> STREAM_CODEC =
             StreamCodec.of((buffer, packet) -> encode(packet, buffer), ClientSpellgunCastPacket::decode);
 
+    public ClientSpellgunCastPacket(BlockTargetData targetData) {
+        this(targetData, false);
+    }
     public ClientSpellgunCastPacket {
         if (targetData == null) {
             targetData = new BlockTargetData();
@@ -31,17 +38,23 @@ public record ClientSpellgunCastPacket(BlockTargetData targetData) implements Cu
 
     public static void encode(ClientSpellgunCastPacket packet, FriendlyByteBuf buffer) {
         packet.targetData().writeToBuffer(buffer);
+        buffer.writeBoolean(packet.deferToEpicFightAttack());
     }
 
     public static ClientSpellgunCastPacket decode(FriendlyByteBuf buffer) {
         var targetData = new BlockTargetData();
         targetData.readFromBuffer(buffer);
-        return new ClientSpellgunCastPacket(targetData);
+        return new ClientSpellgunCastPacket(targetData, buffer.readBoolean());
     }
 
     public static void handle(ClientSpellgunCastPacket packet, IPayloadContext context) {
         context.enqueueWork(() -> {
             if (!(context.player() instanceof ServerPlayer sender) || sender.isSpectator()) {
+                return;
+            }
+
+            if (packet.deferToEpicFightAttack()
+                    && EpicFightCompat.queueMainhandSpellgunCast(sender, packet.targetData())) {
                 return;
             }
 

--- a/src/main/resources/assets/apprenticecodex/item_skins/copper_spellcaster_gun.json
+++ b/src/main/resources/assets/apprenticecodex/item_skins/copper_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "renderer": "minecraft:base"
+}

--- a/src/main/resources/assets/apprenticecodex/item_skins/diamond_spellcaster_gun.json
+++ b/src/main/resources/assets/apprenticecodex/item_skins/diamond_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "renderer": "minecraft:base"
+}

--- a/src/main/resources/assets/apprenticecodex/item_skins/gold_spellcaster_gun.json
+++ b/src/main/resources/assets/apprenticecodex/item_skins/gold_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "renderer": "minecraft:base"
+}

--- a/src/main/resources/assets/apprenticecodex/item_skins/iron_spellcaster_gun.json
+++ b/src/main/resources/assets/apprenticecodex/item_skins/iron_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "renderer": "minecraft:base"
+}

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -174,6 +174,7 @@
   "item.apprenticecodex.spellgun.tooltip.ammo_condition_above_epic": "Above Epic",
   "item.apprenticecodex.common.spellgun.desc_1": "When held in the main hand, cast a spell with [%1$s].",
   "item.apprenticecodex.common.spellgun.desc_2": "When held in the offhand, cast a spell with [%1$s].",
+  "item.apprenticecodex.common.spellgun.epicfight.offhand_warning": "While held in the offhand, Guard skills cannot be used.",
   "item.apprenticecodex.wisdom_shard.desc": "Can be installed as an adjustment item for some equipment.",
   "item.apprenticecodex.apprentice_desk.disabled_tooltip": "Only functional as a job site block for an Errand Mage.",
   "item.apprenticecodex.spell_dispenser.creative_tooltip": "Creative version",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -180,6 +180,7 @@
   "item.apprenticecodex.common.imbue_tooltip.cooldown": "クールダウン中(%1$d秒)",
   "item.apprenticecodex.common.spellgun.desc_1": "利き手に持っている時、[%1$s]で魔法を詠唱する。",
   "item.apprenticecodex.common.spellgun.desc_2": "オフハンドに持っている時、[%1$s]で魔法を詠唱する。",
+  "item.apprenticecodex.common.spellgun.epicfight.offhand_warning": "オフハンドに持っている間、ガードスキルが使用できなくなる。",
   "item.apprenticecodex.wisdom_shard.desc": "一部アイテムの調整用アイテムとして装着できる。",
   "item.apprenticecodex.apprentice_desk.disabled_tooltip": "使い走り魔術師の職業ブロックとしてのみ機能する。",
   "item.apprenticecodex.spell_dispenser.creative_tooltip": "クリエイティブバージョン",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -174,6 +174,7 @@
   "item.apprenticecodex.common.desc.spell_hint_open": "适用法术：",
   "item.apprenticecodex.common.spellgun.desc_1": "主手持有时，按[%1$s]施放法术。",
   "item.apprenticecodex.common.spellgun.desc_2": "副手持有时，按[%1$s]施放法术。",
+  "item.apprenticecodex.common.spellgun.epicfight.offhand_warning": "持于副手期间，无法使用格挡技能。",
   "item.apprenticecodex.wisdom_shard.desc": "可作为部分装备的调整用物品安装。",
   "item.apprenticecodex.apprentice_desk.disabled_tooltip": "仅作为跑腿法师的工作站点方块时生效。",
   "item.apprenticecodex.spell_dispenser.creative_tooltip": "创造版",

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/copper_spellcaster_gun.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/copper_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "type": "apprenticecodex:spellgun"
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/diamond_spellcaster_gun.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/diamond_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "type": "apprenticecodex:spellgun"
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/gold_spellcaster_gun.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/gold_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "type": "apprenticecodex:spellgun"
+}

--- a/src/main/resources/data/apprenticecodex/capabilities/weapons/iron_spellcaster_gun.json
+++ b/src/main/resources/data/apprenticecodex/capabilities/weapons/iron_spellcaster_gun.json
@@ -1,0 +1,3 @@
+{
+  "type": "apprenticecodex:spellgun"
+}

--- a/src/main/resources/mixins.apprenticecodex.json
+++ b/src/main/resources/mixins.apprenticecodex.json
@@ -24,6 +24,7 @@
     "FluidStackMixin",
     "EntitySharedFlagAccessor",
     "EfisCompatPlayerAnimationEventsMixin",
+    "EpicFightGuardSkillMixin",
     "EpicFightLivingEntityPatchMixin",
     "EpicFightPlayerPatchMixin",
     "IronsSpellbooksSchoolSpellCacheHotfixMixin",


### PR DESCRIPTION
## 概要

PR #726 の変更を `main`（Minecraft 1.20.1）から `1.21.1-main` へforward-portします。

- 詠唱銃をEpic FightのComboAttacksへ接続
- Controlify対応の専用クライアントプロファイルを追加
- キー割り当て変更時や非LivingEntity照準時の入力フォールバックを追加
- ディメンション移動後に再生成されるLocalPlayerPatchへイベントを再登録
- オフハンド詠唱銃装備中のGuard無効化とツールチップ警告を追加
- Epic Fight用weapon capability / item skinデータとGameTestを追加

## 1.21.1向け調整

- Forge APIをNeoForge 21.1.219のAPIへ置換
- BasicAttack系APIを `ComboAttackEvent` / `SkillSlots.COMBO_ATTACKS` へ移行
- Epic Fight 21.17.3.1のイベント登録・registry・skill APIへ適合
- ペイロード変更に伴いネットワークプロトコルを58へ更新
- Controlify 2.5.0とYACL 3.8.2の1.21.1 NeoForge版を使用
- 1.21.1側のaxe presetおよびFakePlayer初期mode差分にGameTestを適合

## 影響

Epic Fightのbattle modeで詠唱銃をメインハンド攻撃として使用できます。Controlify利用時や攻撃キーを再割り当てした環境でも入力を処理し、使用可能なオフハンド詠唱銃を装備している間はGuardを無効化します。

## 確認

- [x] `./gradlew.bat compileJava`
- [x] Controlify / YACL依存解決
- [x] `./gradlew.bat runGameTestServer`（825件成功）
- [x] `./gradlew.bat runGameTestServerEpicFight`（825件成功）
- [x] `./gradlew.bat build`
- [x] `./gradlew.bat runClientEpicFightController`（手動確認、問題なし）

forward-port元の6コミットは順序を保ち、`git cherry-pick -x` で取り込んでいます。