### PR TITLE
PR #740 装備による特定魔法のクールダウン・詠唱時間短縮のサーバー設定化＋一部ナーフ forward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/ApprenticeCodex.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/ApprenticeCodex.java
@@ -9,6 +9,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexCommonConfig;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.event.ApprenticeDeskConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.event.CircuitHeatStaffConfigSyncEvents;
+import jp.aquafactory.apprenticecodex.event.EquipmentSpellTimingConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.event.IsekaiTravelGuidebookConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.event.ManaForceBladeConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.event.ManaShieldCharmConfigSyncEvents;
@@ -82,6 +83,7 @@ public class ApprenticeCodex
         ModEntityAttributeEvent.register(modEventBus);
         ApprenticeDeskConfigSyncEvents.register(modEventBus);
         CircuitHeatStaffConfigSyncEvents.register(modEventBus);
+        EquipmentSpellTimingConfigSyncEvents.register(modEventBus);
         ChargecastCatalystbookConfigSyncEvents.register(modEventBus);
         FocusStaffbowConfigSyncEvents.register(modEventBus);
         IsekaiTravelGuidebookConfigSyncEvents.register(modEventBus);

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -315,6 +315,10 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.craftsmansDelightFortuneLevel();
     }
 
+    public static double craftsmansDelightCooldownMultiplier() {
+        return ITEMS_CONFIG.craftsmansDelightCooldownMultiplier();
+    }
+
     public static boolean isCraftsmansDelightGracedRainGrowthDenied(ResourceLocation entityTypeId) {
         return ITEMS_CONFIG.isCraftsmansDelightGracedRainGrowthDenied(entityTypeId);
     }
