### PR TITLE
Iron's Spells 'n Spellbooksの要求バージョンを1.21.1側も最新に変更

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - Mod ローダー: NeoForge 21.1.219
 - 言語/実行環境: Java 21
 - ビルドツール: Gradle Wrapper（Windows では `./gradlew.bat` を使用）
-- 主要依存 MOD: Iron's Spells 'n Spellbooks（1.21.1-3.15.4）, Curios（9.5.1+1.21.1）, GeckoLib（4.8.3）
+- 主要依存 MOD: Iron's Spells 'n Spellbooks（1.21.1-3.16.2）, Iron's Lib（1.21.1-2.1.0）, Curios（9.5.1+1.21.1）, GeckoLib（4.8.3）
 - ローカルでは `JDK21_HOME` を設定し、必要に応じて `.\scripts\use-java.ps1` で `JAVA_HOME` を切り替える。
 - `main`（1.20.1）を触る場合のみ Java 17 を使う。
 

--- a/build.gradle
+++ b/build.gradle
@@ -303,6 +303,9 @@ dependencies {
     // ISSへの強依存を追加.
     implementation "io.redspace:irons_spellbooks:${irons_spells_version}"
 
+    // Iron's Lib.
+    runtimeOnly "io.redspace:irons_lib:${irons_lib_version}"
+
     // GeckoLib.
     implementation "software.bernie.geckolib:geckolib-neoforge-${minecraft_version}:${geckolib_version}"
 
@@ -394,6 +397,7 @@ var generateModMetadata = tasks.register("generateModMetadata", ProcessResources
             mod_issue_tracker_url  : mod_issue_tracker_url,
             mod_logo_file          : mod_logo_file,
             irons_spells_version   : irons_spells_version,
+            irons_lib_version      : irons_lib_version,
             geckolib_version       : geckolib_version,
             curios_version         : curios_version,
             patchouli_version      : patchouli_version,
@@ -429,6 +433,7 @@ tasks.named('processResources', ProcessResources).configure {
             mod_issue_tracker_url  : mod_issue_tracker_url,
             mod_logo_file          : mod_logo_file,
             irons_spells_version   : irons_spells_version,
+            irons_lib_version      : irons_lib_version,
             geckolib_version       : geckolib_version,
             curios_version         : curios_version,
             patchouli_version      : patchouli_version,

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,8 @@ mod_issue_tracker_url=https\://github.com/hexqua/apprentice_codex/issues
 mod_logo_file=apprenticecodex_logo.png
 
 ## Other MOD.
-irons_spells_version=1.21.1-3.15.4
+irons_spells_version=1.21.1-3.16.2
+irons_lib_version=1.21.1-2.1.0
 geckolib_version=4.8.3
 curios_version=9.5.1+1.21.1
 create_version=6.0.8

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -37,6 +37,13 @@ config="mixins.apprenticecodex.json"
     side="BOTH"
 
 [[dependencies.apprenticecodex]]
+    modId="irons_lib"
+    mandatory=true
+    versionRange="[${irons_lib_version},)"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies.apprenticecodex]]
     modId="geckolib"
     mandatory=true
     versionRange="[${geckolib_version},)"


### PR DESCRIPTION
- runtime 依存解決: 成功
- ./gradlew.bat build: 成功
- ./gradlew.bat runGameTestServer: 成功
- 必須 GameTest: 925件すべて成功
- 生成メタデータの依存下限: 正常