### PR TITLE
粗製インクを1.21.1へforward-port

### DIFF
--- a/src/generated/resources/data/apprenticecodex/advancement/recipes/misc/crude_ink.json
+++ b/src/generated/resources/data/apprenticecodex/advancement/recipes/misc/crude_ink.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_glow_berries": {
+      "conditions": {
+        "items": [
+          {
+            "items": "minecraft:glow_berries"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "apprenticecodex:crude_ink"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_glow_berries"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "apprenticecodex:crude_ink"
+    ]
+  }
+}

--- a/src/generated/resources/data/apprenticecodex/recipe/crude_ink.json
+++ b/src/generated/resources/data/apprenticecodex/recipe/crude_ink.json
@@ -1,0 +1,34 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "type": "neoforge:components",
+      "components": {
+        "minecraft:potion_contents": {
+          "potion": "minecraft:water"
+        }
+      },
+      "items": "minecraft:potion"
+    },
+    {
+      "item": "minecraft:lapis_lazuli"
+    },
+    {
+      "item": "minecraft:redstone"
+    },
+    {
+      "item": "minecraft:glow_berries"
+    },
+    {
+      "item": "minecraft:glow_berries"
+    },
+    {
+      "item": "minecraft:ink_sac"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "apprenticecodex:crude_ink"
+  }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/apprenticedesk/ApprenticeDeskMenu.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/apprenticedesk/ApprenticeDeskMenu.java
@@ -11,8 +11,10 @@ import io.redspace.ironsspellbooks.api.spells.SpellData;
 import io.redspace.ironsspellbooks.api.spells.SpellRarity;
 import io.redspace.ironsspellbooks.util.ModTags;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.apprenticedesk.CrudeInkItem;
 import jp.aquafactory.apprenticecodex.item.apprenticedesk.PartiallyUsedInkState;
 import jp.aquafactory.apprenticecodex.registry.BlockRegistry;
+import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.MenuRegistry;
 import jp.aquafactory.apprenticecodex.registry.SoundRegistry;
 import jp.aquafactory.apprenticecodex.registry.TagRegistry;