@@ -349,6 +353,14 @@ public final class ApprenticeCodexServerConfig {
 
     public static double magiAgentSuitSchoolSpellPowerBonus() {
         return ITEMS_CONFIG.magiAgentSuitSchoolSpellPowerBonus();
+    }
+
+    public static double magiAgentSuitBootsCooldownMultiplier() {
+        return ITEMS_CONFIG.magiAgentSuitBootsCooldownMultiplier();
+    }
+
+    public static double magiAgentSuitBootsCastTimeMultiplier() {
+        return ITEMS_CONFIG.magiAgentSuitBootsCastTimeMultiplier();
     }
 
     public static double magiAgentSuitAmmoNoConsumeChance() {
@@ -860,6 +872,26 @@ public final class ApprenticeCodexServerConfig {
         return () -> ITEMS_CONFIG.setCraftsmansDelightGracedRainDenylistsForGameTest(
                 previousGrowthDenylist,
                 previousBreedingCooldownDenylist
+        );
+    }
+
+    public static GameTestConfigOverride useEquipmentSpellTimingMultipliersOverrideForGameTest(
+            double craftsmansDelightCooldownMultiplier,
+            double magiAgentSuitBootsCooldownMultiplier,
+            double magiAgentSuitBootsCastTimeMultiplier
+    ) {
+        var previousCraftsmansDelightCooldownMultiplier = ITEMS_CONFIG.craftsmansDelightCooldownMultiplier();
+        var previousMagiAgentSuitBootsCooldownMultiplier = ITEMS_CONFIG.magiAgentSuitBootsCooldownMultiplier();
+        var previousMagiAgentSuitBootsCastTimeMultiplier = ITEMS_CONFIG.magiAgentSuitBootsCastTimeMultiplier();
+        ITEMS_CONFIG.setEquipmentSpellTimingMultipliersForGameTest(
+                craftsmansDelightCooldownMultiplier,
+                magiAgentSuitBootsCooldownMultiplier,
+                magiAgentSuitBootsCastTimeMultiplier
+        );
+        return () -> ITEMS_CONFIG.setEquipmentSpellTimingMultipliersForGameTest(
+                previousCraftsmansDelightCooldownMultiplier,
+                previousMagiAgentSuitBootsCooldownMultiplier,
+                previousMagiAgentSuitBootsCastTimeMultiplier
         );
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -248,6 +248,10 @@ final class ItemsServerConfig {
         return craftsmansDelightConfig.fortuneLevel();
     }
 
+    double craftsmansDelightCooldownMultiplier() {
+        return craftsmansDelightConfig.cooldownMultiplier();
+    }
+
     boolean isCraftsmansDelightGracedRainGrowthDenied(ResourceLocation entityTypeId) {
         return craftsmansDelightConfig.isGracedRainGrowthDenied(entityTypeId);
     }
@@ -290,6 +294,14 @@ final class ItemsServerConfig {
 
     double magiAgentSuitSchoolSpellPowerBonus() {
         return magicArmorConfig.magiAgentSuitSchoolSpellPowerBonus();
+    }
+
+    double magiAgentSuitBootsCooldownMultiplier() {
+        return magicArmorConfig.magiAgentSuitBootsCooldownMultiplier();
+    }
+
+    double magiAgentSuitBootsCastTimeMultiplier() {
+        return magicArmorConfig.magiAgentSuitBootsCastTimeMultiplier();
     }
 
     double magiAgentSuitAmmoNoConsumeChance() {
@@ -752,6 +764,16 @@ final class ItemsServerConfig {
                 gracedRainGrowthDenylist,
                 gracedRainBreedingCooldownDenylist
         );
+    }
+
+    void setEquipmentSpellTimingMultipliersForGameTest(
+            double craftsmansDelightCooldownMultiplier,
+            double magiAgentSuitBootsCooldownMultiplier,
+            double magiAgentSuitBootsCastTimeMultiplier
+    ) {
+        craftsmansDelightConfig.setCooldownMultiplierForGameTest(craftsmansDelightCooldownMultiplier);
+        magicArmorConfig.setMagiAgentSuitBootsCooldownMultiplierForGameTest(magiAgentSuitBootsCooldownMultiplier);
+        magicArmorConfig.setMagiAgentSuitBootsCastTimeMultiplierForGameTest(magiAgentSuitBootsCastTimeMultiplier);
     }
 
     void setMultipurposeStaffrifleSpellDenylistForGameTest(List<String> spellDenylist) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/CraftsmansDelightServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/CraftsmansDelightServerConfig.java
@@ -10,21 +10,25 @@ public final class CraftsmansDelightServerConfig {
     private final ModConfigSpec.BooleanValue canImbueEnchantment;
     private final ModConfigSpec.DoubleValue requiredMana;
     private final ModConfigSpec.IntValue fortuneLevel;
+    private final ModConfigSpec.DoubleValue cooldownMultiplier;
     private final ModConfigSpec.ConfigValue<List<? extends String>> gracedRainGrowthDenylist;
     private final ModConfigSpec.ConfigValue<List<? extends String>> gracedRainBreedingCooldownDenylist;
     private List<String> gracedRainGrowthDenylistOverride;
     private List<String> gracedRainBreedingCooldownDenylistOverride;
+    private Double cooldownMultiplierOverride;
 
     private CraftsmansDelightServerConfig(
             ModConfigSpec.BooleanValue canImbueEnchantment,
             ModConfigSpec.DoubleValue requiredMana,
             ModConfigSpec.IntValue fortuneLevel,
+            ModConfigSpec.DoubleValue cooldownMultiplier,
             ModConfigSpec.ConfigValue<List<? extends String>> gracedRainGrowthDenylist,
             ModConfigSpec.ConfigValue<List<? extends String>> gracedRainBreedingCooldownDenylist
     ) {
         this.canImbueEnchantment = canImbueEnchantment;
         this.requiredMana = requiredMana;
         this.fortuneLevel = fortuneLevel;
+        this.cooldownMultiplier = cooldownMultiplier;
         this.gracedRainGrowthDenylist = gracedRainGrowthDenylist;
         this.gracedRainBreedingCooldownDenylist = gracedRainBreedingCooldownDenylist;
     }
@@ -35,6 +39,9 @@ public final class CraftsmansDelightServerConfig {
         var canImbueEnchantment = builder.define("canImbueEnchantment", true);
         var requiredMana = builder.defineInRange("requiredMana", 500.0d, 0.0d, 10000.0d);
         var fortuneLevel = builder.defineInRange("fortuneLevel", 3, 1, 10);
+        var cooldownMultiplier = builder
+                .comment("Multiplier applied to target spell cooldowns. 0.5 = 50%. A value of 0.0 still leaves a minimum cooldown of 1 tick.")
+                .defineInRange("cooldownMultiplier", 0.5D, 0.0D, 1.0D);
         var gracedRainGrowthDenylist = builder
                 .comment("Entity type IDs blocked from Craftsman's Delight Graced Rain baby growth acceleration. Entries use \"modid:path\".")
                 .defineListAllowEmpty("gracedRainGrowthDenylist", List.<String>of(), CraftsmansDelightServerConfig::isEntityTypeId);
@@ -47,6 +54,7 @@ public final class CraftsmansDelightServerConfig {
                 canImbueEnchantment,
                 requiredMana,
                 fortuneLevel,
+                cooldownMultiplier,
                 gracedRainGrowthDenylist,
                 gracedRainBreedingCooldownDenylist
         );
@@ -62,6 +70,10 @@ public final class CraftsmansDelightServerConfig {
 
     public int fortuneLevel() {
         return fortuneLevel.get();
+    }
+
+    public double cooldownMultiplier() {
+        return cooldownMultiplierOverride == null ? cooldownMultiplier.get() : cooldownMultiplierOverride;
     }
 
     public boolean isGracedRainGrowthDenied(ResourceLocation entityTypeId) {
@@ -88,6 +100,10 @@ public final class CraftsmansDelightServerConfig {
     ) {
         this.gracedRainGrowthDenylistOverride = List.copyOf(gracedRainGrowthDenylist);
         this.gracedRainBreedingCooldownDenylistOverride = List.copyOf(gracedRainBreedingCooldownDenylist);
+    }
+
+    public void setCooldownMultiplierForGameTest(double value) {
+        cooldownMultiplierOverride = value;
     }
 
     private static boolean containsEntityTypeId(List<String> configuredIds, ResourceLocation entityTypeId) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/MagicArmorServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/MagicArmorServerConfig.java
@@ -10,11 +10,15 @@ public final class MagicArmorServerConfig {
     private final ModConfigSpec.DoubleValue elementMaidenRobeSchoolSpellPowerBonus;
     private final ModConfigSpec.DoubleValue magiAgentSuitSpellPowerBonus;
     private final ModConfigSpec.DoubleValue magiAgentSuitSchoolSpellPowerBonus;
+    private final ModConfigSpec.DoubleValue magiAgentSuitBootsCooldownMultiplier;
+    private final ModConfigSpec.DoubleValue magiAgentSuitBootsCastTimeMultiplier;
     private final ModConfigSpec.DoubleValue magiAgentSuitAmmoNoConsumeChance;
     private final ModConfigSpec.BooleanValue magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumed;
     private final ModConfigSpec.DoubleValue stealthRuneArmorSpellPowerBonusPerPiece;
 
     private Double elementMaidenRobeSchoolSpellPowerBonusOverride;
+    private Double magiAgentSuitBootsCooldownMultiplierOverride;
+    private Double magiAgentSuitBootsCastTimeMultiplierOverride;
     private Double magiAgentSuitAmmoNoConsumeChanceOverride;
     private Boolean magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumedOverride;
 
@@ -26,6 +30,8 @@ public final class MagicArmorServerConfig {
             ModConfigSpec.DoubleValue elementMaidenRobeSchoolSpellPowerBonus,
             ModConfigSpec.DoubleValue magiAgentSuitSpellPowerBonus,
             ModConfigSpec.DoubleValue magiAgentSuitSchoolSpellPowerBonus,
+            ModConfigSpec.DoubleValue magiAgentSuitBootsCooldownMultiplier,
+            ModConfigSpec.DoubleValue magiAgentSuitBootsCastTimeMultiplier,
             ModConfigSpec.DoubleValue magiAgentSuitAmmoNoConsumeChance,
             ModConfigSpec.BooleanValue magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumed,
             ModConfigSpec.DoubleValue stealthRuneArmorSpellPowerBonusPerPiece
@@ -37,6 +43,8 @@ public final class MagicArmorServerConfig {
         this.elementMaidenRobeSchoolSpellPowerBonus = elementMaidenRobeSchoolSpellPowerBonus;
         this.magiAgentSuitSpellPowerBonus = magiAgentSuitSpellPowerBonus;
         this.magiAgentSuitSchoolSpellPowerBonus = magiAgentSuitSchoolSpellPowerBonus;
+        this.magiAgentSuitBootsCooldownMultiplier = magiAgentSuitBootsCooldownMultiplier;
+        this.magiAgentSuitBootsCastTimeMultiplier = magiAgentSuitBootsCastTimeMultiplier;
         this.magiAgentSuitAmmoNoConsumeChance = magiAgentSuitAmmoNoConsumeChance;
         this.magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumed =
                 magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumed;
@@ -79,6 +87,8 @@ public final class MagicArmorServerConfig {
                 "MagiAgentSuit",
                 0.10D
         );
+        var magiAgentSuitBootsCooldownMultiplier = defineMagiAgentSuitBootsCooldownMultiplier(builder);
+        var magiAgentSuitBootsCastTimeMultiplier = defineMagiAgentSuitBootsCastTimeMultiplier(builder);
         var magiAgentSuitAmmoNoConsumeChance = defineMagiAgentSuitAmmoNoConsumeChance(builder);
         var magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumed =
                 defineMagiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumed(builder);
@@ -96,6 +106,8 @@ public final class MagicArmorServerConfig {
                 elementMaidenRobeSchoolSpellPowerBonus,
                 magiAgentSuitSpellPowerBonus,
                 magiAgentSuitSchoolSpellPowerBonus,
+                magiAgentSuitBootsCooldownMultiplier,
+                magiAgentSuitBootsCastTimeMultiplier,
                 magiAgentSuitAmmoNoConsumeChance,
                 magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumed,
                 stealthRuneArmorSpellPowerBonusPerPiece
@@ -132,6 +144,18 @@ public final class MagicArmorServerConfig {
         return magiAgentSuitSchoolSpellPowerBonus.get();
     }
 
+    public double magiAgentSuitBootsCooldownMultiplier() {
+        return magiAgentSuitBootsCooldownMultiplierOverride == null
+                ? magiAgentSuitBootsCooldownMultiplier.get()
+                : magiAgentSuitBootsCooldownMultiplierOverride;
+    }
+
+    public double magiAgentSuitBootsCastTimeMultiplier() {
+        return magiAgentSuitBootsCastTimeMultiplierOverride == null
+                ? magiAgentSuitBootsCastTimeMultiplier.get()
+                : magiAgentSuitBootsCastTimeMultiplierOverride;
+    }
+
     public double magiAgentSuitAmmoNoConsumeChance() {
         return magiAgentSuitAmmoNoConsumeChanceOverride == null
                 ? magiAgentSuitAmmoNoConsumeChance.get()
@@ -159,6 +183,14 @@ public final class MagicArmorServerConfig {
         magiAgentSuitAmmoNoConsumeChanceOverride = ammoNoConsumeChance;
         magiAgentSuitSkipStaffrifleManaCostWhenAmmoNotConsumedOverride =
                 skipStaffrifleManaCostWhenAmmoNotConsumed;
+    }
+
+    public void setMagiAgentSuitBootsCooldownMultiplierForGameTest(double value) {
+        magiAgentSuitBootsCooldownMultiplierOverride = value;
+    }
+
+    public void setMagiAgentSuitBootsCastTimeMultiplierForGameTest(double value) {
+        magiAgentSuitBootsCastTimeMultiplierOverride = value;
     }
 
     private static ModConfigSpec.DoubleValue defineSpellPowerBonusPerPiece(
@@ -238,6 +270,34 @@ public final class MagicArmorServerConfig {
                 0.0D,
                 1.0D
         );
+        builder.pop();
+        return value;
+    }
+
+    private static ModConfigSpec.DoubleValue defineMagiAgentSuitBootsCooldownMultiplier(ModConfigSpec.Builder builder) {
+        builder.push("MagiAgentSuit");
+        var value = builder
+                .comment("Multiplier applied by Magi Agent Suit Boots to target spell cooldowns. 0.5 = 50%. A value of 0.0 still leaves a minimum cooldown of 1 tick.")
+                .defineInRange(
+                        "bootsCooldownMultiplier",
+                        0.5D,
+                        0.0D,
+                        1.0D
+                );
+        builder.pop();
+        return value;
+    }
+
+    private static ModConfigSpec.DoubleValue defineMagiAgentSuitBootsCastTimeMultiplier(ModConfigSpec.Builder builder) {
+        builder.push("MagiAgentSuit");
+        var value = builder
+                .comment("Multiplier applied by Magi Agent Suit Boots to target LONG spell cast times. 0.5 = 50%. A value of 0.0 still leaves a minimum cast time of 1 tick.")
+                .defineInRange(
+                        "bootsCastTimeMultiplier",
+                        0.5D,
+                        0.0D,
+                        1.0D
+                );
         builder.pop();
         return value;
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/EquipmentSpellTimingConfigSyncEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/EquipmentSpellTimingConfigSyncEvents.java
@@ -1,0 +1,102 @@
+package jp.aquafactory.apprenticecodex.event;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.EquipmentSpellTimingConfigState;
+import jp.aquafactory.apprenticecodex.network.Networks;
+import jp.aquafactory.apprenticecodex.network.packet.SyncEquipmentSpellTimingConfigPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.config.ModConfig;
+import net.neoforged.fml.event.config.ModConfigEvent;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.server.ServerLifecycleHooks;
+
+@EventBusSubscriber(modid = ApprenticeCodex.MODID)
+public final class EquipmentSpellTimingConfigSyncEvents {
+    private EquipmentSpellTimingConfigSyncEvents() {
+    }
+
+    public static void register(IEventBus modEventBus) {
+        modEventBus.addListener(EquipmentSpellTimingConfigSyncEvents::onConfigLoading);
+        modEventBus.addListener(EquipmentSpellTimingConfigSyncEvents::onConfigReloading);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    private static void syncToPlayer(ServerPlayer player) {
+        Networks.sendToPlayer(player, createPacket());
+    }
+
+    private static void syncToAllPlayers() {
+        var server = ServerLifecycleHooks.getCurrentServer();
+        if (server == null) {
+            return;
+        }
+
+        var packet = createPacket();
+        for (var player : server.getPlayerList().getPlayers()) {
+            Networks.sendToPlayer(player, packet);
+        }
+    }
+
+    private static SyncEquipmentSpellTimingConfigPacket createPacket() {
+        return new SyncEquipmentSpellTimingConfigPacket(
+                ApprenticeCodexServerConfig.craftsmansDelightCooldownMultiplier(),
+                ApprenticeCodexServerConfig.magiAgentSuitBootsCooldownMultiplier(),
+                ApprenticeCodexServerConfig.magiAgentSuitBootsCastTimeMultiplier()
+        );
+    }
+
+    private static void onConfigLoading(ModConfigEvent.Loading event) {
+        syncIfServerConfig(event);
+    }
+
+    private static void onConfigReloading(ModConfigEvent.Reloading event) {
+        syncIfServerConfig(event);
+    }
+
+    private static void syncIfServerConfig(ModConfigEvent event) {
+        if (event.getConfig().getType() != ModConfig.Type.SERVER
+                || !ApprenticeCodex.MODID.equals(event.getConfig().getModId())) {
+            return;
+        }
+
+        // 実行中の SERVER config リロードをクライアント側の詠唱予測にも反映する。
+        syncToAllPlayers();
+    }
+
+    @EventBusSubscriber(modid = ApprenticeCodex.MODID, value = Dist.CLIENT)
+    public static final class ClientEvents {
+        private ClientEvents() {
+        }
+
+        @SubscribeEvent
+        public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+            EquipmentSpellTimingConfigState.reset();
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -13,6 +13,8 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     private static final String MINING_SPELL_ISOLATED_BATCH = "apprenticecodex.mining_spell_isolated";
     private static final String CRAFTSMANS_DELIGHT_GRACED_RAIN_DENYLIST_CONFIG_BATCH =
             "apprenticecodex.craftsmans_delight_graced_rain_denylist_config";
+    private static final String EQUIPMENT_SPELL_TIMING_MULTIPLIER_CONFIG_BATCH =
+            "apprenticecodex.equipment_spell_timing_multiplier_config";
     private static final String FOCUS_STAFFBOW_CONTINUOUS_BATCH = "apprenticecodex.focus_staffbow_continuous";
     private static final String FOCUS_STAFFBOW_ARROW_CONFIG_BATCH =
             "apprenticecodex.focus_staffbow_arrow_config";
@@ -1779,8 +1781,14 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
-    public static void magiAgentSuitBootsCooldownKeepsCraftsmansDelightBestValue(GameTestHelper helper) {
-        EquipmentSpellBehaviorBridgeGameTestScenarios.magiAgentSuitBootsCooldownKeepsCraftsmansDelightBestValue(helper);
+    public static void equipmentCooldownReductionsDoNotStack(GameTestHelper helper) {
+        EquipmentSpellBehaviorBridgeGameTestScenarios.equipmentCooldownReductionsDoNotStack(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = EQUIPMENT_SPELL_TIMING_MULTIPLIER_CONFIG_BATCH)
+    public static void equipmentSpellTimingMultipliersFollowServerConfigAndKeepOneTickMinimum(GameTestHelper helper) {
+        EquipmentSpellBehaviorBridgeGameTestScenarios
+                .equipmentSpellTimingMultipliersFollowServerConfigAndKeepOneTickMinimum(helper);
     }
 
     @GameTest(template = TEMPLATE)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellBehaviorBridgeGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentSpellBehaviorBridgeGameTestScenarios.java
@@ -110,6 +110,7 @@ import jp.aquafactory.apprenticecodex.item.scrollcastergauntlet.ScrollcasterGaun
 import jp.aquafactory.apprenticecodex.item.scrollcastergauntlet.ScrollcasterGauntletCastEvent;
 import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.item.armor.MagiAgentSuitCooldownEvent;
+import jp.aquafactory.apprenticecodex.item.armor.MagiAgentSuitEffects;
 import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmulet;
 import jp.aquafactory.apprenticecodex.item.curios.autocastamulet.AutocastAmuletAutoCastEvent;
 import jp.aquafactory.apprenticecodex.item.curios.archivistsgrimoire.ArchivistsGrimoire;
@@ -541,9 +542,9 @@ final class EquipmentSpellBehaviorBridgeGameTestScenarios extends ApprenticeCode
             CraftsmansDelightManaCostDiscountEvent.onSpellCast(touchDigManaEvent);
             helper.assertTrue(touchDigManaEvent.getManaCost() == 8,
                     "CraftsmansDelight should halve Touch Dig mana to 8 but got " + touchDigManaEvent.getManaCost());
-            var expectedTouchDigBaseCooldown = Math.max(1, touchDigSpell.getSpellCooldown() / 3);
+            var expectedTouchDigBaseCooldown = Math.max(1, (int) (touchDigSpell.getSpellCooldown() * 0.5D));
             helper.assertTrue(CraftsmansDelight.applyCooldownDiscount(touchDigSpell.getSpellCooldown(), player) == expectedTouchDigBaseCooldown,
-                    "CraftsmansDelight should reduce Touch Dig base cooldown to one third before player modifiers");
+                    "CraftsmansDelight should apply the default 0.5 cooldown multiplier before player modifiers");
 
             var touchDigCooldownEvent = new SpellCooldownAddedEvent.Pre(
                     10,
@@ -567,9 +568,9 @@ final class EquipmentSpellBehaviorBridgeGameTestScenarios extends ApprenticeCode
             CraftsmansDelightManaCostDiscountEvent.onSpellCast(spectralHammerManaEvent);
             helper.assertTrue(spectralHammerManaEvent.getManaCost() == 8,
                     "CraftsmansDelight should halve Spectral Hammer mana to 8 but got " + spectralHammerManaEvent.getManaCost());
-            var expectedSpectralHammerBaseCooldown = Math.max(1, spectralHammerSpell.getSpellCooldown() / 3);
+            var expectedSpectralHammerBaseCooldown = Math.max(1, (int) (spectralHammerSpell.getSpellCooldown() * 0.5D));
             helper.assertTrue(CraftsmansDelight.applyCooldownDiscount(spectralHammerSpell.getSpellCooldown(), player) == expectedSpectralHammerBaseCooldown,
-                    "CraftsmansDelight should reduce Spectral Hammer base cooldown to one third before player modifiers");
+                    "CraftsmansDelight should apply the default 0.5 cooldown multiplier before player modifiers");
 
             var spectralHammerCooldownEvent = new SpellCooldownAddedEvent.Pre(
                     40,
@@ -679,7 +680,7 @@ final class EquipmentSpellBehaviorBridgeGameTestScenarios extends ApprenticeCode
         });
     }
 
-    static void magiAgentSuitBootsCooldownKeepsCraftsmansDelightBestValue(GameTestHelper helper) {
+    static void equipmentCooldownReductionsDoNotStack(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
                     "magi_agent_boots_craftsmans_cooldown_test");
@@ -700,12 +701,80 @@ final class EquipmentSpellBehaviorBridgeGameTestScenarios extends ApprenticeCode
                     player,
                     CastSource.SPELLBOOK
             );
-            var bootsOnlyCooldown = Math.max(1, spell.getSpellCooldown() / 2);
-            helper.assertTrue(expectedCooldown < bootsOnlyCooldown,
-                    "CraftsmansDelight should remain the stronger Thermal Process cooldown reduction");
+            var singleReductionCooldown = Math.max(1, (int) (spell.getSpellCooldown() * 0.5D));
+            helper.assertTrue(expectedCooldown == singleReductionCooldown,
+                    "Equal equipment cooldown multipliers should apply once instead of stacking");
             helper.assertTrue(cooldownEvent.getEffectiveCooldown() == expectedCooldown,
                     "Magi Agent Suit Boots and CraftsmansDelight should keep the strongest cooldown but got "
                             + cooldownEvent.getEffectiveCooldown() + " / expected " + expectedCooldown);
+        });
+    }
+
+    static void equipmentSpellTimingMultipliersFollowServerConfigAndKeepOneTickMinimum(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0),
+                    "equipment_spell_timing_multiplier_config_test");
+            equipRingCurio(player, new ItemStack(ItemRegistry.CRAFTSMANS_DELIGHT.get()));
+            player.setItemSlot(EquipmentSlot.FEET, new ItemStack(ItemRegistry.MAGI_AGENT_SUIT_BOOTS.get()));
+            var craftsmansSpell = SpellRegistry.HARVEST_MOON.get();
+            var magiAgentSpell = SpellRegistry.COMMENCE_FIRE.get();
+
+            var effectiveCastTime = 101;
+
+            try (var ignored = ApprenticeCodexServerConfig.useEquipmentSpellTimingMultipliersOverrideForGameTest(
+                    0.25D,
+                    0.75D,
+                    0.25D
+            )) {
+                helper.assertTrue(
+                        CraftsmansDelight.applyCooldownDiscount(craftsmansSpell.getSpellCooldown(), player)
+                                == Math.max(1, (int) (craftsmansSpell.getSpellCooldown() * 0.25D)),
+                        "CraftsmansDelight should follow its server cooldown multiplier"
+                );
+                helper.assertTrue(
+                        MagiAgentSuitEffects.applyBootsCooldownDiscount(
+                                magiAgentSpell.getSpellCooldown(),
+                                magiAgentSpell,
+                                player
+                        ) == Math.max(1, (int) (magiAgentSpell.getSpellCooldown() * 0.75D)),
+                        "Magi Agent Suit Boots should follow their server cooldown multiplier"
+                );
+                helper.assertTrue(
+                        MagiAgentSuitEffects.applyBootsCastTimeReduction(
+                                magiAgentSpell,
+                                effectiveCastTime,
+                                player
+                        ) == Math.max(1, (int) Math.round(effectiveCastTime * 0.25D)),
+                        "Magi Agent Suit Boots should follow their server cast time multiplier"
+                );
+            }
+
+            try (var ignored = ApprenticeCodexServerConfig.useEquipmentSpellTimingMultipliersOverrideForGameTest(
+                    0.0D,
+                    0.0D,
+                    0.0D
+            )) {
+                helper.assertTrue(
+                        CraftsmansDelight.applyCooldownDiscount(craftsmansSpell.getSpellCooldown(), player) == 1,
+                        "CraftsmansDelight should keep a 1 tick minimum at multiplier 0.0"
+                );
+                helper.assertTrue(
+                        MagiAgentSuitEffects.applyBootsCooldownDiscount(
+                                magiAgentSpell.getSpellCooldown(),
+                                magiAgentSpell,
+                                player
+                        ) == 1,
+                        "Magi Agent Suit Boots should keep a 1 tick minimum at multiplier 0.0"
+                );
+                helper.assertTrue(
+                        MagiAgentSuitEffects.applyBootsCastTimeReduction(
+                                magiAgentSpell,
+                                effectiveCastTime,
+                                player
+                        ) == 1,
+                        "Magi Agent Suit Boots should keep a 1 tick cast time minimum at multiplier 0.0"
+                );
+            }
         });
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/EquipmentSpellTimingConfigState.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/EquipmentSpellTimingConfigState.java
@@ -1,0 +1,51 @@
+package jp.aquafactory.apprenticecodex.item;
+
+import net.minecraft.util.Mth;
+
+public final class EquipmentSpellTimingConfigState {
+    public static final double DEFAULT_CRAFTSMANS_DELIGHT_COOLDOWN_MULTIPLIER = 0.5D;
+    public static final double DEFAULT_MAGI_AGENT_SUIT_BOOTS_COOLDOWN_MULTIPLIER = 0.5D;
+    public static final double DEFAULT_MAGI_AGENT_SUIT_BOOTS_CAST_TIME_MULTIPLIER = 0.5D;
+
+    private static double craftsmansDelightCooldownMultiplier =
+            DEFAULT_CRAFTSMANS_DELIGHT_COOLDOWN_MULTIPLIER;
+    private static double magiAgentSuitBootsCooldownMultiplier =
+            DEFAULT_MAGI_AGENT_SUIT_BOOTS_COOLDOWN_MULTIPLIER;
+    private static double magiAgentSuitBootsCastTimeMultiplier =
+            DEFAULT_MAGI_AGENT_SUIT_BOOTS_CAST_TIME_MULTIPLIER;
+
+    private EquipmentSpellTimingConfigState() {
+    }
+
+    public static double craftsmansDelightCooldownMultiplier() {
+        return craftsmansDelightCooldownMultiplier;
+    }
+
+    public static double magiAgentSuitBootsCooldownMultiplier() {
+        return magiAgentSuitBootsCooldownMultiplier;
+    }
+
+    public static double magiAgentSuitBootsCastTimeMultiplier() {
+        return magiAgentSuitBootsCastTimeMultiplier;
+    }
+
+    public static void set(
+            double craftsmansDelightMultiplier,
+            double magiAgentSuitBootsCooldownMultiplier,
+            double magiAgentSuitBootsCastTimeMultiplier
+    ) {
+        craftsmansDelightCooldownMultiplier = Mth.clamp(craftsmansDelightMultiplier, 0.0D, 1.0D);
+        EquipmentSpellTimingConfigState.magiAgentSuitBootsCooldownMultiplier =
+                Mth.clamp(magiAgentSuitBootsCooldownMultiplier, 0.0D, 1.0D);
+        EquipmentSpellTimingConfigState.magiAgentSuitBootsCastTimeMultiplier =
+                Mth.clamp(magiAgentSuitBootsCastTimeMultiplier, 0.0D, 1.0D);
+    }
+
+    public static void reset() {
+        set(
+                DEFAULT_CRAFTSMANS_DELIGHT_COOLDOWN_MULTIPLIER,
+                DEFAULT_MAGI_AGENT_SUIT_BOOTS_COOLDOWN_MULTIPLIER,
+                DEFAULT_MAGI_AGENT_SUIT_BOOTS_CAST_TIME_MULTIPLIER
+        );
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/WeaponImbueCooldownHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/WeaponImbueCooldownHelper.java
@@ -71,4 +71,12 @@ public final class WeaponImbueCooldownHelper {
         }
         return selectedCooldown;
     }
+
+    public static int applyLimitedCooldownMultiplier(int baseCooldown, double multiplier) {
+        if (baseCooldown <= 0) {
+            return baseCooldown;
+        }
+
+        return Math.max(1, (int) (baseCooldown * multiplier));
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/armor/MagiAgentSuitEffects.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/armor/MagiAgentSuitEffects.java
@@ -5,6 +5,8 @@ import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastType;
 import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.EquipmentSpellTimingConfigState;
+import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
 import jp.aquafactory.apprenticecodex.spell.IMagiAgentSuitAffectedSpell;
 import jp.aquafactory.apprenticecodex.spell.divinepossession.DivinePossessionPowerHelper;
@@ -88,7 +90,14 @@ public final class MagiAgentSuitEffects {
         if (baseCooldown <= 0 || !isTargetSpell(spell) || !isWearingSuitPiece(player, ArmorItem.Type.BOOTS)) {
             return baseCooldown;
         }
-        return Math.max(1, baseCooldown / 2);
+        // 実行中の SERVER config リロード後も予測結果を一致させるため、クライアントでは同期値を使う。
+        var cooldownMultiplier = player.level().isClientSide
+                ? EquipmentSpellTimingConfigState.magiAgentSuitBootsCooldownMultiplier()
+                : ApprenticeCodexServerConfig.magiAgentSuitBootsCooldownMultiplier();
+        return WeaponImbueCooldownHelper.applyLimitedCooldownMultiplier(
+                baseCooldown,
+                cooldownMultiplier
+        );
     }
 
     public static int applyBootsCastTimeReduction(AbstractSpell spell, int effectiveCastTime, @Nullable LivingEntity entity) {
@@ -96,7 +105,12 @@ public final class MagiAgentSuitEffects {
                 || !isTargetSpell(spell) || !isWearingSuitPiece(entity, ArmorItem.Type.BOOTS)) {
             return effectiveCastTime;
         }
-        return Math.max(1, Math.round(effectiveCastTime * 0.5F));
+        var castTimeMultiplier = entity.level().isClientSide
+                ? EquipmentSpellTimingConfigState.magiAgentSuitBootsCastTimeMultiplier()
+                : ApprenticeCodexServerConfig.magiAgentSuitBootsCastTimeMultiplier();
+        return Math.max(1, (int) Math.round(
+                effectiveCastTime * castTimeMultiplier
+        ));
     }
 
     public static int applyBootsCommenceFireRecastCastTime(AbstractSpell spell, int effectiveCastTime, LivingEntity entity) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/craftsmansdelight/CraftsmansDelight.java
@@ -7,6 +7,7 @@ import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.compat.Curios;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.EquipmentSpellTimingConfigState;
 import jp.aquafactory.apprenticecodex.item.ImbueTooltipHelper;
 import jp.aquafactory.apprenticecodex.item.WeaponImbueCooldownHelper;
 import jp.aquafactory.apprenticecodex.registry.EffectRegistry;
@@ -48,7 +49,6 @@ public class CraftsmansDelight extends Item implements ICurioItem, IJeiInfoItem 
     private static final float BREAK_SPEED_BONUS_MULTIPLIER = 2.0f;
     private static final float PROCESS_SPEED_BONUS_MULTIPLIER = 1.5f;
     private static final float MANA_COST_DISCOUNT_MULTIPLIER = 0.5f;
-    private static final int COOLDOWN_DIVISOR = 3;
     private static final int TOUCH_DIG_RANGE_BLOCKS = 8;
     private static final int TOUCH_DIG_RANGE_WITH_BONUS_BLOCKS = 16;
     private static final int CASTING_MOBILITY_EFFECT_REFRESH_TICKS = 5;
@@ -230,7 +230,14 @@ public class CraftsmansDelight extends Item implements ICurioItem, IJeiInfoItem 
             return baseCooldown;
         }
 
-        return Math.max(1, baseCooldown / COOLDOWN_DIVISOR);
+        // 実行中の SERVER config リロード後も予測結果を一致させるため、クライアントでは同期値を使う。
+        var cooldownMultiplier = entity.level().isClientSide
+                ? EquipmentSpellTimingConfigState.craftsmansDelightCooldownMultiplier()
+                : ApprenticeCodexServerConfig.craftsmansDelightCooldownMultiplier();
+        return WeaponImbueCooldownHelper.applyLimitedCooldownMultiplier(
+                baseCooldown,
+                cooldownMultiplier
+        );
     }
 
     public static int getTouchDigRangeBlocks(@Nullable LivingEntity entity) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -20,6 +20,7 @@ import jp.aquafactory.apprenticecodex.network.packet.HealingBloomPulsePacket;
 import jp.aquafactory.apprenticecodex.network.packet.ManaSiphonOrbEffectPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SenseEvilHighlightsPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncElementalBowOverheatPacket;
+import jp.aquafactory.apprenticecodex.network.packet.SyncEquipmentSpellTimingConfigPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncAutocastAmuletNotificationPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncAutocastAmuletProfileSpellIdsPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncApprenticeDeskConfigPacket;
@@ -63,7 +64,7 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "61";
+    private static final String PROTOCOL_VERSION = "62";
 
     private Networks() {
     }
@@ -193,6 +194,11 @@ public final class Networks {
                 SyncZenithStaffConfigPacket.TYPE,
                 SyncZenithStaffConfigPacket.STREAM_CODEC,
                 SyncZenithStaffConfigPacket::handle
+        );
+        registrar.playToClient(
+                SyncEquipmentSpellTimingConfigPacket.TYPE,
+                SyncEquipmentSpellTimingConfigPacket.STREAM_CODEC,
+                SyncEquipmentSpellTimingConfigPacket::handle
         );
         registrar.playToClient(
                 SyncScarletThirstHealthPacket.TYPE,

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncEquipmentSpellTimingConfigPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncEquipmentSpellTimingConfigPacket.java
@@ -1,0 +1,78 @@
+package jp.aquafactory.apprenticecodex.network.packet;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.EquipmentSpellTimingConfigState;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+public final class SyncEquipmentSpellTimingConfigPacket implements CustomPacketPayload {
+    public static final Type<SyncEquipmentSpellTimingConfigPacket> TYPE =
+            new Type<>(ResourceLocation.fromNamespaceAndPath(
+                    ApprenticeCodex.MODID,
+                    "sync_equipment_spell_timing_config"
+            ));
+    public static final StreamCodec<RegistryFriendlyByteBuf, SyncEquipmentSpellTimingConfigPacket> STREAM_CODEC =
+            StreamCodec.of((buffer, packet) -> encode(packet, buffer), SyncEquipmentSpellTimingConfigPacket::decode);
+
+    private final double craftsmansDelightCooldownMultiplier;
+    private final double magiAgentSuitBootsCooldownMultiplier;
+    private final double magiAgentSuitBootsCastTimeMultiplier;
+
+    public SyncEquipmentSpellTimingConfigPacket(
+            double craftsmansDelightCooldownMultiplier,
+            double magiAgentSuitBootsCooldownMultiplier,
+            double magiAgentSuitBootsCastTimeMultiplier
+    ) {
+        this.craftsmansDelightCooldownMultiplier = craftsmansDelightCooldownMultiplier;
+        this.magiAgentSuitBootsCooldownMultiplier = magiAgentSuitBootsCooldownMultiplier;
+        this.magiAgentSuitBootsCastTimeMultiplier = magiAgentSuitBootsCastTimeMultiplier;
+    }
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    private static void encode(SyncEquipmentSpellTimingConfigPacket packet, FriendlyByteBuf buffer) {
+        buffer.writeDouble(packet.craftsmansDelightCooldownMultiplier);
+        buffer.writeDouble(packet.magiAgentSuitBootsCooldownMultiplier);
+        buffer.writeDouble(packet.magiAgentSuitBootsCastTimeMultiplier);
+    }
+
+    private static SyncEquipmentSpellTimingConfigPacket decode(FriendlyByteBuf buffer) {
+        return new SyncEquipmentSpellTimingConfigPacket(
+                buffer.readDouble(),
+                buffer.readDouble(),
+                buffer.readDouble()
+        );
+    }
+
+    public static void handle(SyncEquipmentSpellTimingConfigPacket packet, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            if (FMLEnvironment.dist == Dist.CLIENT) {
+                ClientHandler.handle(packet);
+            }
+        });
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private static final class ClientHandler {
+        private ClientHandler() {
+        }
+
+        private static void handle(SyncEquipmentSpellTimingConfigPacket packet) {
+            EquipmentSpellTimingConfigState.set(
+                    packet.craftsmansDelightCooldownMultiplier,
+                    packet.magiAgentSuitBootsCooldownMultiplier,
+                    packet.magiAgentSuitBootsCastTimeMultiplier
+            );
+        }
+    }
+}


### PR DESCRIPTION
- PR #740 の forward-port 対応
- 装備由来のクールダウン・詠唱時間倍率をサーバー設定化し、NeoForge 1.21.1 の payload API でクライアントへ同期
- 職人の歓喜の対象魔法クールダウン倍率を既定 0.5 に変更
- `runGameTestServer`: 成功、861/861 テスト通過
- `build`: 成功（`checkTextEncodingHygiene` を含む）