### PR TITLE
レシピ難易度の調整

### DIFF
--- a/src/generated/resources/data/apprenticecodex/advancements/recipes/combat/diamond_spellcaster_gun.json
+++ b/src/generated/resources/data/apprenticecodex/advancements/recipes/combat/diamond_spellcaster_gun.json
@@ -1,12 +1,12 @@
 {
   "parent": "minecraft:recipes/root",
   "criteria": {
-    "has_mithril_ingot": {
+    "has_mithril_scrap": {
       "conditions": {
         "items": [
           {
             "items": [
-              "irons_spellbooks:mithril_ingot"
+              "irons_spellbooks:mithril_scrap"
             ]
           }
         ]
@@ -22,7 +22,7 @@
   },
   "requirements": [
     [
-      "has_mithril_ingot",
+      "has_mithril_scrap",
       "has_the_recipe"
     ]
   ],

--- a/src/generated/resources/data/apprenticecodex/advancements/recipes/decorations/spellcaster_workbench.json
+++ b/src/generated/resources/data/apprenticecodex/advancements/recipes/decorations/spellcaster_workbench.json
@@ -1,12 +1,12 @@
 {
   "parent": "minecraft:recipes/root",
   "criteria": {
-    "has_iron_spellcaster_gun": {
+    "has_magic_cloth": {
       "conditions": {
         "items": [
           {
             "items": [
-              "apprenticecodex:iron_spellcaster_gun"
+              "irons_spellbooks:magic_cloth"
             ]
           }
         ]
@@ -22,7 +22,7 @@
   },
   "requirements": [
     [
-      "has_iron_spellcaster_gun",
+      "has_magic_cloth",
       "has_the_recipe"
     ]
   ],

--- a/src/generated/resources/data/apprenticecodex/recipes/diamond_spellcaster_gun.json
+++ b/src/generated/resources/data/apprenticecodex/recipes/diamond_spellcaster_gun.json
@@ -2,24 +2,24 @@
   "type": "minecraft:crafting_shaped",
   "category": "equipment",
   "key": {
+    "A": {
+      "item": "irons_spellbooks:arcane_ingot"
+    },
     "B": {
       "tag": "minecraft:buttons"
     },
     "D": {
       "item": "minecraft:diamond"
     },
-    "L": {
-      "item": "irons_spellbooks:cooldown_upgrade_orb"
-    },
     "M": {
-      "item": "irons_spellbooks:mithril_ingot"
+      "item": "irons_spellbooks:mithril_scrap"
     },
     "R": {
       "item": "minecraft:redstone"
     }
   },
   "pattern": [
-    "DML",
+    "DAM",
     " DR",
     " BD"
   ],

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
@@ -84,7 +84,7 @@ public final class RecipeGenerator extends RecipeProvider {
                 .define('M', io.redspace.ironsspellbooks.registries.ItemRegistry.MAGIC_CLOTH.get())
                 .define('S', ItemTags.WOODEN_SLABS)
                 .define('F', ItemTags.WOODEN_FENCES)
-                .unlockedBy(getHasName(ItemRegistry.IRON_SPELLCASTER_GUN.get()), has(ItemRegistry.IRON_SPELLCASTER_GUN.get()))
+                .unlockedBy(getHasName(io.redspace.ironsspellbooks.registries.ItemRegistry.MAGIC_CLOTH.get()), has(io.redspace.ironsspellbooks.registries.ItemRegistry.MAGIC_CLOTH.get()))
                 .save(recipeWriter);
 
         ShapedRecipeBuilder.shaped(RecipeCategory.DECORATIONS, ItemRegistry.ATELIER_STATION.get())

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
@@ -777,15 +777,15 @@ public final class RecipeGenerator extends RecipeProvider {
                 .save(recipeWriter);
 
         ShapedRecipeBuilder.shaped(RecipeCategory.COMBAT, ItemRegistry.DIAMOND_SPELLCASTER_GUN.get())
-                .pattern("DML")
+                .pattern("DAM")
                 .pattern(" DR")
                 .pattern(" BD")
-                .define('M', io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_INGOT.get())
-                .define('L', io.redspace.ironsspellbooks.registries.ItemRegistry.COOLDOWN_UPGRADE_ORB.get())
+                .define('A', io.redspace.ironsspellbooks.registries.ItemRegistry.ARCANE_INGOT.get())
+                .define('M', io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_SCRAP.get())
                 .define('D', Items.DIAMOND)
                 .define('R', Items.REDSTONE)
                 .define('B', ItemTags.BUTTONS)
-                .unlockedBy(getHasName(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_INGOT.get()), has(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_INGOT.get()))
+                .unlockedBy(getHasName(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_SCRAP.get()), has(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_SCRAP.get()))
                 .save(recipeWriter);
 
         ShapedRecipeBuilder.shaped(RecipeCategory.COMBAT, ItemRegistry.MULTIPURPOSE_STAFFRIFLE.get())


### PR DESCRIPTION
- `SpellcasterWorkbench`は機能が増えてきたのでSpellgunとは無関係のレシピアンロックに変更
- ダイヤ詠唱銃は明らかにミスリルをこんな使う性能はないのでミスリル破片1個相当に変更
    - ミスリルを使ってはいるので耐火性は維持
- `runClient`確認済み
- `runGameTestServer` : `All 889 required tests passed :)`