### PR TITLE
[1.21.1] PR CIのbuildとGameTestを分離

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -18,8 +18,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-gametest:
-    name: build-and-gametest
+  build:
+    name: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -45,5 +45,35 @@ jobs:
       - name: Ensure Gradle wrapper is executable
         run: chmod +x ./gradlew
 
-      - name: Build and run GameTest server
-        run: ./gradlew build runGameTestServer --no-daemon --stacktrace
+      - name: Build
+        run: ./gradlew build --no-daemon --stacktrace
+
+  gametest:
+    name: gametest
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Temurin 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      # PR から持ち込まれた wrapper を実行する前に正規の Gradle wrapper かを検証する。
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e
+
+      - name: Ensure Gradle wrapper is executable
+        run: chmod +x ./gradlew
+
+      - name: Run GameTest server
+        run: ./gradlew runGameTestServer --no-daemon --stacktrace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Get-ChildItem build\libs\*.jar
 8. client 専用 UI、renderer、screen、入力操作に影響する変更では必要に応じて `./gradlew.bat runClient` で確認する。
 9. コミットはレビューしやすく、forward-port しやすい粒度に分ける。無関係な整形や広域整理を混ぜない。
 10. `1.21.1-main` へ取り込む変更は必ずブランチ + PR で流し、直 push しない。
-11. PR では GitHub Actions の `PR CI / build-and-gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
+11. PR では必須の GitHub Actions `PR CI / build` と `PR CI / gametest`、Codex Cloud のスマートトリガーレビュー、人間のレビューを確認してから取り込む。スマートトリガーレビューは補助であり、CI と人間の判断を置き換えない。
 12. 通常は merge commit で取り込む。バージョン更新だけは rebase merge を使ってよい。squash merge は使わない。
 
 ## 6. レビューチェックリスト
@@ -133,7 +133,7 @@ Get-ChildItem build\libs\*.jar
 - サーバー側の登録、データ読込、レシピ、生成に影響する変更では `./gradlew.bat runGameTestServer` が成功していること。
 - `main` から `1.21.1-main` への forward-port では、実装内容に関係なく `./gradlew.bat runGameTestServer` と `./gradlew.bat build` が成功していること。
 - optional MOD 連携に影響する変更では、該当する `runGameTestServerCompat` / `runGameTestServerEasyMagic` / `runGameTestServerBetterCombat` / `runGameTestServerEpicFight`、または対応する `runClient...` の実行結果が説明されていること。
-- `1.21.1-main` 向け PR では GitHub Actions の `PR CI / build-and-gametest` が成功していること。
+- `1.21.1-main` 向け PR では GitHub Actions の `PR CI / build` と `PR CI / gametest` が成功していること。
 - Codex Cloud のスマートトリガーレビューで指摘が出ている場合、対応または明示的な見送り理由があること。
 - 追加・変更した要素の登録漏れ（Registry/EventBus）がないこと。
 - サーバー専用環境で問題となるクライアント専用参照を追加していないこと。
@@ -166,7 +166,7 @@ Get-ChildItem build\libs\*.jar
 
 ## 8.1 `1.21.1-main` の PR CI 運用
 - `1.21.1-main` への反映は PR 経由のみとし、直接 push しない。
-- required check は `PR CI / build-and-gametest` とする。
+- required check は `PR CI / build` と `PR CI / gametest` とする。
 - workflow は `pull_request` でのみ動かし、`pull_request_target` は使わない。
 - CI では repository secrets を使わず、`GITHUB_TOKEN` は read-only に固定する。
 - 通常変更は `merge commit` を使い、バージョン更新 PR だけ `rebase merge` を許可する。

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 
 ## PR 運用
 
-- `1.21.1-main` への取り込みは PR 経由で行い、`PR CI / build-and-gametest` の成功を必須とします。
+- `1.21.1-main` への取り込みは PR 経由で行い、`PR CI / build` と `PR CI / gametest` の成功を必須とします。
 - optional MOD 付きの特殊 GameTest / client 起動は required CI に含めません。必要な変更ではローカルまたは Codex 実行結果を PR コメントや最終報告に残します。
 - Codex Cloud のスマートトリガーレビューをレビュー補助として使います。人間の判断と CI 通過を置き換えるものではありません。
 - GitHub Actions は `pull_request` でのみ実行し、`pull_request_target` は使いません。

--- a/docs/github-pr-protection.md
+++ b/docs/github-pr-protection.md
@@ -1,6 +1,6 @@
 # GitHub PR 保護設定（`1.21.1-main`）
 
-このリポジトリでは `1.21.1-main` への反映を PR に統一し、`PR CI / build-and-gametest` が成功しない限りマージしない。Codex Cloud のスマートトリガーレビューは PR レビュー補助として使い、CI と人間の判断を置き換えない。
+このリポジトリでは `1.21.1-main` への反映を PR に統一し、`PR CI / build` と `PR CI / gametest` が成功しない限りマージしない。Codex Cloud のスマートトリガーレビューは PR レビュー補助として使い、CI と人間の判断を置き換えない。
 
 ## 1. Actions セキュリティ設定
 
@@ -26,10 +26,10 @@ target branch に workflow が存在しない段階で required check を先に�
 
 1. `1.21.1-main` 向け workflow を含む PR を作る
 2. required status check はまだ有効化しない
-3. その PR で `PR CI / build-and-gametest` が 1 回成功することを確認する
+3. その PR で `PR CI / build` と `PR CI / gametest` が 1 回成功することを確認する
 4. PR を `Create a merge commit` で `1.21.1-main` に取り込む
 5. `1.21.1-main` 上に `.github/workflows/pr-ci.yml` が存在することを確認する
-6. その後で ruleset に `PR CI / build-and-gametest` を required check として追加する
+6. その後で ruleset に check run `build` と `gametest` を required check として追加する
 
 ## 3. `1.21.1-main` の Ruleset
 
@@ -41,7 +41,8 @@ GitHub の `Settings` -> `Rules` -> `Rulesets` で `1-21-1-main-pr-ci-protection
 - Require a pull request before merging: `On`
 - Allowed merge methods: `merge`, `rebase`
 - Required status checks:
-  - `PR CI / build-and-gametest`
+  - `build`（GitHub Actions）
+  - `gametest`（GitHub Actions）
 - Require branches to be up to date before merging: `On`
 
 補足:
@@ -49,6 +50,7 @@ GitHub の `Settings` -> `Rules` -> `Rulesets` で `1-21-1-main-pr-ci-protection
 - `Squash and merge` は repository settings 側で無効化する。
 - 通常変更は `Create a merge commit` を使う。
 - バージョン更新 PR だけ `Rebase and merge` を使ってよい。
+- GitHub の画面上では workflow 名込みで `PR CI / build` と `PR CI / gametest` と表示されることがあるが、ruleset には check run `build` と `gametest` を登録する。
 
 必要に応じて次も有効化する。
 
@@ -59,7 +61,7 @@ GitHub の `Settings` -> `Rules` -> `Rulesets` で `1-21-1-main-pr-ci-protection
 
 - PR 作成後、Codex Cloud のスマートトリガーレビューを走らせる。
 - 指摘が出た場合は、修正するか、見送る理由を PR 上で明示する。
-- スマートトリガーレビューは必須 CI の代替にしない。`PR CI / build-and-gametest` と人間のレビューを最終判断に使う。
+- スマートトリガーレビューは必須 CI の代替にしない。`build`、`gametest`、人間のレビューを最終判断に使う。
 - 将来、Codex Cloud 側で安定した check 名を required status check にできる状態になった場合のみ、Ruleset への追加を検討する。
 
 ## 5. Merge 運用
@@ -71,9 +73,9 @@ GitHub の `Settings` -> `Rules` -> `Rulesets` で `1-21-1-main-pr-ci-protection
 
 ## 6. 受け入れ確認
 
-1. 軽微な変更で `1.21.1-main` 向け PR を作成し、`PR CI / build-and-gametest` が自動起動することを確認する。
+1. 軽微な変更で `1.21.1-main` 向け PR を作成し、`PR CI / build` と `PR CI / gametest` が自動起動することを確認する。
 2. workflow を含む最初の PR では、required check 未設定の状態で CI 成功後に merge できることを確認する。
-3. workflow 反映後に ruleset へ `PR CI / build-and-gametest` を required check として追加する。
-4. 以後の PR では、この check が成功しない限り merge できないことを確認する。
+3. workflow 反映後に ruleset へ check run `build` と `gametest` を required check として追加する。
+4. 以後の PR では、両checkが成功しない限り merge できないことを確認する。
 5. merge 可否まで確認したい場合は、無害な docs 変更を使った検証 PR を 1 本だけ merge してもよい。
 6. Codex Cloud のスマートトリガーレビューが PR 上で確認でき、指摘の対応状況を追えることを確認する。


### PR DESCRIPTION
## 変更内容

- `build` と `gametest` を独立したGitHub Actionsジョブへ分割
- `build` は `./gradlew build` を実行
- `gametest` は `./gradlew runGameTestServer` を実行
- Java 21、既存のaction固定SHA、wrapper検証を維持
- main向けコミット `21046d23c` を `-x` 付きでforward-portし、Java 21固有差分を適用

## 目的

1.21.1環境ではbuildとGameTestの両方をrequired status checkとして扱えるよう、チェックを独立させます。ruleset側ではこのPRのチェック名を確認後、`build`と`gametest`の両方を必須に設定します。

## 検証

- `git diff --check`: 成功
- `./gradlew.bat checkTextEncodingHygiene`（Java 21）: 成功
- workflowのみの変更のため、ローカルのフルビルドとGameTestは省略

## 補足

- ドキュメントは既存のcheck名と必須/任意の記載だけを更新し、暫定運用の追加説明は行っていません。
- 管理者のrulesetバイパスは、直接pushを許可しない `For pull requests only` へ変更済みです。