### PR TITLE
PR #752を1.21.1へforward-port

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/ApprenticeCodex.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/ApprenticeCodex.java
@@ -19,6 +19,7 @@ import jp.aquafactory.apprenticecodex.event.ModEntityAttributeEvent;
 import jp.aquafactory.apprenticecodex.event.ZenithStaffConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.event.client.ClientModBusEvents;
 import jp.aquafactory.apprenticecodex.item.armor.ElementMaidenRobeSchoolPowerBonusEvents;
+import jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBowConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbowConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.item.chargecastcatalystbook.ChargecastCatalystbookConfigSyncEvents;
 import jp.aquafactory.apprenticecodex.network.Networks;
@@ -87,6 +88,7 @@ public class ApprenticeCodex
         CircuitHeatStaffConfigSyncEvents.register(modEventBus);
         EquipmentSpellTimingConfigSyncEvents.register(modEventBus);
         ChargecastCatalystbookConfigSyncEvents.register(modEventBus);
+        ElementalBowConfigSyncEvents.register(modEventBus);
         FocusStaffbowConfigSyncEvents.register(modEventBus);
         IsekaiTravelGuidebookConfigSyncEvents.register(modEventBus);
         ManaForceBladeConfigSyncEvents.register(modEventBus);

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ApprenticeCodexServerConfig.java
@@ -797,6 +797,10 @@ public final class ApprenticeCodexServerConfig {
         return ITEMS_CONFIG.elementalBowMagicReadyDrawTicksMultiplier();
     }
 
+    public static List<ResourceLocation> elementalBowMagicArrowCatalystItemIds() {
+        return ITEMS_CONFIG.elementalBowMagicArrowCatalystItemIds();
+    }
+
     public static float elementalBowOverheatAdditionalManaLinearMultiplier() {
         return ITEMS_CONFIG.elementalBowOverheatAdditionalManaLinearMultiplier();
     }
@@ -925,6 +929,14 @@ public final class ApprenticeCodexServerConfig {
                 previousOverheatDurationCapTicks,
                 previousPowerArrowSpellLevelBonusPerLevel
         );
