### PR TITLE
PR CIのbuildとGameTestを分離

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-gametest:
-    name: build-and-gametest
+  build:
+    name: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -45,5 +45,35 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
-      - name: Build and run GameTest server
-        run: ./gradlew build runGameTestServer --no-daemon --stacktrace
+      - name: Build
+        run: ./gradlew build --no-daemon --stacktrace
+
+  gametest:
+    name: gametest
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Temurin 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      # PR から持ち込まれた wrapper を実行する前に正規の Gradle wrapper かを検証する。
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      - name: Run GameTest server
+        run: ./gradlew runGameTestServer --no-daemon --stacktrace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,14 +114,14 @@ Get-ChildItem build\libs\*.jar
    - 組み合わせバランス確認: `./gradlew.bat runClientCompatEasyBetter`
 9. コミットはレビューしやすく、forward-port しやすい粒度に分ける。無関係な整形や広域整理を混ぜない。
 10. `main` へ反映する変更は必ずブランチ + PR で流し、直 push しない。
-11. PR では GitHub Actions の `PR CI / build-and-gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
+11. PR では必須の GitHub Actions `PR CI / build`、任意の `PR CI / gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
 12. 通常は merge commit で取り込む。バージョン更新だけは rebase merge を使ってよい。squash merge は使わない。
 
 ## 6. レビューチェックリスト
 - Java 17 環境で必要な検証が通っていること。コード/リソース変更では `./gradlew.bat build` を必須とする。
 - サーバー側の登録、データ読込、レシピ、生成に影響する変更では `./gradlew.bat runGameTestServer` が成功していること。
 - optional MOD 連携に影響する変更では、該当する `runGameTestServerCompat` / `runGameTestServerEasyMagic` / `runGameTestServerBetterCombat` / `runGameTestServerEpicFight`、または対応する `runClient...` の実行結果が説明されていること。
-- `main` へ送る PR では GitHub Actions の `PR CI / build-and-gametest` が成功していること。
+- `main` へ送る PR では GitHub Actions の `PR CI / build` が成功し、任意の `PR CI / gametest` の結果も確認されていること。
 - Codex Cloud のスマートトリガーレビューで指摘が出ている場合、対応または明示的な見送り理由があること。
 - 追加・変更した要素の登録漏れ（Registry/EventBus）がないこと。
 - サーバー専用環境で問題となるクライアント専用参照を追加していないこと。

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 ## GitHub 運用
 
 - `main` への反映は、バージョン更新を含めてすべて PR 経由で行います。
-- PR では GitHub Actions の `PR CI / build-and-gametest` が必須です。`build` と `runGameTestServer` の両方が成功しない限りマージしません。
+- PR では GitHub Actions の `PR CI / build` が必須です。`PR CI / gametest` も実行しますが、1.20.1 側では任意チェックとして結果を確認します。
 - optional MOD 付きの特殊 GameTest / client 起動は required CI に含めません。必要な変更ではローカルまたは Codex 実行結果を PR コメントや最終報告に残します。
 - Codex Cloud のスマートトリガーレビューをレビュー補助として使います。人間の判断と CI 通過を置き換えるものではありません。
 - CI は GitHub-hosted runner 上で `pull_request` イベントだけを使い、repository secrets は使いません。

--- a/docs/github-pr-protection.md
+++ b/docs/github-pr-protection.md
@@ -1,6 +1,6 @@
 # GitHub PR 保護設定
 
-このリポジトリでは `main` への反映を PR に統一し、GitHub Actions の check run `build-and-gametest` が成功しない限りマージしない。Codex Cloud のスマートトリガーレビューは PR レビュー補助として使い、CI と人間の判断を置き換えない。
+このリポジトリでは `main` への反映を PR に統一し、GitHub Actions の check run `build` が成功しない限りマージしない。`gametest` も実行するが、1.20.1 側では任意チェックとして結果を確認する。Codex Cloud のスマートトリガーレビューは PR レビュー補助として使い、CI と人間の判断を置き換えない。
 
 ## 1. Actions セキュリティ設定
 
