### PR TITLE
PR #754を1.21.1へforward-port

### DIFF
--- a/src/generated/resources/data/apprenticecodex/advancement/recipes/combat/diamond_spellcaster_gun.json
+++ b/src/generated/resources/data/apprenticecodex/advancement/recipes/combat/diamond_spellcaster_gun.json
@@ -1,11 +1,11 @@
 {
   "parent": "minecraft:recipes/root",
   "criteria": {
-    "has_mithril_ingot": {
+    "has_mithril_scrap": {
       "conditions": {
         "items": [
           {
-            "items": "irons_spellbooks:mithril_ingot"
+            "items": "irons_spellbooks:mithril_scrap"
           }
         ]
       },
@@ -21,7 +21,7 @@
   "requirements": [
     [
       "has_the_recipe",
-      "has_mithril_ingot"
+      "has_mithril_scrap"
     ]
   ],
   "rewards": {

--- a/src/generated/resources/data/apprenticecodex/advancement/recipes/decorations/spellcaster_workbench.json
+++ b/src/generated/resources/data/apprenticecodex/advancement/recipes/decorations/spellcaster_workbench.json
@@ -1,11 +1,11 @@
 {
   "parent": "minecraft:recipes/root",
   "criteria": {
-    "has_iron_spellcaster_gun": {
+    "has_magic_cloth": {
       "conditions": {
         "items": [
           {
-            "items": "apprenticecodex:iron_spellcaster_gun"
+            "items": "irons_spellbooks:magic_cloth"
           }
         ]
       },
@@ -21,7 +21,7 @@
   "requirements": [
     [
       "has_the_recipe",
-      "has_iron_spellcaster_gun"
+      "has_magic_cloth"
     ]
   ],
   "rewards": {

--- a/src/generated/resources/data/apprenticecodex/recipe/diamond_spellcaster_gun.json
+++ b/src/generated/resources/data/apprenticecodex/recipe/diamond_spellcaster_gun.json
@@ -2,24 +2,24 @@
   "type": "minecraft:crafting_shaped",
   "category": "equipment",
   "key": {
+    "A": {
+      "item": "irons_spellbooks:arcane_ingot"
+    },
     "B": {
       "tag": "minecraft:buttons"
     },
     "D": {
       "item": "minecraft:diamond"
     },
-    "L": {
-      "item": "irons_spellbooks:cooldown_upgrade_orb"
-    },
     "M": {
-      "item": "irons_spellbooks:mithril_ingot"
+      "item": "irons_spellbooks:mithril_scrap"
     },
     "R": {
       "item": "minecraft:redstone"
     }
   },
   "pattern": [
-    "DML",
+    "DAM",
     " DR",
     " BD"
   ],

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
@@ -780,15 +780,15 @@ public final class RecipeGenerator extends RecipeProvider {
                 .save(recipeOutput);
 
         ShapedRecipeBuilder.shaped(RecipeCategory.COMBAT, ItemRegistry.DIAMOND_SPELLCASTER_GUN.get())
-                .pattern("DML")
+                .pattern("DAM")
                 .pattern(" DR")
                 .pattern(" BD")
-                .define('M', io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_INGOT.get())
-                .define('L', io.redspace.ironsspellbooks.registries.ItemRegistry.COOLDOWN_UPGRADE_ORB.get())
+                .define('A', io.redspace.ironsspellbooks.registries.ItemRegistry.ARCANE_INGOT.get())
+                .define('M', io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_SCRAP.get())
                 .define('D', Items.DIAMOND)
                 .define('R', Items.REDSTONE)
                 .define('B', ItemTags.BUTTONS)
-                .unlockedBy(getHasName(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_INGOT.get()), has(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_INGOT.get()))
+                .unlockedBy(getHasName(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_SCRAP.get()), has(io.redspace.ironsspellbooks.registries.ItemRegistry.MITHRIL_SCRAP.get()))
                 .save(recipeOutput);
 
         ShapedRecipeBuilder.shaped(RecipeCategory.COMBAT, ItemRegistry.MULTIPURPOSE_STAFFRIFLE.get())

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
@@ -84,7 +84,7 @@ public final class RecipeGenerator extends RecipeProvider {
                 .define('M', io.redspace.ironsspellbooks.registries.ItemRegistry.MAGIC_CLOTH.get())
                 .define('S', ItemTags.WOODEN_SLABS)
                 .define('F', ItemTags.WOODEN_FENCES)
-                .unlockedBy(getHasName(ItemRegistry.IRON_SPELLCASTER_GUN.get()), has(ItemRegistry.IRON_SPELLCASTER_GUN.get()))
+                .unlockedBy(getHasName(io.redspace.ironsspellbooks.registries.ItemRegistry.MAGIC_CLOTH.get()), has(io.redspace.ironsspellbooks.registries.ItemRegistry.MAGIC_CLOTH.get()))
                 .save(recipeOutput);
 
         ShapedRecipeBuilder.shaped(RecipeCategory.DECORATIONS, ItemRegistry.ATELIER_STATION.get())


### PR DESCRIPTION
## 概要

PR #754「レシピ難易度の調整」を Minecraft 1.21.1 / NeoForge へ forward-port します。

- 詠唱者の作業台のレシピアンロック条件を、鉄の詠唱銃から魔法の布へ変更
- ダイヤ詠唱銃のミスリルインゴットをミスリル破片へ変更
- クールダウン強化オーブを秘術のインゴットへ変更
- ミスリル素材を使用するため、ダイヤ詠唱銃の耐火性は維持

## 変更理由と影響

詠唱者の作業台は詠唱銃以外にも多数の機能を持つため、詠唱銃に依存しないアンロック条件へ変更します。また、ダイヤ詠唱銃の性能に対してレシピ難易度が高すぎたため、ミスリルを入手し始めた段階で作成できるコストへ調整します。

## 1.21.1向け調整

- datagen の `recipeOutput` を維持して競合を解決
- generated resource を 1.21.1 の単数形パス `advancement/` / `recipe/` へ再生成
- 1.20.1 の複数形パス `advancements/` / `recipes/` を持ち込まないことを確認

## 検証

- `./gradlew.bat runData` 成功（対象 JSON 3件を再生成）
- `./gradlew.bat runGameTestServer` 成功（All 905 required tests passed）
- `./gradlew.bat build` 成功
- `checkTextEncodingHygiene` 成功