+    }
+
+    public static GameTestConfigOverride useElementalBowMagicArrowCatalystItemsOverrideForGameTest(
+            List<String> magicArrowCatalystItems
+    ) {
+        var previousMagicArrowCatalystItems = ITEMS_CONFIG.elementalBowMagicArrowCatalystItems();
+        ITEMS_CONFIG.setElementalBowMagicArrowCatalystItemsForGameTest(magicArrowCatalystItems);
+        return () -> ITEMS_CONFIG.setElementalBowMagicArrowCatalystItemsForGameTest(previousMagicArrowCatalystItems);
     }
 
     public static GameTestConfigOverride useMultipurposeStaffrifleSpellDenylistOverrideForGameTest(

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/ItemsServerConfig.java
@@ -666,6 +666,14 @@ final class ItemsServerConfig {
         return elementalBowConfig.magicReadyDrawTicksMultiplier();
     }
 
+    List<ResourceLocation> elementalBowMagicArrowCatalystItemIds() {
+        return elementalBowConfig.magicArrowCatalystItemIds();
+    }
+
+    List<String> elementalBowMagicArrowCatalystItems() {
+        return elementalBowConfig.magicArrowCatalystItems();
+    }
+
     float elementalBowOverheatAdditionalManaLinearMultiplier() {
         return elementalBowConfig.overheatAdditionalManaLinearMultiplier();
     }
@@ -898,6 +906,10 @@ final class ItemsServerConfig {
                 overheatDurationCapTicks,
                 powerArrowSpellLevelBonusPerLevel
         );
+    }
+
+    void setElementalBowMagicArrowCatalystItemsForGameTest(List<String> magicArrowCatalystItems) {
+        elementalBowConfig.setMagicArrowCatalystItemsForGameTest(magicArrowCatalystItems);
     }
 
     void setCircuitHeatStaffConfigForGameTest(

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/ElementalBowServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/ElementalBowServerConfig.java
@@ -1,8 +1,13 @@
 package jp.aquafactory.apprenticecodex.config.item;
 
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
+import java.util.List;
+import java.util.Objects;
+
 public final class ElementalBowServerConfig {
+    private final ModConfigSpec.ConfigValue<List<? extends String>> magicArrowCatalystItems;
     private final ModConfigSpec.DoubleValue magicReadyDrawTicksMultiplier;
     private final ModConfigSpec.DoubleValue overheatAdditionalManaLinearMultiplier;
     private final ModConfigSpec.DoubleValue overheatAdditionalManaQuadraticMultiplier;
@@ -11,6 +16,7 @@ public final class ElementalBowServerConfig {
     private final ModConfigSpec.IntValue overheatDurationCapTicks;
     private final ModConfigSpec.DoubleValue powerArrowSpellLevelBonusPerLevel;
 
+    private List<String> magicArrowCatalystItemsOverride;
     private Double magicReadyDrawTicksMultiplierOverride;
     private Double overheatAdditionalManaLinearMultiplierOverride;
     private Double overheatAdditionalManaQuadraticMultiplierOverride;
@@ -20,6 +26,7 @@ public final class ElementalBowServerConfig {
     private Double powerArrowSpellLevelBonusPerLevelOverride;
 
     private ElementalBowServerConfig(
+            ModConfigSpec.ConfigValue<List<? extends String>> magicArrowCatalystItems,
             ModConfigSpec.DoubleValue magicReadyDrawTicksMultiplier,
             ModConfigSpec.DoubleValue overheatAdditionalManaLinearMultiplier,
             ModConfigSpec.DoubleValue overheatAdditionalManaQuadraticMultiplier,
@@ -28,6 +35,7 @@ public final class ElementalBowServerConfig {
             ModConfigSpec.IntValue overheatDurationCapTicks,
             ModConfigSpec.DoubleValue powerArrowSpellLevelBonusPerLevel
     ) {
+        this.magicArrowCatalystItems = magicArrowCatalystItems;
         this.magicReadyDrawTicksMultiplier = magicReadyDrawTicksMultiplier;
         this.overheatAdditionalManaLinearMultiplier = overheatAdditionalManaLinearMultiplier;
         this.overheatAdditionalManaQuadraticMultiplier = overheatAdditionalManaQuadraticMultiplier;
@@ -39,6 +47,9 @@ public final class ElementalBowServerConfig {
 
     public static ElementalBowServerConfig define(ModConfigSpec.Builder builder) {
         builder.push("ElementalBow");
+        var magicArrowCatalystItems = builder
+                .comment("Item IDs accepted as Elemental Bow magic mode arrow catalysts. Empty list makes non-Synthesis survival casts unusable.")
+                .defineListAllowEmpty("magicArrowCatalystItems", List.of("minecraft:arrow"), ElementalBowServerConfig::isItemId);
         var magicReadyDrawTicksMultiplier = builder
                 .comment("Multiplier applied to Elemental Bow magic mode required draw ticks from its mode profile.")
                 .defineInRange("magicReadyDrawTicksMultiplier", 1.0D, 0.0D, 100.0D);
@@ -63,6 +74,7 @@ public final class ElementalBowServerConfig {
         builder.pop();
 
         return new ElementalBowServerConfig(
+                magicArrowCatalystItems,
                 magicReadyDrawTicksMultiplier,
                 overheatAdditionalManaLinearMultiplier,
                 overheatAdditionalManaQuadraticMultiplier,
@@ -71,6 +83,19 @@ public final class ElementalBowServerConfig {
                 overheatDurationCapTicks,
                 powerArrowSpellLevelBonusPerLevel
         );
+    }
+
+    public List<String> magicArrowCatalystItems() {
+        return Objects.requireNonNullElseGet(magicArrowCatalystItemsOverride, () -> magicArrowCatalystItems.get().stream()
+                .map(String::valueOf)
+                .toList());
+    }
+
+    public List<ResourceLocation> magicArrowCatalystItemIds() {
+        return magicArrowCatalystItems().stream()
+                .map(ResourceLocation::tryParse)
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     public double magicReadyDrawTicksMultiplier() {
@@ -127,5 +152,13 @@ public final class ElementalBowServerConfig {
         this.overheatDurationMinTicksOverride = overheatDurationMinTicks;
         this.overheatDurationCapTicksOverride = overheatDurationCapTicks;
         this.powerArrowSpellLevelBonusPerLevelOverride = powerArrowSpellLevelBonusPerLevel;
+    }
+
+    public void setMagicArrowCatalystItemsForGameTest(List<String> magicArrowCatalystItems) {
+        this.magicArrowCatalystItemsOverride = List.copyOf(magicArrowCatalystItems);
+    }
+
+    private static boolean isItemId(Object value) {
+        return value instanceof String text && text.contains(":") && ResourceLocation.tryParse(text) != null;
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -1417,6 +1417,16 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
         SpellcasterQuiverGameTestScenarios.focusStaffbowConsumesSpellcasterQuiverArrowsBeforeInventory(helper);
     }
 
+    @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)
+    public static void bowAmmoNotificationCountsExactArrowsAcrossInventoryAndQuiver(GameTestHelper helper) {
+        SpellcasterQuiverGameTestScenarios.bowAmmoNotificationCountsExactArrowsAcrossInventoryAndQuiver(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)
+    public static void focusStaffbowAmmoConsumptionResultDistinguishesConsumptionFromBypass(GameTestHelper helper) {
+        SpellcasterQuiverGameTestScenarios.focusStaffbowAmmoConsumptionResultDistinguishesConsumptionFromBypass(helper);
+    }
+
     @GameTest(template = TEMPLATE)
     public static void focusStaffbowExposesExpectedMainhandAttributes(GameTestHelper helper) {
         FocusStaffbowGameTestScenarios.focusStaffbowExposesExpectedMainhandAttributes(helper);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -1148,6 +1148,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void elementalBowMagicArrowCatalystItemsAllowsConfiguredSpecialArrow(GameTestHelper helper) {
+        ElementalBowGameTestScenarios.elementalBowMagicArrowCatalystItemsAllowsConfiguredSpecialArrow(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void elementalBowSynthesisDoesNotConsumeMagicModeArrows(GameTestHelper helper) {
         ElementalBowGameTestScenarios.elementalBowSynthesisDoesNotConsumeMagicModeArrows(helper);
     }
@@ -1165,6 +1170,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)
     public static void elementalBowConsumesSpellcasterQuiverArrowsBeforeInventory(GameTestHelper helper) {
         SpellcasterQuiverGameTestScenarios.elementalBowConsumesSpellcasterQuiverArrowsBeforeInventory(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)
+    public static void elementalBowMagicModeUsesConfiguredSpellcasterQuiverCatalyst(GameTestHelper helper) {
+        SpellcasterQuiverGameTestScenarios.elementalBowMagicModeUsesConfiguredSpellcasterQuiverCatalyst(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ElementalBowGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ElementalBowGameTestScenarios.java
@@ -1004,6 +1004,42 @@ final class ElementalBowGameTestScenarios {
                     "Elemental Bow Synthesis magic shot should still consume spell mana");
         });
     }
+
+    static void elementalBowMagicArrowCatalystItemsAllowsConfiguredSpecialArrow(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            try (var ignored = ApprenticeCodexServerConfig.useElementalBowMagicArrowCatalystItemsOverrideForGameTest(
+                    List.of("minecraft:spectral_arrow")
+            )) {
+                var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "elemental_bow_magic_configured_arrow_test");
+                var stack = new ItemStack(ItemRegistry.ELEMENTAL_BOW.get());
+                setElementalBowShotSelection(stack, "magic", SchoolRegistry.FIRE_RESOURCE);
+                player.setItemInHand(InteractionHand.MAIN_HAND, stack);
+                player.getInventory().setItem(1, new ItemStack(Items.SPECTRAL_ARROW, 2));
+                player.getInventory().setItem(2, new ItemStack(Items.ARROW, 3));
+
+                var magicData = MagicData.getPlayerMagicData(player);
+                helper.assertTrue(magicData != null, "Elemental Bow configured catalyst test could not resolve player mana data");
+                magicData.setMana(250.0F);
+
+                var result = stack.getItem().use(helper.getLevel(), player, InteractionHand.MAIN_HAND);
+                helper.assertTrue(result.getResult().consumesAction(),
+                        "Elemental Bow magic mode should accept a configured special arrow catalyst: " + result.getResult());
+                stack.getItem().releaseUsing(
+                        stack,
+                        helper.getLevel(),
+                        player,
+                        stack.getUseDuration(player) - ElementalBow.READY_DRAW_TICKS
+                );
+                player.stopUsingItem();
+
+                helper.assertTrue(player.getInventory().getItem(1).getCount() == 1,
+                        "Elemental Bow magic mode should consume the configured spectral arrow catalyst");
+                helper.assertTrue(player.getInventory().getItem(2).getCount() == 3,
+                        "Elemental Bow magic mode should leave unconfigured normal arrows untouched");
+            }
+        });
+    }
+
     static void elementalBowSynthesisDoesNotConsumeMagicModeArrows(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var synthesis = helper.getLevel().registryAccess().lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.SYNTHESIS);

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellcasterQuiverGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellcasterQuiverGameTestScenarios.java
@@ -419,6 +419,53 @@ final class SpellcasterQuiverGameTestScenarios {
                     "Elemental Bow should leave loose inventory arrows untouched while the quiver has arrows");
         });
     }
+
+    static void elementalBowMagicModeUsesConfiguredSpellcasterQuiverCatalyst(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            try (var ignored = ApprenticeCodexServerConfig.useElementalBowMagicArrowCatalystItemsOverrideForGameTest(
+                    List.of("minecraft:arrow")
+            )) {
+                var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "elemental_bow_magic_quiver_catalyst_test");
+                var bowStack = new ItemStack(ItemRegistry.ELEMENTAL_BOW.get());
+                setElementalBowShotSelection(bowStack, "magic", SchoolRegistry.FIRE_RESOURCE);
+                player.setItemInHand(InteractionHand.MAIN_HAND, bowStack);
+
+                var quiverStack = new ItemStack(ItemRegistry.SPELLCASTER_QUIVER.get());
+                SpellcasterQuiver.store(quiverStack, new ItemStack(Items.ARROW, 3));
+                SpellcasterQuiver.store(quiverStack, new ItemStack(Items.SPECTRAL_ARROW, 1));
+                equipCurio(player, CuriosSlotConstants.BACK, quiverStack);
+
+                var magicData = MagicData.getPlayerMagicData(player);
+                helper.assertTrue(magicData != null, "Elemental Bow quiver catalyst test could not resolve player mana data");
+                magicData.setMana(250.0F);
+
+                var result = bowStack.getItem().use(helper.getLevel(), player, InteractionHand.MAIN_HAND);
+                helper.assertTrue(result.getResult().consumesAction(),
+                        "Elemental Bow magic mode should accept the configured quiver catalyst: " + result.getResult());
+                bowStack.getItem().releaseUsing(
+                        bowStack,
+                        helper.getLevel(),
+                        player,
+                        bowStack.getUseDuration(player)
+                                - jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBow.READY_DRAW_TICKS
+                );
+                player.stopUsingItem();
+
+                var normalView = findElementalBowSelectionView(player, bowStack, "arrow", null);
+                helper.assertTrue(normalView != null && "2".equals(normalView.badgeText()),
+                        "Elemental Bow magic mode should consume one configured normal arrow from Spellcaster Quiver");
+                var spectralView = findElementalBowSelectionView(
+                        player,
+                        bowStack,
+                        "special",
+                        ResourceLocation.fromNamespaceAndPath("minecraft", "spectral_arrow")
+                );
+                helper.assertTrue(spectralView != null && "1".equals(spectralView.badgeText()),
+                        "Elemental Bow magic mode should leave the unconfigured spectral arrow in Spellcaster Quiver");
+            }
+        });
+    }
+
     static void elementalBowSelectionViewsIncludeSpellcasterQuiverArrows(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "elemental_bow_quiver_selection_test");

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellcasterQuiverGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellcasterQuiverGameTestScenarios.java
@@ -117,6 +117,7 @@ import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDe
 import jp.aquafactory.apprenticecodex.item.curios.craftsmansdelight.CraftsmansDelightSpellSupport;
 import jp.aquafactory.apprenticecodex.item.curios.manashieldcharm.ManaShieldCharm;
 import jp.aquafactory.apprenticecodex.item.curios.spellstainedrunictablet.SpellStainedRunicTablet;
+import jp.aquafactory.apprenticecodex.item.ammo.BowAmmoConsumptionNotification;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiver;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiverPickupEvent;
 import jp.aquafactory.apprenticecodex.item.flask.AlchemistsFlask;
@@ -640,6 +641,78 @@ final class SpellcasterQuiverGameTestScenarios {
                     "Focus Staffbow should consume the equipped Spellcaster Quiver arrow before loose inventory arrows");
             helper.assertTrue(player.getInventory().getItem(1).getCount() == 3,
                     "Focus Staffbow should leave loose inventory arrows untouched while the quiver still has arrows");
+        });
+    }
+
+    static void bowAmmoNotificationCountsExactArrowsAcrossInventoryAndQuiver(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "bow_ammo_notification_count_test");
+            var healingArrow = PotionContentsHelper.createPotionStack(Items.TIPPED_ARROW, Potions.HEALING.value());
+            healingArrow.setCount(4);
+            var poisonArrow = PotionContentsHelper.createPotionStack(Items.TIPPED_ARROW, Potions.POISON.value());
+            poisonArrow.setCount(3);
+            player.getInventory().setItem(1, healingArrow.copy());
+            player.setItemInHand(InteractionHand.OFF_HAND, poisonArrow.copy());
+
+            var quiverStack = new ItemStack(ItemRegistry.SPELLCASTER_QUIVER.get());
+            SpellcasterQuiver.store(
+                    quiverStack,
+                    PotionContentsHelper.createPotionStack(Items.TIPPED_ARROW, Potions.HEALING.value()).copyWithCount(2)
+            );
+            SpellcasterQuiver.store(
+                    quiverStack,
+                    PotionContentsHelper.createPotionStack(Items.TIPPED_ARROW, Potions.POISON.value()).copyWithCount(5)
+            );
+            equipCurio(player, CuriosSlotConstants.BACK, quiverStack);
+
+            var packet = BowAmmoConsumptionNotification.createPacket(
+                    player,
+                    ItemRegistry.ELEMENTAL_BOW.getId(),
+                    healingArrow
+            );
+            helper.assertTrue(packet.sourceId().equals(ItemRegistry.ELEMENTAL_BOW.getId().toString()),
+                    "Bow ammo notification should preserve the source weapon id");
+            helper.assertTrue(ItemStack.isSameItemSameComponents(packet.iconStack(), healingArrow)
+                            && packet.iconStack().getCount() == 1,
+                    "Bow ammo notification should preserve the consumed tipped arrow as a single icon");
+            helper.assertTrue(packet.remainingCount() == 6L,
+                    "Bow ammo notification should total matching inventory and quiver arrows while excluding different potion NBT");
+        });
+    }
+
+    static void focusStaffbowAmmoConsumptionResultDistinguishesConsumptionFromBypass(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "focus_staffbow_ammo_result_test");
+            player.getInventory().setItem(1, new ItemStack(Items.ARROW, 3));
+
+            var quiverStack = new ItemStack(ItemRegistry.SPELLCASTER_QUIVER.get());
+            SpellcasterQuiver.store(quiverStack, new ItemStack(Items.ARROW, 2));
+            equipCurio(player, CuriosSlotConstants.BACK, quiverStack);
+
+            var consumed = BowCastAmmoResolver.consumeFocusStaffbowAmmoWithResult(
+                    player,
+                    BowCastAmmoResolver.FocusStaffbowAmmoRoute.ARROW_CATALYST
+            );
+            helper.assertTrue(consumed.successful() && consumed.consumedArrow()
+                            && consumed.consumedStack().is(Items.ARROW)
+                            && consumed.consumedStack().getCount() == 1,
+                    "Focus Staffbow ammo result should preserve the arrow that was actually consumed");
+            helper.assertTrue(BowAmmoConsumptionNotification.countRemaining(player, consumed.consumedStack()) == 4L,
+                    "Focus Staffbow notification count should include the remaining quiver and inventory arrows");
+
+            var bypassed = BowCastAmmoResolver.consumeFocusStaffbowAmmoWithResult(
+                    player,
+                    BowCastAmmoResolver.FocusStaffbowAmmoRoute.BYPASS
+            );
+            helper.assertTrue(bypassed.successful() && !bypassed.consumedArrow(),
+                    "Focus Staffbow creative, Synthesis, and disabled-requirement bypasses should not report arrow consumption");
+
+            var rejected = BowCastAmmoResolver.consumeFocusStaffbowAmmoWithResult(
+                    player,
+                    BowCastAmmoResolver.FocusStaffbowAmmoRoute.NONE
+            );
+            helper.assertTrue(!rejected.successful() && !rejected.consumedArrow(),
+                    "Focus Staffbow missing-ammo results should fail without reporting arrow consumption");
         });
     }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ammo/BowAmmoConsumptionNotification.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ammo/BowAmmoConsumptionNotification.java