@@ -31,12 +31,12 @@ GitHub の `Settings` -> `Rules` -> `Rulesets` で `main-pr-ci-protection` を�
 - Require a pull request before merging: `On`
 - Require status checks to pass before merging: `On`
 - Required status checks:
-  - `build-and-gametest`（GitHub Actions）
+  - `build`（GitHub Actions）
 - Require branches to be up to date before merging: `On`
 
 補足:
 
-- GitHub の画面上では workflow 名込みで `PR CI / build-and-gametest` と表示されることがあるが、ruleset には GitHub Actions の check run `build-and-gametest` を登録する。
+- GitHub の画面上では workflow 名込みで `PR CI / build` と表示されることがあるが、ruleset には GitHub Actions の check run `build` を登録する。`PR CI / gametest` は任意チェックとして登録しない。
 
 必要に応じて次も有効化する。
 
@@ -47,7 +47,7 @@ GitHub の `Settings` -> `Rules` -> `Rulesets` で `main-pr-ci-protection` を�
 
 - PR 作成後、Codex Cloud のスマートトリガーレビューを走らせる。
 - 指摘が出た場合は、修正するか、見送る理由を PR 上で明示する。
-- スマートトリガーレビューは必須 CI の代替にしない。`build-and-gametest` と人間のレビューを最終判断に使う。
+- スマートトリガーレビューは必須 CI の代替にしない。`build`、任意の `gametest` の結果、人間のレビューを最終判断に使う。
 - 将来、Codex Cloud 側で安定した check 名を required status check にできる状態になった場合のみ、Ruleset への追加を検討する。
 
 ## 4. Merge 運用
@@ -59,8 +59,8 @@ GitHub の `Settings` -> `Rules` -> `Rulesets` で `main-pr-ci-protection` を�
 
 ## 5. 受け入れ確認
 
-1. 軽微な変更で PR を作成し、`PR CI / build-and-gametest` の workflow が自動起動し、`build-and-gametest` check run が記録されることを確認する。
-2. 意図的に GameTest を落とした PR で required check failure により merge できないことを確認する。
-3. 修正 push 後に同じ check 名で再実行され、成功時のみ merge 可能になることを確認する。
+1. 軽微な変更で PR を作成し、`PR CI / build` と `PR CI / gametest` が自動起動し、各 check run が記録されることを確認する。
+2. 意図的に `build` を落とした PR で required check failure により merge できないことを確認する。
+3. `gametest` が失敗しても任意チェックとして記録され、`build` が成功していれば required check を満たすことを確認する。
 4. `main` への直接 push が拒否されることを確認する。
 5. Codex Cloud のスマートトリガーレビューが PR 上で確認でき、指摘の対応状況を追えることを確認する。


### PR DESCRIPTION
## 変更内容

- `build` と `gametest` を独立したGitHub Actionsジョブへ分割
- `build` は `./gradlew build` を実行
- `gametest` は `./gradlew runGameTestServer` を実行
- Java 17、既存のaction固定SHA、wrapper検証を維持

## 目的

1.20.1環境ではGitHub Actions上のGameTestが長時間化・不安定化することがあるため、buildを必須、GameTestを任意として別々に判定できるようにします。ruleset側ではこのPRのチェック名を確認後、`build`のみをrequired status checkに設定します。

## 検証

- `git diff --check`: 成功
- `./gradlew.bat checkTextEncodingHygiene`（Java 17）: 成功
- workflowのみの変更のため、ローカルのフルビルドとGameTestは省略

## 補足

- ドキュメントは既存のcheck名と必須/任意の記載だけを更新し、暫定運用の追加説明は行っていません。
- 管理者のrulesetバイパスは、直接pushを許可しない `For pull requests only` へ変更済みです。