@@ -27,6 +29,7 @@ import net.minecraft.world.inventory.DataSlot;
 import net.minecraft.world.inventory.ResultContainer;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -201,7 +204,8 @@ public class ApprenticeDeskMenu extends AbstractContainerMenu {
 
     private static boolean isValidInk(ItemStack stack) {
         return !stack.isEmpty()
-                && (PartiallyUsedInkState.OfficialInk.fromOriginal(stack) != null
+                && (stack.is(ItemRegistry.CRUDE_INK.get())
+                || PartiallyUsedInkState.OfficialInk.fromOriginal(stack) != null
                 || PartiallyUsedInkState.readValid(stack).isPresent());
     }
 
@@ -233,7 +237,7 @@ public class ApprenticeDeskMenu extends AbstractContainerMenu {
             if (canInkCraft(spell)) {
                 var inkRarity = getInkRarity();
                 var spellLevel = spell.getMinLevelForRarity(inkRarity);
-                result = new ItemStack(jp.aquafactory.apprenticecodex.registry.ItemRegistry.WOODEN_WAND.get());
+                result = new ItemStack(ItemRegistry.WOODEN_WAND.get());
                 var spellContainer = ISpellContainer.create(1, false, false).mutableCopy();
                 spellContainer.addSpellAtIndex(spell, spellLevel, 0, true);
                 ISpellContainer.set(result, spellContainer.toImmutable());
@@ -276,6 +280,9 @@ public class ApprenticeDeskMenu extends AbstractContainerMenu {
 
     private @Nullable SpellRarity getInkRarity() {
         var stack = inkSlot.getItem();
+        if (stack.is(ItemRegistry.CRUDE_INK.get())) {
+            return CrudeInkItem.RARITY;
+        }
         var original = PartiallyUsedInkState.OfficialInk.fromOriginal(stack);
         if (original != null) {
             return original.rarity();
@@ -289,6 +296,10 @@ public class ApprenticeDeskMenu extends AbstractContainerMenu {
         var stack = inkSlot.getItem();
         var returnGlassBottle =
                 ApprenticeCodexServerConfig.apprenticeDeskReturnGlassBottleWhenInkDepleted();
+        if (stack.is(ItemRegistry.CRUDE_INK.get())) {
+            inkSlot.set(returnGlassBottle ? new ItemStack(Items.GLASS_BOTTLE) : ItemStack.EMPTY);
+            return;
+        }
         var original = PartiallyUsedInkState.OfficialInk.fromOriginal(stack);
         if (original != null) {
             inkSlot.set(PartiallyUsedInkState.consumeOriginal(

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/RecipeGenerator.java
@@ -2,11 +2,13 @@ package jp.aquafactory.apprenticecodex.datagen;
 
 import jp.aquafactory.apprenticecodex.recipe.smithing.AlchemistsFlaskSmithingRecipe;
 import jp.aquafactory.apprenticecodex.recipe.smithing.SpellbookCarryoverSmithingRecipe;
+import jp.aquafactory.apprenticecodex.utility.PotionContentsHelper;
 import net.minecraft.advancements.AdvancementRequirements;
 import net.minecraft.advancements.AdvancementRewards;
 import net.minecraft.advancements.critereon.RecipeUnlockedTrigger;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
@@ -17,13 +19,16 @@ import net.minecraft.data.recipes.ShapedRecipeBuilder;
 import net.minecraft.data.recipes.ShapelessRecipeBuilder;
 import net.minecraft.data.recipes.SmithingTransformRecipeBuilder;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.alchemy.PotionContents;
+import net.minecraft.world.item.alchemy.Potions;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.common.Tags;
+import net.neoforged.neoforge.common.crafting.DataComponentIngredient;
 import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.CompletableFuture;
 
@@ -43,6 +48,24 @@ public final class RecipeGenerator extends RecipeProvider {
 
     @Override
     protected void buildRecipes(@NotNull RecipeOutput recipeOutput) {
+        var waterPotion = PotionContentsHelper.createPotionStack(Items.POTION, Potions.WATER.value());
+        var waterPotionContents = waterPotion.getOrDefault(DataComponents.POTION_CONTENTS, PotionContents.EMPTY);
+
+        ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, ItemRegistry.CRUDE_INK.get())
+                // 1.21.1 ではポーション種別をデータコンポーネントで照合し、通常の水入り瓶だけを受理する。
+                .requires(DataComponentIngredient.of(
+                        false,
+                        DataComponents.POTION_CONTENTS,
+                        waterPotionContents,
+                        Items.POTION
+                ))
+                .requires(Items.LAPIS_LAZULI)
+                .requires(Items.REDSTONE)
+                .requires(Items.GLOW_BERRIES, 2)
+                .requires(Items.INK_SAC)
+                .unlockedBy(getHasName(Items.GLOW_BERRIES), has(Items.GLOW_BERRIES))
+                .save(recipeOutput, ItemRegistry.CRUDE_INK.getId());
+
         ShapedRecipeBuilder.shaped(RecipeCategory.DECORATIONS, ItemRegistry.APPRENTICE_DESK.get())
                 .pattern("CAC")
                 .pattern("SSS")

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientModBusEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientModBusEvents.java
@@ -660,6 +660,10 @@ public final class ClientModBusEvents {
 
     private static void registerItemColors(RegisterColorHandlersEvent.Item event) {
         event.register(SpellcastersFlask::getItemTintColor, ItemRegistry.SPELLCASTERS_FLASK.get(), ItemRegistry.ALCHEMISTS_FLASK.get());
+        event.register(
+                (stack, tintIndex) -> tintIndex == 0 ? 0x000000 : -1,
+                ItemRegistry.CRUDE_INK.get()
+        );
     }
 
     private static void registerRenderBuffers(RegisterRenderBuffersEvent event) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientModBusEvents.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/event/client/ClientModBusEvents.java
@@ -661,7 +661,8 @@ public final class ClientModBusEvents {
     private static void registerItemColors(RegisterColorHandlersEvent.Item event) {
         event.register(SpellcastersFlask::getItemTintColor, ItemRegistry.SPELLCASTERS_FLASK.get(), ItemRegistry.ALCHEMISTS_FLASK.get());
         event.register(
-                (stack, tintIndex) -> tintIndex == 0 ? 0x000000 : -1,
+                // 1.21.1 は tint のアルファ値も描画に使うため、不透明な黒を返す。
+                (stack, tintIndex) -> tintIndex == 0 ? 0xFF000000 : -1,
                 ItemRegistry.CRUDE_INK.get()
         );
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeDeskReworkGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeDeskReworkGameTests.java
@@ -12,6 +12,7 @@ import jp.aquafactory.apprenticecodex.block.apprenticedesk.ApprenticeDeskFeature
 import jp.aquafactory.apprenticecodex.block.apprenticedesk.ApprenticeDeskInkTooltip;
 import jp.aquafactory.apprenticecodex.block.apprenticedesk.ApprenticeDeskMenu;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
+import jp.aquafactory.apprenticecodex.item.apprenticedesk.CrudeInkItem;
 import jp.aquafactory.apprenticecodex.item.apprenticedesk.PartiallyUsedInkItem;
 import jp.aquafactory.apprenticecodex.item.apprenticedesk.PartiallyUsedInkState;
 import jp.aquafactory.apprenticecodex.item.magicitem.WoodenWand;
@@ -25,17 +26,25 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.gametest.framework.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.inventory.ContainerLevelAccess;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomData;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.item.alchemy.Potions;
+import net.minecraft.world.item.crafting.ShapelessRecipe;
 import net.minecraft.world.item.enchantment.Enchantments;
 import net.neoforged.neoforge.common.util.FakePlayer;
 import net.neoforged.neoforge.event.OnDatapackSyncEvent;
 import net.neoforged.neoforge.gametest.GameTestHolder;
 import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+
+import java.util.ArrayList;
 
 @GameTestHolder(ApprenticeCodex.MODID)
 @PrefixGameTestTemplate(false)
@@ -360,6 +369,161 @@ public final class ApprenticeDeskReworkGameTests {
         helper.succeed();
     }
 
+    @GameTest(template = TEMPLATE, batch = DESK_SPELL_CONFIG_BATCH)
+    public static void crudeInkCraftsCommonWandAndDepletesOnce(GameTestHelper helper) {
+        var previousSpellConfigManager = SpellConfigManager.INSTANCE;
+        try (var ignored = ApprenticeCodexServerConfig.useApprenticeDeskInkConfigOverrideForGameTest(
+                99, 4, 3, 3, 2, true
+        )) {
+            SpellConfigManager.INSTANCE = new SpellConfigManager();
+            SpellConfigManager.INSTANCE.handleServerConfigUpdate();
+            SpellConfigManager.onDatapackSync(new OnDatapackSyncEvent(
+                    helper.getLevel().getServer().getPlayerList(),
+                    null
+            ));
+
+            var player = createPlayer(helper, "crude_ink_common_wand_test");
+            var menu = new ApprenticeDeskMenu(0, player.getInventory(), ContainerLevelAccess.NULL);
+            var magicMissile = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+            MagicData.getPlayerMagicData(player).getSyncedData().learnSpell(magicMissile, false);
+
+            menu.container.setItem(ApprenticeDeskMenu.INK_SLOT, new ItemStack(ItemRegistry.CRUDE_INK.get()));
+            menu.container.setItem(ApprenticeDeskMenu.WAND_BASE_SLOT, new ItemStack(Items.STICK));
+            menu.container.setItem(ApprenticeDeskMenu.FOCUS_SLOT, new ItemStack(Items.ENDER_PEARL));
+
+            helper.assertTrue(menu.hasAllInputs(), "Apprentice Desk did not accept Crude Ink");
+            helper.assertTrue(menu.canInkCraft(magicMissile), "Crude Ink did not support a Common spell");
+            var selectedIndex = menu.getAvailableSpells().indexOf(magicMissile);
+            helper.assertTrue(selectedIndex >= 0 && menu.clickMenuButton(player, selectedIndex),
+                    "Crude Ink could not select Magic Missile");
+
+            var resultSlot = menu.getSlot(ApprenticeDeskMenu.RESULT_SLOT);
+            var result = resultSlot.getItem();
+            var spellContainer = ISpellContainer.get(result);
+            helper.assertTrue(result.is(ItemRegistry.WOODEN_WAND.get())
+                            && spellContainer != null
+                            && spellContainer.getSpellAtIndex(0).getSpell() == magicMissile
+                            && spellContainer.getSpellAtIndex(0).getLevel()
+                            == magicMissile.getMinLevelForRarity(SpellRarity.COMMON),
+                    "Crude Ink did not create an unmodified Common wand");
+            helper.assertTrue(result.getMaxDamage() == WoodenWand.MAX_DAMAGE && result.getDamageValue() == 0,
+                    "Crude Ink changed the wooden wand durability");
+
+            var taken = resultSlot.remove(1);
+            resultSlot.onTake(player, taken);
+            helper.assertTrue(menu.container.getItem(ApprenticeDeskMenu.INK_SLOT).is(Items.GLASS_BOTTLE),
+                    "Crude Ink did not return a bottle when bottle return was enabled");
+            helper.assertTrue(menu.container.getItem(ApprenticeDeskMenu.FOCUS_SLOT).is(Items.ENDER_PEARL),
+                    "Crude Ink crafting consumed the school focus");
+        } finally {
+            SpellConfigManager.INSTANCE = previousSpellConfigManager;
+        }
+
+        SpellConfigManager.INSTANCE = new SpellConfigManager();
+        SpellConfigManager.INSTANCE.handleServerConfigUpdate();
+        SpellConfigManager.onDatapackSync(new OnDatapackSyncEvent(
+                helper.getLevel().getServer().getPlayerList(),
+                null
+        ));
+        try (var ignored = ApprenticeCodexServerConfig.useApprenticeDeskInkConfigOverrideForGameTest(
+                99, 4, 3, 3, 2, false
+        )) {
+            var player = createPlayer(helper, "crude_ink_no_bottle_test");
+            var menu = new ApprenticeDeskMenu(0, player.getInventory(), ContainerLevelAccess.NULL);
+            menu.container.setItem(ApprenticeDeskMenu.INK_SLOT, new ItemStack(ItemRegistry.CRUDE_INK.get()));
+            menu.container.setItem(ApprenticeDeskMenu.WAND_BASE_SLOT, new ItemStack(Items.STICK));
+            menu.container.setItem(ApprenticeDeskMenu.FOCUS_SLOT, new ItemStack(Items.ENDER_PEARL));
+            var magicMissile = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+            MagicData.getPlayerMagicData(player).getSyncedData().learnSpell(magicMissile, false);
+            var selectedIndex = menu.getAvailableSpells().indexOf(magicMissile);
+            helper.assertTrue(selectedIndex >= 0 && menu.clickMenuButton(player, selectedIndex),
+                    "Crude Ink could not select Magic Missile with bottle return disabled");
+            var resultSlot = menu.getSlot(ApprenticeDeskMenu.RESULT_SLOT);
+            var taken = resultSlot.remove(1);
+            resultSlot.onTake(player, taken);
+            helper.assertTrue(menu.container.getItem(ApprenticeDeskMenu.INK_SLOT).isEmpty(),
+                    "Depleted Crude Ink remained when bottle return was disabled");
+        } finally {
+            SpellConfigManager.INSTANCE = previousSpellConfigManager;
+        }
+        helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crudeInkTooltipShowsSingleUseDescription(GameTestHelper helper) {
+        var stack = new ItemStack(ItemRegistry.CRUDE_INK.get());
+        var lines = new ArrayList<Component>();
+        stack.getItem().appendHoverText(
+                stack,
+                Item.TooltipContext.of(helper.getLevel()),
+                lines,
+                TooltipFlag.Default.NORMAL
+        );
+
+        helper.assertTrue(stack.getItem() instanceof CrudeInkItem,
+                "Crude Ink was registered with the wrong item class");
+        helper.assertTrue(lines.size() == 2
+                        && lines.get(0).getContents() instanceof TranslatableContents description
+                        && "item.apprenticecodex.crude_ink.desc".equals(description.getKey())
+                        && lines.get(1).getContents() instanceof TranslatableContents singleUse
+                        && "item.apprenticecodex.crude_ink.single_use".equals(singleUse.getKey())
+                        && singleUse.getArgs().length == 0,
+                "Crude Ink tooltip did not expose its description and single-use behavior");
+        helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void crudeInkRecipeRequiresExactShapelessIngredients(GameTestHelper helper) {
+        var recipe = (ShapelessRecipe) helper.getLevel().getRecipeManager()
+                .byKey(ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "crude_ink"))
+                .orElseThrow()
+                .value();
+        var waterBottle = jp.aquafactory.apprenticecodex.utility.PotionContentsHelper.createPotionStack(
+                Items.POTION,
+                Potions.WATER.value()
+        );
+        var valid = ApprenticeCodexGameTestScenarios.createCraftingInput(
+                new ItemStack(Items.GLOW_BERRIES),
+                new ItemStack(Items.INK_SAC),
+                waterBottle,
+                new ItemStack(Items.REDSTONE),
+                new ItemStack(Items.GLOW_BERRIES),
+                new ItemStack(Items.LAPIS_LAZULI)
+        );
+
+        helper.assertTrue(recipe.matches(valid, helper.getLevel()),
+                "Crude Ink recipe rejected the required ingredients in a shuffled layout");
+        helper.assertTrue(recipe.assemble(valid, helper.getLevel().registryAccess()).is(ItemRegistry.CRUDE_INK.get()),
+                "Crude Ink recipe returned the wrong item");
+        helper.assertTrue(recipe.getRemainingItems(valid).stream().allMatch(ItemStack::isEmpty),
+                "Crude Ink recipe returned a glass bottle before the ink was used");
+
+        var wrongPotion = ApprenticeCodexGameTestScenarios.createCraftingInput(
+                jp.aquafactory.apprenticecodex.utility.PotionContentsHelper.createPotionStack(
+                        Items.POTION,
+                        Potions.AWKWARD.value()
+                ),
+                new ItemStack(Items.LAPIS_LAZULI),
+                new ItemStack(Items.REDSTONE),
+                new ItemStack(Items.GLOW_BERRIES),
+                new ItemStack(Items.GLOW_BERRIES),
+                new ItemStack(Items.INK_SAC)
+        );
+        helper.assertFalse(recipe.matches(wrongPotion, helper.getLevel()),
+                "Crude Ink recipe accepted a non-water potion");
+
+        var missingBerry = ApprenticeCodexGameTestScenarios.createCraftingInput(
+                waterBottle,
+                new ItemStack(Items.LAPIS_LAZULI),
+                new ItemStack(Items.REDSTONE),
+                new ItemStack(Items.GLOW_BERRIES),
+                new ItemStack(Items.INK_SAC)
+        );
+        helper.assertFalse(recipe.matches(missingBerry, helper.getLevel()),
+                "Crude Ink recipe accepted only one Glow Berry");
+        helper.succeed();
+    }
+
     @GameTest(template = TEMPLATE)
     public static void woodenWandUsesOwnSpellAndConsumesDurabilityOnCooldown(GameTestHelper helper) {
         var player = createPlayer(helper, "wooden_wand_durability_test");
@@ -422,4 +586,5 @@ public final class ApprenticeDeskReworkGameTests {
     private static FakePlayer createPlayer(GameTestHelper helper, String name) {
         return BowGameTestSupport.createEquipmentTestPlayer(helper, new BlockPos(1, 2, 1), name);
     }
+
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/apprenticedesk/CrudeInkItem.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/apprenticedesk/CrudeInkItem.java
@@ -1,0 +1,33 @@
+package jp.aquafactory.apprenticecodex.item.apprenticedesk;
+
+import io.redspace.ironsspellbooks.api.spells.SpellRarity;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class CrudeInkItem extends Item {
+    public static final SpellRarity RARITY = SpellRarity.COMMON;
+
+    public CrudeInkItem() {
+        super(new Item.Properties().stacksTo(16));
+    }
+
+    @Override
+    public void appendHoverText(
+            @NotNull ItemStack stack,
+            @NotNull TooltipContext context,
+            @NotNull List<Component> lines,
+            @NotNull TooltipFlag flag
+    ) {
+        super.appendHoverText(stack, context, lines, flag);
+        lines.add(Component.translatable("item.apprenticecodex.crude_ink.desc")
+                .withStyle(ChatFormatting.GRAY));
+        lines.add(Component.translatable("item.apprenticecodex.crude_ink.single_use")
+                .withStyle(ChatFormatting.GRAY));
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/registry/CreativeTabRegistry.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/registry/CreativeTabRegistry.java
@@ -43,6 +43,7 @@ public final class CreativeTabRegistry {
 
     private static void addItemsToTab(CreativeModeTab.ItemDisplayParameters params, CreativeModeTab.Output output) {
         output.accept(ItemRegistry.APPRENTICE_DESK.get());
+        output.accept(ItemRegistry.CRUDE_INK.get());
         for (var source : PartiallyUsedInkState.OfficialInk.values()) {
             output.accept(PartiallyUsedInkState.create(source, source.creativeDefaultCapacity()));
         }

--- a/src/main/java/jp/aquafactory/apprenticecodex/registry/ItemRegistry.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/registry/ItemRegistry.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.registry;
 
 import jp.aquafactory.apprenticecodex.ApprenticeCodex;
 import jp.aquafactory.apprenticecodex.item.ArcaneCinderItem;
+import jp.aquafactory.apprenticecodex.item.apprenticedesk.CrudeInkItem;
 import jp.aquafactory.apprenticecodex.item.apprenticedesk.PartiallyUsedInkItem;
 import jp.aquafactory.apprenticecodex.item.blockitem.ArcanumInAJarItem;
 import jp.aquafactory.apprenticecodex.item.blockitem.ApprenticeDeskItem;
@@ -284,6 +285,8 @@ public final class ItemRegistry {
     public static final DeferredHolder<Item, Item> APPRENTICE_DESK =
             ITEMS.register("apprentice_desk",
                     () -> new ApprenticeDeskItem(BlockRegistry.APPRENTICE_DESK.get(), new Item.Properties()));
+    public static final DeferredHolder<Item, Item> CRUDE_INK =
+            ITEMS.register("crude_ink", CrudeInkItem::new);
     public static final DeferredHolder<Item, Item> PARTIALLY_USED_INK =
             ITEMS.register("partially_used_ink", PartiallyUsedInkItem::new);
     public static final DeferredHolder<Item, Item> SPELLCASTER_WORKBENCH =

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -31,6 +31,9 @@
   "item.apprenticecodex.partially_used_ink.desc": "Partially used; it can only be used to craft wands.",
   "item.apprenticecodex.partially_used_ink.remaining": "Uses remaining: %1$d/%2$d",
   "item.apprenticecodex.partially_used_ink.remaining_unknown": "Uses remaining: Unknown",
+  "item.apprenticecodex.crude_ink": "Crude Ink",
+  "item.apprenticecodex.crude_ink.desc": "Its quality is too poor for anything except crafting wands with Common spells.",
+  "item.apprenticecodex.crude_ink.single_use": "Consumed completely after one use.",
 
   "item.apprenticecodex.arcane_cinder": "Arcane Cinder",
   "item.apprenticecodex.wisdom_shard": "Shard of Wisdom",

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -31,6 +31,9 @@
   "item.apprenticecodex.partially_used_ink.desc": "使いかけのため、ワンドを作る用途にしか使えない。",
   "item.apprenticecodex.partially_used_ink.remaining": "残り使用回数: %1$d/%2$d",
   "item.apprenticecodex.partially_used_ink.remaining_unknown": "残り使用回数: 不明",
+  "item.apprenticecodex.crude_ink": "粗製のインク",
+  "item.apprenticecodex.crude_ink.desc": "品質が低すぎて、コモン魔法のワンドを作る用途にしかつかえない。",
+  "item.apprenticecodex.crude_ink.single_use": "一度で全て使い切る。",
 
   "item.apprenticecodex.arcane_cinder": "神秘の燃え殻",
   "item.apprenticecodex.wisdom_shard": "叡智の破片",

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -31,6 +31,9 @@
   "item.apprenticecodex.partially_used_ink.desc": "由于已经用过，只能用于制作法杖。",
   "item.apprenticecodex.partially_used_ink.remaining": "剩余使用次数：%1$d/%2$d",
   "item.apprenticecodex.partially_used_ink.remaining_unknown": "剩余使用次数：未知",
+  "item.apprenticecodex.crude_ink": "粗制墨水",
+  "item.apprenticecodex.crude_ink.desc": "品质太低，只能用于制作带有普通级法术的法杖。",
+  "item.apprenticecodex.crude_ink.single_use": "一次便会全部用完。",
 
   "item.apprenticecodex.arcane_cinder": "奥术余烬",
   "item.apprenticecodex.wisdom_shard": "智慧碎片",

--- a/src/main/resources/assets/apprenticecodex/models/item/crude_ink.json
+++ b/src/main/resources/assets/apprenticecodex/models/item/crude_ink.json
@@ -1,0 +1,3 @@
+{
+  "parent": "minecraft:item/potion"
+}


### PR DESCRIPTION
## 概要
- PR #764 の粗製インクを Minecraft 1.21.1 / NeoForge 向けに forward-port
- 見習いの机で Common 魔法の木の杖を作れる、1回使い切りのインクを追加
- アイテム登録、レシピ、モデル、3言語の翻訳、GameTest を追加

## 1.21.1向けの調整
- 水入り瓶のレシピ判定を `forge:partial_nbt` から `neoforge:components` / `minecraft:potion_contents` へ移行
- generated resource を `advancement/` と `recipe/` の単数形パスへ再生成
- item tint がARGBとして処理されるため、粗製インクの黒色を `0xFF000000` で完全不透明に指定

## 影響
秘術のエッセンスを使わずに、粗製インクからCommon魔法の木の杖を作成できます。インクは1回で使い切り、設定に応じて空瓶を返します。

## 確認
- `./gradlew.bat runData`
- `./gradlew.bat runGameTestServer`（必須916件すべて成功）
- `./gradlew.bat build`
- `runClient` で粗製インクのモデル・黒色表示・機能を確認済み