@@ -1,0 +1,71 @@
+package jp.aquafactory.apprenticecodex.item.ammo;
+
+import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiver;
+import jp.aquafactory.apprenticecodex.network.Networks;
+import jp.aquafactory.apprenticecodex.network.packet.SyncRemainingCountNotificationPacket;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+public final class BowAmmoConsumptionNotification {
+    private BowAmmoConsumptionNotification() {
+    }
+
+    public static void send(ServerPlayer player, ResourceLocation sourceId, ItemStack consumedStack) {
+        if (player.connection == null || consumedStack.isEmpty()) {
+            return;
+        }
+
+        Networks.sendToPlayer(player, createPacket(player, sourceId, consumedStack));
+    }
+
+    public static SyncRemainingCountNotificationPacket createPacket(
+            Player player,
+            ResourceLocation sourceId,
+            ItemStack consumedStack
+    ) {
+        var iconStack = consumedStack.copyWithCount(1);
+        return new SyncRemainingCountNotificationPacket(
+                sourceId.toString(),
+                iconStack,
+                countRemaining(player, iconStack),
+                SyncRemainingCountNotificationPacket.DisplayType.ITEM_REMAINING
+        );
+    }
+
+    public static long countRemaining(Player player, ItemStack consumedStack) {
+        if (consumedStack.isEmpty()) {
+            return 0L;
+        }
+
+        long total = 0L;
+        for (var stack : player.getInventory().items) {
+            total = addMatchingCount(total, stack, consumedStack);
+        }
+        for (var stack : player.getInventory().offhand) {
+            total = addMatchingCount(total, stack, consumedStack);
+        }
+
+        var quiverTotal = new long[1];
+        SpellcasterQuiver.forEachAccessibleArrow(player, (stack, count) -> {
+            if (ItemStack.isSameItemSameComponents(stack, consumedStack)) {
+                quiverTotal[0] = addSaturated(quiverTotal[0], count);
+            }
+        });
+        return addSaturated(total, quiverTotal[0]);
+    }
+
+    private static long addMatchingCount(long total, ItemStack stack, ItemStack consumedStack) {
+        return ItemStack.isSameItemSameComponents(stack, consumedStack)
+                ? addSaturated(total, stack.getCount())
+                : total;
+    }
+
+    private static long addSaturated(long left, long right) {
+        if (right <= 0L) {
+            return left;
+        }
+        return Long.MAX_VALUE - left < right ? Long.MAX_VALUE : left + right;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ammo/BowCastAmmoResolver.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ammo/BowCastAmmoResolver.java
@@ -27,6 +27,16 @@ public final class BowCastAmmoResolver {
         ARROW_CATALYST
     }
 
+    public record FocusStaffbowAmmoConsumption(boolean successful, ItemStack consumedStack) {
+        public FocusStaffbowAmmoConsumption {
+            consumedStack = consumedStack.isEmpty() ? ItemStack.EMPTY : consumedStack.copyWithCount(1);
+        }
+
+        public boolean consumedArrow() {
+            return !consumedStack.isEmpty();
+        }
+    }
+
     public static boolean canStartFocusStaffbowUse(Player player, ItemStack weaponStack) {
         return canStartFocusStaffbowUse(player, weaponStack, true, DEFAULT_FOCUS_STAFFBOW_ARROW_CATALYST_ITEMS);
     }
@@ -82,11 +92,37 @@ public final class BowCastAmmoResolver {
             FocusStaffbowAmmoRoute route,
             List<ResourceLocation> arrowCatalystItemIds
     ) {
-        return switch (route) {
-            case BYPASS -> true;
-            case ARROW_CATALYST -> consume(resolveFocusStaffbowArrowCatalystAmmo(player, arrowCatalystItemIds));
-            case NONE -> false;
-        };
+        return consumeFocusStaffbowAmmoWithResult(player, route, arrowCatalystItemIds).successful();
+    }
+
+    public static FocusStaffbowAmmoConsumption consumeFocusStaffbowAmmoWithResult(
+            Player player,
+            FocusStaffbowAmmoRoute route
+    ) {
+        return consumeFocusStaffbowAmmoWithResult(player, route, DEFAULT_FOCUS_STAFFBOW_ARROW_CATALYST_ITEMS);
+    }
+
+    public static FocusStaffbowAmmoConsumption consumeFocusStaffbowAmmoWithResult(
+            Player player,
+            FocusStaffbowAmmoRoute route,
+            List<ResourceLocation> arrowCatalystItemIds
+    ) {
+        if (route == FocusStaffbowAmmoRoute.BYPASS) {
+            return new FocusStaffbowAmmoConsumption(true, ItemStack.EMPTY);
+        }
+        if (route == FocusStaffbowAmmoRoute.NONE) {
+            return new FocusStaffbowAmmoConsumption(false, ItemStack.EMPTY);
+        }
+
+        var ammoSource = resolveFocusStaffbowArrowCatalystAmmo(player, arrowCatalystItemIds);
+        if (ammoSource == null || ammoSource.stack().isEmpty()) {
+            return new FocusStaffbowAmmoConsumption(false, ItemStack.EMPTY);
+        }
+
+        var consumedStack = ammoSource.stack().copyWithCount(1);
+        return ammoSource.consume()
+                ? new FocusStaffbowAmmoConsumption(true, consumedStack)
+                : new FocusStaffbowAmmoConsumption(false, ItemStack.EMPTY);
     }
 
     @Nullable
@@ -119,10 +155,6 @@ public final class BowCastAmmoResolver {
     @Nullable
     public static SpellcasterQuiverBowAmmoResolver.AmmoSource resolveElementalNormalArrowAmmo(Player player) {
         return resolveFocusStaffbowArrowCatalystAmmo(player, DEFAULT_FOCUS_STAFFBOW_ARROW_CATALYST_ITEMS);
-    }
-
-    private static boolean consume(@Nullable SpellcasterQuiverBowAmmoResolver.AmmoSource ammoSource) {
-        return ammoSource != null && ammoSource.consume();
     }
 
     private static boolean hasSynthesis(ItemStack stack) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/ammo/BowCastAmmoResolver.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/ammo/BowCastAmmoResolver.java
@@ -130,11 +130,27 @@ public final class BowCastAmmoResolver {
             Player player,
             List<ResourceLocation> arrowCatalystItemIds
     ) {
+        return resolveArrowCatalystAmmo(player, arrowCatalystItemIds);
+    }
+
+    @Nullable
+    public static SpellcasterQuiverBowAmmoResolver.AmmoSource resolveElementalMagicArrowCatalystAmmo(
+            Player player,
+            List<ResourceLocation> arrowCatalystItemIds
+    ) {
+        return resolveArrowCatalystAmmo(player, arrowCatalystItemIds);
+    }
+
+    @Nullable
+    private static SpellcasterQuiverBowAmmoResolver.AmmoSource resolveArrowCatalystAmmo(
+            Player player,
+            List<ResourceLocation> arrowCatalystItemIds
+    ) {
         if (arrowCatalystItemIds.isEmpty()) {
             return null;
         }
 
-        Predicate<ItemStack> catalystPredicate = stack -> isFocusStaffbowArrowCatalyst(stack, arrowCatalystItemIds);
+        Predicate<ItemStack> catalystPredicate = stack -> isArrowCatalyst(stack, arrowCatalystItemIds);
 
         var quiverAmmo = SpellcasterQuiver.findAccessibleArrow(player, catalystPredicate);
         if (quiverAmmo != null) {
@@ -161,7 +177,7 @@ public final class BowCastAmmoResolver {
         return getEnchantmentLevel(stack, jp.aquafactory.apprenticecodex.enchantment.Enchantments.SYNTHESIS.location()) > 0;
     }
 
-    private static boolean isFocusStaffbowArrowCatalyst(ItemStack stack, List<ResourceLocation> arrowCatalystItemIds) {
+    private static boolean isArrowCatalyst(ItemStack stack, List<ResourceLocation> arrowCatalystItemIds) {
         var itemId = BuiltInRegistries.ITEM.getKey(stack.getItem());
         return itemId != null && arrowCatalystItemIds.contains(itemId);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
@@ -9,6 +9,7 @@ import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.network.SyncManaPacket;
 import jp.aquafactory.apprenticecodex.compat.jei.IJeiInfoItem;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.enchantment.PlunderTarget;
 import jp.aquafactory.apprenticecodex.enchantment.TranscendencePolicy;
 import jp.aquafactory.apprenticecodex.enchantment.WisdomPolicy;
@@ -510,7 +511,7 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
     }
 
     private void releaseElementalShot(ItemStack stack, Level level, Player player, int timeLeft, ResolvedDefinition mode) {
-        var ammoSource = resolveVanillaAmmoSource(player, stack);
+        var ammoSource = resolveMagicArrowCatalystAmmoSource(player);
         var hasSynthesisEnchantment = hasSynthesis(stack);
         var canFireWithoutAmmo = player.getAbilities().instabuild || hasSynthesisEnchantment;
         var drawDuration = stack.getUseDuration(player) - timeLeft;
@@ -821,7 +822,8 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
     @Nullable
     private AmmoSource resolveAmmoSource(Player player, ItemStack bowStack, ModeSelection selection) {
         return switch (selection.kind()) {
-            case NORMAL, MAGIC -> resolveVanillaAmmoSource(player, bowStack);
+            case NORMAL -> resolveVanillaAmmoSource(player, bowStack);
+            case MAGIC -> resolveMagicArrowCatalystAmmoSource(player);
             case ARROW -> resolveNormalArrowAmmoSource(player);
             case SPECIAL -> resolveSpecialAmmoSource(player, selection.id());
             case MOD -> resolveModAmmoSource(player, selection.id());
@@ -842,6 +844,14 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
     @Nullable
     private AmmoSource resolveNormalArrowAmmoSource(Player player) {
         return adaptAmmoSource(BowCastAmmoResolver.resolveElementalNormalArrowAmmo(player));
+    }
+
+    @Nullable
+    private AmmoSource resolveMagicArrowCatalystAmmoSource(Player player) {
+        return adaptAmmoSource(BowCastAmmoResolver.resolveElementalMagicArrowCatalystAmmo(
+                player,
+                ApprenticeCodexServerConfig.elementalBowMagicArrowCatalystItemIds()
+        ));
     }
 
     @Nullable

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
@@ -13,12 +13,14 @@ import jp.aquafactory.apprenticecodex.enchantment.PlunderTarget;
 import jp.aquafactory.apprenticecodex.enchantment.TranscendencePolicy;
 import jp.aquafactory.apprenticecodex.enchantment.WisdomPolicy;
 import jp.aquafactory.apprenticecodex.item.SneakSelectionUiItem;
+import jp.aquafactory.apprenticecodex.item.ammo.BowAmmoConsumptionNotification;
 import jp.aquafactory.apprenticecodex.item.ammo.BowCastAmmoResolver;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiver;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver.SpellcasterQuiverBowAmmoResolver;
 import jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBowModeManager;
 import jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBowModeManager.ResolvedDefinition;
 import jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBowOverheatManager;
+import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.utility.PotionContentsHelper;
 import jp.aquafactory.apprenticecodex.utility.SchoolAffinityRegistry;
 import net.minecraft.ChatFormatting;
@@ -443,7 +445,7 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
 
         fireVanillaArrow(level, player, stack, ammoStack, power, infiniteAmmo);
         if (!player.getAbilities().instabuild && hasAmmo && !infiniteAmmo) {
-            ammoSource.consume();
+            consumeAmmoAndNotify(player, ammoSource);
         }
         triggerReleaseAnimation(player, stack);
     }
@@ -462,8 +464,8 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
             }
 
             @Override
-            public void consume() {
-                ammoSource.consume();
+            public boolean consume() {
+                return ammoSource.consume();
             }
 
             @Override
@@ -502,7 +504,7 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
 
         fireVanillaArrow(level, player, stack, ammoStack, power, infiniteAmmo);
         if (!player.getAbilities().instabuild && hasAmmo && !infiniteAmmo) {
-            ammoSource.consume();
+            consumeAmmoAndNotify(player, ammoSource);
         }
         triggerReleaseAnimation(player, stack);
     }
@@ -566,7 +568,7 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
         if (!player.getAbilities().instabuild) {
             stack.hurtAndBreak(1, player, LivingEntity.getSlotForHand(player.getUsedItemHand()));
             if (ammoSource != null && !hasSynthesisEnchantment) {
-                ammoSource.consume();
+                consumeAmmoAndNotify(player, ammoSource);
             }
         }
 
@@ -642,6 +644,19 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
                 1.0F / (player.getRandom().nextFloat() * 0.4F + 1.2F) + power * 0.5F
         );
         player.awardStat(Stats.ITEM_USED.get(this));
+    }
+
+    private void consumeAmmoAndNotify(Player player, AmmoSource ammoSource) {
+        var consumedStack = ammoSource.stack().copyWithCount(1);
+        if (!ammoSource.consume() || !(player instanceof ServerPlayer serverPlayer)) {
+            return;
+        }
+
+        BowAmmoConsumptionNotification.send(
+                serverPlayer,
+                ItemRegistry.ELEMENTAL_BOW.getId(),
+                consumedStack
+        );
     }
 
     @Nullable
@@ -913,8 +928,8 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
             }
 
             @Override
-            public void consume() {
-                ammoSource.consume();
+            public boolean consume() {
+                return ammoSource.consume();
             }
 
             @Override
@@ -1517,7 +1532,7 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
     private interface AmmoSource {
         ItemStack stack();
 
-        void consume();
+        boolean consume();
 
         default boolean isInfinite(ItemStack bowStack, Player player) {
             return stack().getItem() instanceof ArrowItem arrowItem && arrowItem.isInfinite(stack(), bowStack, player);
@@ -1526,15 +1541,16 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
 
     private record LooseAmmoSource(ItemStack stack) implements AmmoSource {
         @Override
-        public void consume() {
+        public boolean consume() {
             stack.shrink(1);
+            return true;
         }
     }
 
     private record StoredAmmoSource(ItemStack stack, BooleanSupplier consumer) implements AmmoSource {
         @Override
-        public void consume() {
-            consumer.getAsBoolean();
+        public boolean consume() {
+            return consumer.getAsBoolean();
         }
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBow.java
@@ -850,7 +850,9 @@ public class ElementalBow extends BowItem implements GeoItem, IPresetSpellContai
     private AmmoSource resolveMagicArrowCatalystAmmoSource(Player player) {
         return adaptAmmoSource(BowCastAmmoResolver.resolveElementalMagicArrowCatalystAmmo(
                 player,
-                ApprenticeCodexServerConfig.elementalBowMagicArrowCatalystItemIds()
+                player.level().isClientSide
+                        ? ElementalBowClientConfigState.magicArrowCatalystItemIds()
+                        : ApprenticeCodexServerConfig.elementalBowMagicArrowCatalystItemIds()
         ));
     }
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBowClientConfigState.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBowClientConfigState.java
@@ -1,0 +1,26 @@
+package jp.aquafactory.apprenticecodex.item.elementalbow;
+
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.List;
+
+public final class ElementalBowClientConfigState {
+    private static final List<ResourceLocation> DEFAULT_MAGIC_ARROW_CATALYST_ITEM_IDS =
+            List.of(ResourceLocation.fromNamespaceAndPath("minecraft", "arrow"));
+    private static List<ResourceLocation> magicArrowCatalystItemIds = DEFAULT_MAGIC_ARROW_CATALYST_ITEM_IDS;
+
+    private ElementalBowClientConfigState() {
+    }
+
+    public static void setMagicArrowCatalystItemIds(List<ResourceLocation> magicArrowCatalystItemIds) {
+        ElementalBowClientConfigState.magicArrowCatalystItemIds = List.copyOf(magicArrowCatalystItemIds);
+    }
+
+    public static void reset() {
+        magicArrowCatalystItemIds = DEFAULT_MAGIC_ARROW_CATALYST_ITEM_IDS;
+    }
+
+    public static List<ResourceLocation> magicArrowCatalystItemIds() {
+        return magicArrowCatalystItemIds;
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBowConfigSyncEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/elementalbow/ElementalBowConfigSyncEvents.java
@@ -1,0 +1,120 @@
+package jp.aquafactory.apprenticecodex.item.elementalbow;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.network.Networks;
+import jp.aquafactory.apprenticecodex.network.packet.SyncElementalBowConfigPacket;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.fml.config.ModConfig;
+import net.neoforged.fml.event.config.ModConfigEvent;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.server.ServerLifecycleHooks;
+
+@EventBusSubscriber(modid = ApprenticeCodex.MODID)
+public final class ElementalBowConfigSyncEvents {
+    private ElementalBowConfigSyncEvents() {
+    }
+
+    public static void register(IEventBus modEventBus) {
+        modEventBus.addListener(ElementalBowConfigSyncEvents::onConfigLoading);
+        modEventBus.addListener(ElementalBowConfigSyncEvents::onConfigReloading);
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    @SubscribeEvent
+    public static void onPlayerChangedDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (event.getEntity() instanceof ServerPlayer serverPlayer) {
+            syncToPlayer(serverPlayer);
+        }
+    }
+
+    private static void syncToPlayer(ServerPlayer player) {
+        Networks.sendToPlayer(player, createPacket());
+    }
+
+    private static void syncToAllPlayers() {
+        var server = ServerLifecycleHooks.getCurrentServer();
+        if (server == null) {
+            return;
+        }
+
+        var packet = createPacket();
+        for (var player : server.getPlayerList().getPlayers()) {
+            Networks.sendToPlayer(player, packet);
+        }
+    }
+
+    private static SyncElementalBowConfigPacket createPacket() {
+        return new SyncElementalBowConfigPacket(
+                ApprenticeCodexServerConfig.elementalBowMagicArrowCatalystItemIds()
+        );
+    }
+
+    private static void onConfigLoading(ModConfigEvent.Loading event) {
+        syncIfServerConfig(event);
+    }
+
+    private static void onConfigReloading(ModConfigEvent.Reloading event) {
+        syncIfServerConfig(event);
+    }
+
+    private static void syncIfServerConfig(ModConfigEvent event) {
+        if (event.getConfig().getType() != ModConfig.Type.SERVER
+                || !ApprenticeCodex.MODID.equals(event.getConfig().getModId())) {
+            return;
+        }
+
+        // NeoForge 1.21.1 でも実行中の SERVER config 再読込後は接続中クライアントへ明示同期する。
+        syncToAllPlayers();
+        logMagicArrowCatalystConfigWarnings();
+    }
+
+    private static void logMagicArrowCatalystConfigWarnings() {
+        var itemIds = ApprenticeCodexServerConfig.elementalBowMagicArrowCatalystItemIds();
+        if (itemIds.isEmpty()) {
+            ApprenticeCodex.LOGGER.warn(
+                    "Elemental Bow magicArrowCatalystItems is empty. Non-Synthesis survival casts will be unusable."
+            );
+            return;
+        }
+
+        for (var itemId : itemIds) {
+            if (!BuiltInRegistries.ITEM.containsKey(itemId)) {
+                ApprenticeCodex.LOGGER.warn(
+                        "Elemental Bow magicArrowCatalystItems contains an unknown item id: {}",
+                        itemId
+                );
+            }
+        }
+    }
+
+    @EventBusSubscriber(modid = ApprenticeCodex.MODID, value = Dist.CLIENT)
+    public static final class ClientEvents {
+        private ClientEvents() {
+        }
+
+        @SubscribeEvent
+        public static void onClientLogout(ClientPlayerNetworkEvent.LoggingOut event) {
+            ElementalBowClientConfigState.reset();
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/focusstaffbow/FocusStaffbowCastManager.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/focusstaffbow/FocusStaffbowCastManager.java
@@ -19,13 +19,15 @@ import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateT
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.spellstates.FocusStaffbowCastState;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.entity.SummonWeaponEntity;
-import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbow;
+import jp.aquafactory.apprenticecodex.item.ammo.BowAmmoConsumptionNotification;
 import jp.aquafactory.apprenticecodex.item.ammo.BowCastAmmoResolver;
+import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbow;
 import jp.aquafactory.apprenticecodex.item.continuouscast.ContinuousCastDurationSimulation;
 import jp.aquafactory.apprenticecodex.mixin.MagicDataAccessor;
 import jp.aquafactory.apprenticecodex.network.Networks;
 import jp.aquafactory.apprenticecodex.network.packet.SyncFocusStaffbowCastStatePacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncFocusStaffbowPresentationPacket;
+import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.spell.AbstractSummonWeaponSpell;
 import jp.aquafactory.apprenticecodex.utility.SpellCooldownHelper;
 import net.minecraft.nbt.CompoundTag;
@@ -415,16 +417,18 @@ public final class FocusStaffbowCastManager {
             clearPendingMagicDataSimulation(magicData);
             return false;
         }
-        if (!BowCastAmmoResolver.consumeFocusStaffbowAmmo(
+        var ammoConsumption = BowCastAmmoResolver.consumeFocusStaffbowAmmoWithResult(
                 player,
                 ammoRoute,
                 ApprenticeCodexServerConfig.focusStaffbowArrowCatalystItemIds()
-        )) {
+        );
+        if (!ammoConsumption.successful()) {
             showInsufficientArrowMessage(player);
             magicData.resetAdditionalCastData();
             clearPendingMagicDataSimulation(magicData);
             return false;
         }
+        sendConsumedArrowNotification(player, ammoConsumption);
 
         if (player.isUsingItem()) {
             player.stopUsingItem();
@@ -531,11 +535,12 @@ public final class FocusStaffbowCastManager {
             cancelPendingPresentation(player, focusStaffbowStack, spell.getSpellId());
             return false;
         }
-        if (!BowCastAmmoResolver.consumeFocusStaffbowAmmo(
+        var ammoConsumption = BowCastAmmoResolver.consumeFocusStaffbowAmmoWithResult(
                 player,
                 ammoRoute,
                 ApprenticeCodexServerConfig.focusStaffbowArrowCatalystItemIds()
-        )) {
+        );
+        if (!ammoConsumption.successful()) {
             cleanupPendingSpellArtifacts(player, magicData.getAdditionalCastData());
             magicData.resetAdditionalCastData();
             clearPendingMagicDataSimulation(magicData);
@@ -543,6 +548,7 @@ public final class FocusStaffbowCastManager {
             showInsufficientArrowMessage(player);
             return false;
         }
+        sendConsumedArrowNotification(player, ammoConsumption);
 
         var modifier = new AttributeModifier(
                 OVERCHARGE_SPELL_POWER_MODIFIER_ID,
@@ -821,6 +827,21 @@ public final class FocusStaffbowCastManager {
         player.connection.send(new ClientboundSetActionBarTextPacket(
                 FocusStaffbow.createInsufficientArrowMessage()
         ));
+    }
+
+    private static void sendConsumedArrowNotification(
+            ServerPlayer player,
+            BowCastAmmoResolver.FocusStaffbowAmmoConsumption consumption
+    ) {
+        if (!consumption.consumedArrow()) {
+            return;
+        }
+
+        BowAmmoConsumptionNotification.send(
+                player,
+                ItemRegistry.FOCUS_STAFFBOW.getId(),
+                consumption.consumedStack()
+        );
     }
 
     private static void showContinuousDisabledMessage(ServerPlayer player) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/Networks.java
@@ -20,6 +20,7 @@ import jp.aquafactory.apprenticecodex.network.packet.HeavenlyFistPulsePacket;
 import jp.aquafactory.apprenticecodex.network.packet.HealingBloomPulsePacket;
 import jp.aquafactory.apprenticecodex.network.packet.ManaSiphonOrbEffectPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SenseEvilHighlightsPacket;
+import jp.aquafactory.apprenticecodex.network.packet.SyncElementalBowConfigPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncElementalBowOverheatPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncEquipmentSpellTimingConfigPacket;
 import jp.aquafactory.apprenticecodex.network.packet.SyncAutocastAmuletNotificationPacket;
@@ -69,7 +70,7 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 
 public final class Networks {
-    private static final String PROTOCOL_VERSION = "68";
+    private static final String PROTOCOL_VERSION = "69";
 
     private Networks() {
     }
@@ -94,6 +95,11 @@ public final class Networks {
                 SyncFocusStaffbowConfigPacket.TYPE,
                 SyncFocusStaffbowConfigPacket.STREAM_CODEC,
                 SyncFocusStaffbowConfigPacket::handle
+        );
+        registrar.playToClient(
+                SyncElementalBowConfigPacket.TYPE,
+                SyncElementalBowConfigPacket.STREAM_CODEC,
+                SyncElementalBowConfigPacket::handle
         );
         registrar.playToClient(
                 SyncChargecastCatalystbookConfigPacket.TYPE,

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncElementalBowConfigPacket.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/packet/SyncElementalBowConfigPacket.java
@@ -1,0 +1,68 @@
+package jp.aquafactory.apprenticecodex.network.packet;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.item.elementalbow.ElementalBowClientConfigState;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record SyncElementalBowConfigPacket(List<ResourceLocation> magicArrowCatalystItemIds)
+        implements CustomPacketPayload {
+    public static final Type<SyncElementalBowConfigPacket> TYPE =
+            new Type<>(ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "sync_elemental_bow_config"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, SyncElementalBowConfigPacket> STREAM_CODEC =
+            StreamCodec.of((buffer, packet) -> encode(packet, buffer), SyncElementalBowConfigPacket::decode);
+
+    public SyncElementalBowConfigPacket {
+        magicArrowCatalystItemIds = List.copyOf(magicArrowCatalystItemIds);
+    }
+
+    @Override
+    public @NotNull Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    public static void encode(SyncElementalBowConfigPacket packet, FriendlyByteBuf buffer) {
+        buffer.writeVarInt(packet.magicArrowCatalystItemIds.size());
+        for (var itemId : packet.magicArrowCatalystItemIds) {
+            buffer.writeResourceLocation(itemId);
+        }
+    }
+
+    public static SyncElementalBowConfigPacket decode(FriendlyByteBuf buffer) {
+        var itemCount = buffer.readVarInt();
+        var itemIds = new ArrayList<ResourceLocation>(itemCount);
+        for (var index = 0; index < itemCount; ++index) {
+            itemIds.add(buffer.readResourceLocation());
+        }
+        return new SyncElementalBowConfigPacket(itemIds);
+    }
+
+    public static void handle(SyncElementalBowConfigPacket packet, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            if (FMLEnvironment.dist == Dist.CLIENT) {
+                ClientHandler.handle(packet);
+            }
+        });
+    }
+
+    @OnlyIn(Dist.CLIENT)
+    private static final class ClientHandler {
+        private ClientHandler() {
+        }
+
+        private static void handle(SyncElementalBowConfigPacket packet) {
+            ElementalBowClientConfigState.setMagicArrowCatalystItemIds(packet.magicArrowCatalystItemIds);
+        }
+    }
+}


### PR DESCRIPTION
## 概要

PR #752「弓系アイテムの矢消費周りの通知及び不親切挙動の修正」を Minecraft 1.21.1 / NeoForge へ forward-port します。

- Elemental Bow と集中の弓杖で、矢を実際に消費した際に残数通知を表示
- Elemental Bow の魔法モード用触媒矢をサーバー設定化
- ログイン、リスポーン、ディメンション移動、SERVER config 再読込時に触媒設定をクライアントへ同期
- インベントリと Spellcaster Quiver を横断し、Data Components が一致する矢だけを残数集計

## 原因と影響

従来は弓系アイテムの触媒矢消費後に残数が通知されず、Elemental Bow の魔法モードはバニラ矢判定へ依存していました。また、実行中に触媒設定を再読込してもクライアント側が古い値を保持し、右クリック予測とサーバー判定が食い違う可能性がありました。

この変更により、消費した矢の種類と残数を確認でき、Elemental Bow の触媒種類をサーバー設定で制御できます。設定再読込後も接続中クライアントへ最新値が同期されます。

## 1.21.1向け調整

- `ItemStack.isSameItemSameComponents` と Data Components ベースの矢比較へ移行
- NeoForge の `CustomPacketPayload` / `StreamCodec` / `RegisterPayloadHandlersEvent` へ移行
- config同期イベントをmod event busへ明示登録
- `BuiltInRegistries` と1.21.1のポーションAPIへ移行

## 検証

- `./gradlew.bat runData` 成功（生成物差分なし）
- `./gradlew.bat runGameTestServer` 成功（All 905 required tests passed）
- `./gradlew.bat build` 成功
- `checkTextEncodingHygiene` 成功
- `runClient` 動作確認済み