### PR TITLE
Sable対応

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@
 ```powershell
 .\scripts\use-java.ps1
 ./gradlew.bat runGameTestServerCompat
+./gradlew.bat runGameTestServerCreateSableAeronautics
 ./gradlew.bat runGameTestServerEasyMagic
 ./gradlew.bat runGameTestServerBetterCombat
 ./gradlew.bat runGameTestServerEpicFight
@@ -59,6 +60,7 @@
 ```powershell
 .\scripts\use-java.ps1
 ./gradlew.bat runClientCompat
+./gradlew.bat runClientCreateSableAeronautics
 ./gradlew.bat runClientEasyMagic
 ./gradlew.bat runClientBetterCombat
 ./gradlew.bat runClientEpicFight
@@ -87,6 +89,7 @@ Get-ChildItem build\libs\*.jar
 - `runGameTestServer` はサーバー側の登録、データ読込、レシピ、生成まわりの検証に使う。renderer / screen など client 専用の起動不良は別途 `runClient` で確認する。
 - `runGameTestServer` は専用 world `run/codex_gametest_clean` を毎回初期化してから起動する。通常の手動確認用 `run/world` は削除しない。
 - `runGameTestServerCompat` は Farmer's Delight / Create / Lodestone / Malum / Atlas API / Iron's Gems 'n Jewelry 連携の確認に使う。
+- `runGameTestServerCreateSableAeronautics` は Create / Sable / Create Simulated / Create Aeronautics / Create Offroad の導入とサーバー起動確認に使う。
 - `runGameTestServerEasyMagic` は Puzzles Lib / Easy Magic 連携の確認に使う。
 - `runGameTestServerBetterCombat` は Cloth Config / Better Combat 連携の確認に使う。
 - `runGameTestServerEpicFight` は Epic Fight 連携の確認に使う。
@@ -95,6 +98,7 @@ Get-ChildItem build\libs\*.jar
 - 実行ツール側の timeout で中断した場合は、初回失敗の記録を保持したまま、同じ source で強制終了 timeout を前回の 2 倍以上へ延長して追加実行する。GameTest 自身が報告した test timeout にはこの延長規則を適用しない。
 - いずれかの GameTest task が一度でも失敗した場合は、後続実行が成功しても失敗を省略せず、`.codex/skills/report-gametest-failure` を使用して観測結果を最終報告に残す。
 - `runClientEpicFightController` は Epic Fight / Controlify / YACL を入れ、実機コントローラー入力を確認する。
+- `runClientCreateSableAeronautics` は通常の client 環境へ Create / Sable / Create Aeronautics bundled jar を追加する。bundled jar には Create Simulated / Create Aeronautics / Create Offroad が含まれる。
 - `runClientCompatEasyBetter` は compat + Easy Magic + Better Combat を入れた実環境寄りの手動バランス確認用。Epic Fight は含めず、自動テスト対象にも含めない。
 - IntelliJ IDEA から client 構成を起動して `Unsupported major.minor version 65.0` が出る場合は、Project SDK / Gradle JVM / 古い実行構成が Java 17 を参照している。IDEA 側を JDK 21 にそろえ、`neoForgeIdeSync` を再実行し、必要なら古い Minecraft run configuration を削除して再生成する。
 - Botania は 1.21.1 側で API 依存を置いていないため、optional MOD profile には含めない。
@@ -125,6 +129,7 @@ Get-ChildItem build\libs\*.jar
 7. `main` から `1.20.1-main` への backport では、1.20.1 側で `./gradlew.bat runGameTestServer` と `./gradlew.bat build` を成功させる。
 8. optional MOD 連携に影響する変更では、対象に応じて特殊 GameTest / client 構成を追加実行する。
    - Create / Lodestone / Malum / Farmer's Delight / Atlas API / Iron's Gems 'n Jewelry: `./gradlew.bat runGameTestServerCompat`
+   - Create Aeronautics / Sable / Create Simulated / Create Offroad: `./gradlew.bat runGameTestServerCreateSableAeronautics`
    - Easy Magic / エンチャントメニュー: `./gradlew.bat runGameTestServerEasyMagic`
    - Better Combat / offhand / weapon_attributes: `./gradlew.bat runGameTestServerBetterCombat`
    - Epic Fight / mixin / capabilities / item_skins: `./gradlew.bat runGameTestServerEpicFight`

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 
 ```powershell
 ./gradlew.bat runGameTestServerCompat
+./gradlew.bat runGameTestServerCreateSableAeronautics
 ./gradlew.bat runGameTestServerEasyMagic
 ./gradlew.bat runGameTestServerBetterCombat
 ./gradlew.bat runGameTestServerEpicFight
 ```
 
 - `runGameTestServerCompat` は Farmer's Delight / Create / Lodestone / Malum / Atlas API / Iron's Gems 'n Jewelry 連携を確認します。
+- `runGameTestServerCreateSableAeronautics` は Create / Sable / Create Simulated / Create Aeronautics / Create Offroad の導入とサーバー起動を確認します。
 - `runGameTestServerEasyMagic` は Puzzles Lib / Easy Magic 連携を確認します。
 - `runGameTestServerBetterCombat` は Cloth Config / Better Combat 連携を確認します。
 - `runGameTestServerEpicFight` は Epic Fight 連携を確認します。
@@ -112,6 +114,7 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
 - IDEA から起動して `Unsupported major.minor version 65.0` が出る場合は、IDEA が Java 17 の Project SDK / Gradle JVM / 古い実行構成を掴んでいます。Project SDK と Gradle JVM を JDK 21 にしてから `neoForgeIdeSync` を再実行し、必要なら古い Minecraft run configuration を削除して再生成してください。
 - Gradle 同期後、通常の `runClient` に加えて次の client 構成を使えます。
   - `runClientCompat`
+  - `runClientCreateSableAeronautics`
   - `runClientEasyMagic`
   - `runClientBetterCombat`
   - `runClientEpicFight`
@@ -119,15 +122,17 @@ powershell -ExecutionPolicy Bypass -File .\scripts\use-java.ps1
   - `runClientCompatEasyBetter`
 - `runClientEpicFightController` は Epic Fight / Controlify / YACL を入れ、実機コントローラー入力を確認する構成です。
 - `runClientCompat` は Farmer's Delight / Create / Lodestone / Malum / Atlas API / Iron's Gems 'n Jewelry を入れた連携確認用の構成です。
+- `runClientCreateSableAeronautics` は通常の client 環境へ Create / Sable / Create Aeronautics bundled jar を追加します。bundled jar には、物理 contraption の中核である Create Simulated、飛行部品を提供する Create Aeronautics、地上車両部品を提供する Create Offroad が含まれます。
 - `runClientCompatEasyBetter` は compat + Easy Magic + Better Combat を入れた実環境寄りの手動バランス確認用です。Epic Fight は含めず、自動テスト対象にもしていません。
 - 一時的な組み合わせ確認では Gradle プロパティでも追加できます。
 
 ```powershell
 ./gradlew.bat runClient "-PdevRuntimeMods=create,malum"
 ./gradlew.bat runClient "-PdevRuntimeMods=epic_fight"
+./gradlew.bat runClient "-PdevRuntimeMods=create_sable_aeronautics"
 ```
 
-- `devRuntimeMods` には `compat`, `easy_magic`, `better_combat`, `epic_fight`, `epic_fight_controller`, `compat_easy_better` または個別名（`create`, `lodestone`, `malum`, `atlas_api`, `irons_jewelry`, `controlify` など）をカンマ区切りで指定できます。`irons_jewelry` は Atlas API も同時に追加します。
+- `devRuntimeMods` には `compat`, `create_sable_aeronautics`, `easy_magic`, `better_combat`, `epic_fight`, `epic_fight_controller`, `compat_easy_better` または個別名（`create`, `sable`, `aeronautics`, `lodestone`, `malum`, `atlas_api`, `irons_jewelry`, `controlify` など）をカンマ区切りで指定できます。`aeronautics` は Create と Sable、`irons_jewelry` は Atlas API も同時に追加します。
 - Botania は 1.21.1 側で API 依存を置いていないため、optional MOD profile には含めていません。
 - Better Combat と Epic Fight は干渉が大きいため、同時投入は通常確認では避けます。
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,30 @@ repositories {
         url = uri("https://maven.theillusivec4.top/")
     }
 
+    // Sable が提供する optional 互換 API.
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "SableCompanion"
+                url = uri("https://maven.ryanhcode.dev/releases")
+            }
+        }
+        filter {
+            includeGroup("dev.ryanhcode.sable-companion")
+        }
+    }
+
     // Create が同梱している Registrate API を compileOnly 参照するため.
-    maven {
-        url = uri("https://maven.tterrag.com/")
+    exclusiveContent {
+        forRepository {
+            maven {
+                name = "Registrate"
+                url = uri("https://mvn.devos.one/snapshots")
+            }
+        }
+        filter {
+            includeGroup("com.tterrag.registrate")
+        }
     }
 }
 
@@ -71,6 +92,8 @@ def requiredOptionalModsProperty = 'apprenticecodex.requiredOptionalMods'
 
 def optionalRuntimeModuleConfigurations = [
         create         : 'createRuntimeOnly',
+        sable          : 'sableRuntimeOnly',
+        create_aeronautics: 'createAeronauticsRuntimeOnly',
         puzzles_lib    : 'puzzlesLibRuntimeOnly',
         easy_magic     : 'easyMagicRuntimeOnly',
         cloth_config   : 'clothConfigRuntimeOnly',
@@ -91,6 +114,7 @@ def clientRuntimeModuleConfigurations = [
 
 def optionalRuntimeProfileModules = [
         compat              : ['create', 'lodestone', 'malum', 'atlas_api', 'irons_jewelry'],
+        create_sable_aeronautics: ['create', 'sable', 'create_aeronautics'],
         easy_magic          : ['puzzles_lib', 'easy_magic'],
         better_combat       : ['cloth_config', 'better_combat'],
         epic_fight          : ['epic_fight'],
@@ -106,6 +130,10 @@ def optionalRuntimeSelectorModules = optionalRuntimeProfileModules + [
         epicfightcontroller: ['epic_fight', 'yacl', 'controlify'],
         controlify    : ['yacl', 'controlify'],
         create        : ['create'],
+        sable         : ['sable'],
+        createaeronautics: ['create', 'sable', 'create_aeronautics'],
+        create_aeronautics: ['create', 'sable', 'create_aeronautics'],
+        aeronautics   : ['create', 'sable', 'create_aeronautics'],
         lodestone     : ['lodestone'],
         malum         : ['lodestone', 'malum'],
         atlasapi      : ['atlas_api'],
@@ -116,6 +144,7 @@ def optionalRuntimeSelectorModules = optionalRuntimeProfileModules + [
 
 def optionalRuntimeRequiredModIds = [
         compat       : 'create,lodestone,malum,atlas_api,irons_jewelry',
+        create_sable_aeronautics: 'create,sable,simulated,aeronautics,offroad,aeronautics_bundled',
         easy_magic   : 'puzzleslib,easymagic',
         better_combat: 'cloth_config,bettercombat',
         epic_fight   : 'epicfight',
@@ -182,6 +211,11 @@ neoForge {
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
         }
 
+        clientCreateSableAeronautics {
+            client()
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+        }
+
         clientEasyMagic {
             client()
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
@@ -211,6 +245,13 @@ neoForge {
             type = "gameTestServer"
             systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
             systemProperty requiredOptionalModsProperty, optionalRuntimeRequiredModIds.compat
+            programArguments.addAll '--world', gameTestServerWorldName
+        }
+
+        gameTestServerCreateSableAeronautics {
+            type = "gameTestServer"
+            systemProperty 'neoforge.enabledGameTestNamespaces', project.mod_id
+            systemProperty requiredOptionalModsProperty, optionalRuntimeRequiredModIds.create_sable_aeronautics
             programArguments.addAll '--world', gameTestServerWorldName
         }
 
@@ -283,17 +324,19 @@ configurations {
     }
 }
 
-['client', 'clientCompat', 'clientEasyMagic', 'clientBetterCombat', 'clientEpicFight', 'clientEpicFightController', 'clientCompatEasyBetter'].each {
+['client', 'clientCompat', 'clientCreateSableAeronautics', 'clientEasyMagic', 'clientBetterCombat', 'clientEpicFight', 'clientEpicFightController', 'clientCompatEasyBetter'].each {
     extendRunJavaClasspathWithClientRuntimeModules(it)
 }
 
 extendRunJavaClasspathWithOptionalRuntimeModules('clientCompat', expandOptionalRuntimeModules(['compat']))
+extendRunJavaClasspathWithOptionalRuntimeModules('clientCreateSableAeronautics', expandOptionalRuntimeModules(['create_sable_aeronautics']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientEasyMagic', expandOptionalRuntimeModules(['easy_magic']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientBetterCombat', expandOptionalRuntimeModules(['better_combat']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientEpicFight', expandOptionalRuntimeModules(['epic_fight']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientEpicFightController', expandOptionalRuntimeModules(['epic_fight_controller']))
 extendRunJavaClasspathWithOptionalRuntimeModules('clientCompatEasyBetter', expandOptionalRuntimeModules(['compat_easy_better']))
 extendRunJavaClasspathWithOptionalRuntimeModules('gameTestServerCompat', expandOptionalRuntimeModules(['compat']))
+extendRunJavaClasspathWithOptionalRuntimeModules('gameTestServerCreateSableAeronautics', expandOptionalRuntimeModules(['create_sable_aeronautics']))
 extendRunJavaClasspathWithOptionalRuntimeModules('gameTestServerEasyMagic', expandOptionalRuntimeModules(['easy_magic']))
 extendRunJavaClasspathWithOptionalRuntimeModules('gameTestServerBetterCombat', expandOptionalRuntimeModules(['better_combat']))
 extendRunJavaClasspathWithOptionalRuntimeModules('gameTestServerEpicFight', expandOptionalRuntimeModules(['epic_fight']))
@@ -325,9 +368,17 @@ dependencies {
     // Create.
     // Create 連携のコンパイル用.
     // ランタイム検証では compat profile から読み込む.
-    compileOnly "maven.modrinth:create:88L641Un"
+    compileOnly "maven.modrinth:create:${create_modrinth_version_id}"
     compileOnly "com.tterrag.registrate:Registrate:${registrate_version}"
-    add(optionalRuntimeModuleConfigurations.create, "maven.modrinth:create:88L641Un")
+    add(optionalRuntimeModuleConfigurations.create, "maven.modrinth:create:${create_modrinth_version_id}")
+
+    // Sable / Create Aeronautics.
+    // Sable 本体の内部 API へ結合せず、optional 互換 API として Companion を参照する。
+    // ランタイムは専用 profile に閉じ、通常環境へ物理 sub-level 実装を持ち込まない。
+    compileOnly "dev.ryanhcode.sable-companion:sable-companion-common-${minecraft_version}:${sable_companion_version}"
+    add(optionalRuntimeModuleConfigurations.sable, "maven.modrinth:sable:${sable_modrinth_version_id}")
+    add(optionalRuntimeModuleConfigurations.create_aeronautics,
+            "maven.modrinth:create-aeronautics:${create_aeronautics_modrinth_version_id}")
 
     // EasyMagic.
     // easy_magic profile から読み込む。通常開発ではエンチャント挙動の変化を避ける.
@@ -429,6 +480,8 @@ tasks.named('processResources', ProcessResources).configure {
             neo_version            : neo_version,
             loader_version_range   : loader_version_range,
             create_version         : create_version,
+            sable_version          : sable_version,
+            simulated_project_version: simulated_project_version,
             jade_version           : jade_version,
             lodestone_version      : lodestone_version,
             malum_version          : malum_version,

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ parchment_minecraft_version=1.21.1
 parchment_mappings_version=2024.11.17
 minecraft_version=1.21.1
 minecraft_version_range=[1.21.1]
-neo_version=21.1.219
+neo_version=21.1.228
 loader_version_range=[1,)
 
 ## Mod Properties
@@ -30,8 +30,14 @@ irons_spells_version=1.21.1-3.16.2
 irons_lib_version=1.21.1-2.1.0
 geckolib_version=4.8.3
 curios_version=9.5.1+1.21.1
-create_version=6.0.8
-registrate_version=MC1.20-1.3.11
+create_version=6.0.10
+create_modrinth_version_id=UjX6dr61
+registrate_version=MC1.21-1.3.0+67
+sable_version=2.0.3
+sable_modrinth_version_id=1L6XJqnY
+sable_companion_version=1.6.0
+simulated_project_version=1.3.0
+create_aeronautics_modrinth_version_id=w7zlLnea
 jei_version=19.27.0.336
 jade_version=15.10.5+neoforge
 lodestone_version=1.8.2

--- a/src/main/java/jp/aquafactory/apprenticecodex/ApprenticeCodex.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/ApprenticeCodex.java
@@ -5,6 +5,7 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexClientConfig;
 import jp.aquafactory.apprenticecodex.capability.codexspelldata.CodexSpellStateTypeRegister;
 import jp.aquafactory.apprenticecodex.compat.create.CreateCompat;
 import jp.aquafactory.apprenticecodex.compat.epicfight.EpicFightCompat;
+import jp.aquafactory.apprenticecodex.compat.sable.SableCompat;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexCommonConfig;
 import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.event.ApprenticeDeskConfigSyncEvents;
@@ -81,6 +82,7 @@ public class ApprenticeCodex
         MenuRegistry.register(modEventBus);
         CreativeTabRegistry.register(modEventBus);
         CreateCompat.register(modEventBus);
+        SableCompat.register(modEventBus);
         EpicFightCompat.register(modEventBus);
         ParticleRegistry.PARTICLES.register(modEventBus);
         RecipeRegistry.register(modEventBus);

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserBlockEntity.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.items.IItemHandler;
@@ -276,7 +277,7 @@ public final class SpellDispenserBlockEntity extends BlockEntity
             return;
         }
 
-        if (!(state.getBlock() instanceof SpellDispenser)) {
+        if (!(state.getBlock() instanceof SpellDispenser spellDispenser)) {
             stopContinuousCast(true);
             return;
         }
@@ -306,6 +307,12 @@ public final class SpellDispenserBlockEntity extends BlockEntity
             return;
         }
 
+        SpellDispenserCastHelper.syncContinuousCastTransform(
+                level,
+                activeContinuousCast,
+                Vec3.atCenterOf(pos),
+                Vec3.atLowerCornerOf(spellDispenser.getFacing(state).getNormal())
+        );
         if (!SpellDispenserCastHelper.tickContinuousCast(level, activeContinuousCast)) {
             startCooldown(activeContinuousCast.consumeFinishedCooldownTicks());
             activeContinuousCast = null;

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserCastFrameBridge.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserCastFrameBridge.java
@@ -1,0 +1,50 @@
+package jp.aquafactory.apprenticecodex.block.spelldispenser;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * Spell Dispenser のローカルな発動座標を、実際に魔法を実行する座標系へ投影する境界。
+ */
+public final class SpellDispenserCastFrameBridge {
+    private static final Projector IDENTITY_PROJECTOR = (level, castBasePosition, frame) -> frame;
+    private static Projector projector = IDENTITY_PROJECTOR;
+
+    private SpellDispenserCastFrameBridge() {
+    }
+
+    public static CastFrame project(ServerLevel level, Vec3 castBasePosition, CastFrame frame) {
+        return Objects.requireNonNull(projector.project(level, castBasePosition, frame));
+    }
+
+    public static void registerProjector(Projector newProjector) {
+        projector = Objects.requireNonNull(newProjector);
+    }
+
+    public static ProjectorOverride useProjectorForGameTest(Projector testProjector) {
+        var previous = projector;
+        registerProjector(testProjector);
+        return () -> projector = previous;
+    }
+
+    public record CastFrame(Vec3 origin, Vec3 forward) {
+        public CastFrame {
+            Objects.requireNonNull(origin);
+            Objects.requireNonNull(forward);
+        }
+    }
+
+    @FunctionalInterface
+    public interface Projector {
+        @NotNull CastFrame project(ServerLevel level, Vec3 castBasePosition, CastFrame frame);
+    }
+
+    @FunctionalInterface
+    public interface ProjectorOverride extends AutoCloseable {
+        @Override
+        void close();
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserCastHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserCastHelper.java
@@ -164,16 +164,12 @@ public final class SpellDispenserCastHelper {
         if (casterProfile == null) {
             return CastResult.missingOwnerProfile(validation);
         }
-        var localCastTransform = resolveCastTransform(castBasePosition, forward, profile);
-        var castFrame = SpellDispenserCastFrameBridge.project(
+        var proxy = createProxy(
                 level,
-                castBasePosition,
-                new SpellDispenserCastFrameBridge.CastFrame(
-                        localCastTransform.origin(),
-                        Vec3.directionFromRotation(localCastTransform.pitch(), localCastTransform.yaw())
-                )
+                resolveProjectedCastTransform(level, castBasePosition, forward, profile),
+                casterProfile,
+                profile
         );
-        var proxy = createProxy(level, resolveCastTransform(castFrame), casterProfile, profile);
         var trackedAnchor = createTrackedAnchorForExplicitProfile(level, proxy, profile, spell.getCastType());
         var spellCaster = resolveSpellCaster(proxy, trackedAnchor);
 
@@ -364,7 +360,12 @@ public final class SpellDispenserCastHelper {
         }
 
         var spellId = spell.getSpellResource();
-        var proxy = createProxy(level, castBasePosition, forward, casterProfile, profile);
+        var proxy = createProxy(
+                level,
+                resolveProjectedCastTransform(level, castBasePosition, forward, profile),
+                casterProfile,
+                profile
+        );
         var trackedAnchor = createTrackedAnchorForExplicitProfile(level, proxy, profile, spell.getCastType());
         var spellCaster = resolveSpellCaster(proxy, trackedAnchor);
         var magicData = MagicData.getPlayerMagicData(proxy);
@@ -433,12 +434,22 @@ public final class SpellDispenserCastHelper {
         );
     }
 
-    public static void syncContinuousCastTransform(ContinuousCastSession session, Vec3 castBasePosition, Vec3 forward) {
+    public static void syncContinuousCastTransform(
+            ServerLevel level,
+            ContinuousCastSession session,
+            Vec3 castBasePosition,
+            Vec3 forward
+    ) {
         if (session.isFinished()) {
             return;
         }
 
-        var castTransform = resolveCastTransform(castBasePosition, forward, session.profile());
+        var castTransform = resolveProjectedCastTransform(
+                level,
+                castBasePosition,
+                forward,
+                session.profile()
+        );
         moveCaster(session.proxy(), castTransform);
         syncTrackedAnchor(session);
     }
@@ -655,17 +666,6 @@ public final class SpellDispenserCastHelper {
 
     private static LivingEntity createProxy(
             ServerLevel level,
-            Vec3 castBasePosition,
-            Vec3 forward,
-            GameProfile casterProfile,
-            SpellDispenserSpellProfile profile
-    ) {
-        var castTransform = resolveCastTransform(castBasePosition, forward, profile);
-        return createProxy(level, castTransform, casterProfile, profile);
-    }
-
-    private static LivingEntity createProxy(
-            ServerLevel level,
             CastTransform castTransform,
             GameProfile casterProfile,
             SpellDispenserSpellProfile profile
@@ -744,6 +744,24 @@ public final class SpellDispenserCastHelper {
     private static CastTransform resolveCastTransform(SpellDispenserCastFrameBridge.CastFrame frame) {
         var normalizedForward = normalizeForward(frame.forward());
         return new CastTransform(frame.origin(), resolveYaw(normalizedForward), resolvePitch(normalizedForward));
+    }
+
+    private static CastTransform resolveProjectedCastTransform(
+            ServerLevel level,
+            Vec3 castBasePosition,
+            Vec3 forward,
+            SpellDispenserSpellProfile profile
+    ) {
+        var localCastTransform = resolveCastTransform(castBasePosition, forward, profile);
+        var projectedFrame = SpellDispenserCastFrameBridge.project(
+                level,
+                castBasePosition,
+                new SpellDispenserCastFrameBridge.CastFrame(
+                        localCastTransform.origin(),
+                        Vec3.directionFromRotation(localCastTransform.pitch(), localCastTransform.yaw())
+                )
+        );
+        return resolveCastTransform(projectedFrame);
     }
 
     private static Vec3 resolveCastOrigin(Vec3 castBasePosition, Vec3 forward, SpellDispenserSpellProfile profile) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserCastHelper.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/block/spelldispenser/SpellDispenserCastHelper.java
@@ -164,7 +164,16 @@ public final class SpellDispenserCastHelper {
         if (casterProfile == null) {
             return CastResult.missingOwnerProfile(validation);
         }
-        var proxy = createProxy(level, castBasePosition, forward, casterProfile, profile);
+        var localCastTransform = resolveCastTransform(castBasePosition, forward, profile);
+        var castFrame = SpellDispenserCastFrameBridge.project(
+                level,
+                castBasePosition,
+                new SpellDispenserCastFrameBridge.CastFrame(
+                        localCastTransform.origin(),
+                        Vec3.directionFromRotation(localCastTransform.pitch(), localCastTransform.yaw())
+                )
+        );
+        var proxy = createProxy(level, resolveCastTransform(castFrame), casterProfile, profile);
         var trackedAnchor = createTrackedAnchorForExplicitProfile(level, proxy, profile, spell.getCastType());
         var spellCaster = resolveSpellCaster(proxy, trackedAnchor);
 
@@ -652,6 +661,15 @@ public final class SpellDispenserCastHelper {
             SpellDispenserSpellProfile profile
     ) {
         var castTransform = resolveCastTransform(castBasePosition, forward, profile);
+        return createProxy(level, castTransform, casterProfile, profile);
+    }
+
+    private static LivingEntity createProxy(
+            ServerLevel level,
+            CastTransform castTransform,
+            GameProfile casterProfile,
+            SpellDispenserSpellProfile profile
+    ) {
         return switch (resolveCasterMode(profile)) {
             case FAKE_PLAYER -> createFakePlayerProxy(level, casterProfile, castTransform);
             case NEUTRAL_LIVING -> createNeutralLivingProxy(level, castTransform);
@@ -721,6 +739,11 @@ public final class SpellDispenserCastHelper {
         var yaw = resolveYaw(normalizedForward) + profile.yawOffset();
         var pitch = Mth.clamp(resolvePitch(normalizedForward) + profile.pitchOffset(), -90.0F, 90.0F);
         return new CastTransform(resolveCastOrigin(castBasePosition, normalizedForward, profile), yaw, pitch);
+    }
+
+    private static CastTransform resolveCastTransform(SpellDispenserCastFrameBridge.CastFrame frame) {
+        var normalizedForward = normalizeForward(frame.forward());
+        return new CastTransform(frame.origin(), resolveYaw(normalizedForward), resolvePitch(normalizedForward));
     }
 
     private static Vec3 resolveCastOrigin(Vec3 castBasePosition, Vec3 forward, SpellDispenserSpellProfile profile) {

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/create/SpellDispenserMovementBehaviour.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/create/SpellDispenserMovementBehaviour.java
@@ -138,7 +138,12 @@ public final class SpellDispenserMovementBehaviour implements MovementBehaviour 
                 return;
             }
 
-            SpellDispenserCastHelper.syncContinuousCastTransform(runtime.session(), resolveCastBasePosition(context), resolveForward(context));
+            SpellDispenserCastHelper.syncContinuousCastTransform(
+                    serverLevel,
+                    runtime.session(),
+                    resolveCastBasePosition(context),
+                    resolveForward(context)
+            );
             if (!SpellDispenserCastHelper.tickContinuousCast(serverLevel, runtime.session())) {
                 startCooldown(context, runtime.session().consumeFinishedCooldownTicks());
                 getOrCreateRuntimeState(context).setContinuousRuntime(null);

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/sable/SableCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/sable/SableCompat.java
@@ -1,0 +1,38 @@
+package jp.aquafactory.apprenticecodex.compat.sable;
+
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
+
+public final class SableCompat {
+    public static final String MOD_ID = "sable";
+    private static final String SPELL_DISPENSER_COMPAT_CLASS =
+            "jp.aquafactory.apprenticecodex.compat.sable.SpellDispenserSableCompat";
+
+    private SableCompat() {
+    }
+
+    public static void register(IEventBus modEventBus) {
+        modEventBus.addListener(SableCompat::onCommonSetup);
+    }
+
+    private static void onCommonSetup(FMLCommonSetupEvent event) {
+        if (!ModList.get().isLoaded(MOD_ID)) {
+            return;
+        }
+
+        event.enqueueWork(SableCompat::registerSpellDispenserCompat);
+    }
+
+    private static void registerSpellDispenserCompat() {
+        try {
+            var compatClass = Class.forName(SPELL_DISPENSER_COMPAT_CLASS);
+            compatClass.getMethod("register").invoke(null);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Sable 用 Spell Dispenser 互換の初期化に失敗しました", exception);
+        }
+
+        ApprenticeCodex.LOGGER.info("Sable Spell Dispenser compat enabled");
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/compat/sable/SpellDispenserSableCompat.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/compat/sable/SpellDispenserSableCompat.java
@@ -1,0 +1,33 @@
+package jp.aquafactory.apprenticecodex.compat.sable;
+
+import dev.ryanhcode.sable.companion.SableCompanion;
+import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserCastFrameBridge;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.phys.Vec3;
+
+@SuppressWarnings("unused")
+public final class SpellDispenserSableCompat {
+    private SpellDispenserSableCompat() {
+    }
+
+    public static void register() {
+        SpellDispenserCastFrameBridge.registerProjector(SpellDispenserSableCompat::projectCastFrame);
+    }
+
+    private static SpellDispenserCastFrameBridge.CastFrame projectCastFrame(
+            ServerLevel level,
+            Vec3 castBasePosition,
+            SpellDispenserCastFrameBridge.CastFrame frame
+    ) {
+        var subLevel = SableCompanion.INSTANCE.getContaining(level, castBasePosition);
+        if (subLevel == null) {
+            return frame;
+        }
+
+        var pose = subLevel.logicalPose();
+        return new SpellDispenserCastFrameBridge.CastFrame(
+                pose.transformPosition(frame.origin()),
+                pose.transformNormal(frame.forward()).normalize()
+        );
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellDispenserGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellDispenserGameTests.java
@@ -344,4 +344,29 @@ public final class ApprenticeCodexSpellDispenserGameTests {
     public static void spellDispenserCastFrameProjectionAppliesProfileOffsetsBeforeProjection(GameTestHelper helper) {
         SpellDispenserGameTestScenarios.spellDispenserCastFrameProjectionAppliesProfileOffsetsBeforeProjection(helper);
     }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserContinuousProjectionUpdatesFireBreathAnchor(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserContinuousProjectionUpdatesFireBreathAnchor(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserContinuousProjectionUpdatesBlazeStormShots(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserContinuousProjectionUpdatesBlazeStormShots(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserContinuousProjectionUpdatesArcaneBeam(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserContinuousProjectionUpdatesArcaneBeam(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserContinuousProjectionUpdatesFujinWeapon(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserContinuousProjectionUpdatesFujinWeapon(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserBlockEntityReprojectsContinuousCastEachTick(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserBlockEntityReprojectsContinuousCastEachTick(helper);
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellDispenserGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSpellDispenserGameTests.java
@@ -329,4 +329,19 @@ public final class ApprenticeCodexSpellDispenserGameTests {
     public static void spellDispenserCastHelperSupportsSpectralHammer(GameTestHelper helper) {
         SpellDispenserGameTestScenarios.spellDispenserCastHelperSupportsSpectralHammer(helper);
     }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserCastFrameProjectionMovesAndRotatesMagicMissile(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserCastFrameProjectionMovesAndRotatesMagicMissile(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserCastFrameProjectionKeepsShockEndpointsInWorldFrame(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserCastFrameProjectionKeepsShockEndpointsInWorldFrame(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void spellDispenserCastFrameProjectionAppliesProfileOffsetsBeforeProjection(GameTestHelper helper) {
+        SpellDispenserGameTestScenarios.spellDispenserCastFrameProjectionAppliesProfileOffsetsBeforeProjection(helper);
+    }
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellDispenserGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellDispenserGameTestScenarios.java
@@ -12,6 +12,7 @@ import io.redspace.ironsspellbooks.entity.spells.spectral_hammer.SpectralHammer;
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenser;
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserBlockEntity;
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserCastAnchorMode;
+import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserCastFrameBridge;
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserCastHelper;
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserCasterMode;
 import jp.aquafactory.apprenticecodex.block.spelldispenser.SpellDispenserManaFluidHelper;
@@ -27,6 +28,7 @@ import jp.aquafactory.apprenticecodex.enchantment.Enchantments;
 import jp.aquafactory.apprenticecodex.item.flask.SpellcastersFlask;
 import jp.aquafactory.apprenticecodex.spell.compoundphial.CompoundPhialProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.precisionjack.PrecisionJackKnifeEntity;
+import jp.aquafactory.apprenticecodex.spell.shock.ShockBoltEntity;
 import jp.aquafactory.apprenticecodex.registry.BlockRegistry;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
@@ -64,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 final class SpellDispenserGameTestScenarios {
 
@@ -301,6 +304,131 @@ final class SpellDispenserGameTestScenarios {
         helper.assertTrue(!(owner instanceof Player), "Spell Dispenser neutral living cast used a Player owner: " + owner);
         helper.assertTrue(!(owner instanceof FakePlayer), "Spell Dispenser neutral living cast used a FakePlayer owner: " + owner);
         assertNoSpellDispenserProxy(helper, castPos, scrollStack, "Spell Dispenser neutral living cast left proxy state behind");
+        helper.succeed();
+    }
+
+    static void spellDispenserCastFrameProjectionMovesAndRotatesMagicMissile(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+        var castBasePosition = helper.absoluteVec(new Vec3(1.5D, 2.5D, 1.5D));
+        var projectedOrigin = helper.absoluteVec(new Vec3(4.5D, 3.0D, 4.5D));
+        var projectedForward = new Vec3(1.0D, 0.0D, 0.0D);
+        var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+        var spawnedProjectiles = new ArrayList<io.redspace.ironsspellbooks.entity.spells.magic_missile.MagicMissileProjectile>();
+        java.util.function.Consumer<EntityJoinLevelEvent> projectileListener = event -> {
+            if (event.getLevel() == level
+                    && event.getEntity() instanceof io.redspace.ironsspellbooks.entity.spells.magic_missile.MagicMissileProjectile projectile) {
+                spawnedProjectiles.add(projectile);
+            }
+        };
+
+        NeoForge.EVENT_BUS.addListener(projectileListener);
+        try (var ignored = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) ->
+                new SpellDispenserCastFrameBridge.CastFrame(projectedOrigin, projectedForward))) {
+            var result = SpellDispenserCastHelper.tryCast(
+                    level,
+                    castBasePosition,
+                    new Vec3(0.0D, 0.0D, 1.0D),
+                    createSpellScroll(spell),
+                    null
+            );
+            helper.assertTrue(result.succeeded(), "Projected Spell Dispenser Magic Missile cast failed");
+        } finally {
+            NeoForge.EVENT_BUS.unregister(projectileListener);
+        }
+
+        helper.assertTrue(!spawnedProjectiles.isEmpty(), "Projected Spell Dispenser cast did not spawn Magic Missile");
+        var projectile = spawnedProjectiles.get(0);
+        helper.assertTrue(Math.abs(projectile.getX() - projectedOrigin.x) < 0.01D
+                        && Math.abs(projectile.getZ() - projectedOrigin.z) < 0.01D,
+                "Magic Missile did not spawn at the projected cast origin: " + projectile.position());
+        var movement = projectile.getDeltaMovement().normalize();
+        helper.assertTrue(movement.dot(projectedForward) > 0.999D,
+                "Magic Missile did not use the projected forward direction: " + projectile.getDeltaMovement());
+        helper.assertTrue(Math.abs(projectile.getDeltaMovement().y) < 1.0E-6D
+                        && Math.abs(projectile.getDeltaMovement().z) < 1.0E-6D,
+                "Magic Missile received an unexpected velocity component: " + projectile.getDeltaMovement());
+        helper.succeed();
+    }
+
+    static void spellDispenserCastFrameProjectionKeepsShockEndpointsInWorldFrame(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+        var castBasePosition = helper.absoluteVec(new Vec3(1.5D, 2.5D, 1.5D));
+        var projectedOrigin = helper.absoluteVec(new Vec3(3.5D, 2.5D, 2.5D));
+        var projectedForward = new Vec3(0.0D, 0.0D, 1.0D);
+        var targetPos = new BlockPos(3, 2, 6);
+        helper.setBlock(targetPos, Blocks.GOLD_BLOCK);
+
+        try (var ignored = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) ->
+                new SpellDispenserCastFrameBridge.CastFrame(projectedOrigin, projectedForward))) {
+            var result = SpellDispenserCastHelper.tryCast(
+                    level,
+                    castBasePosition,
+                    new Vec3(1.0D, 0.0D, 0.0D),
+                    createSpellScroll(SpellRegistry.SHOCK.get()),
+                    null
+            );
+            helper.assertTrue(result.succeeded(), "Projected Spell Dispenser Shock cast failed");
+        }
+
+        var bolts = level.getEntitiesOfClass(
+                ShockBoltEntity.class,
+                new AABB(projectedOrigin, helper.absoluteVec(Vec3.atCenterOf(targetPos))).inflate(2.0D)
+        );
+        helper.assertTrue(!bolts.isEmpty(), "Projected Spell Dispenser cast did not spawn Shock Bolt");
+        var bolt = bolts.get(0);
+        var expectedStart = projectedOrigin.add(0.0D, -0.22D, 0.0D).add(projectedForward.scale(0.55D));
+        assertVecClose(helper, expectedStart, bolt.position(), 0.01D,
+                "Shock Bolt start was not projected into the world frame");
+
+        var end = bolt.getEndPosition();
+        var targetCenter = Vec3.atCenterOf(helper.absolutePos(targetPos));
+        // Shock Bolt の同期終点は float のため、GameTest が配置される大座標では1ブロック程度丸められる。
+        helper.assertTrue(end.distanceToSqr(targetCenter) <= 4.0D,
+                "Shock Bolt did not stop near the projected target block: end=" + end + ", target=" + targetCenter);
+        helper.assertTrue(end.subtract(bolt.position()).normalize().dot(projectedForward) > 0.8D,
+                "Shock Bolt end remained in a different coordinate frame: " + end);
+        helper.succeed();
+    }
+
+    static void spellDispenserCastFrameProjectionAppliesProfileOffsetsBeforeProjection(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+        var castBasePosition = helper.absoluteVec(new Vec3(2.5D, 2.5D, 2.5D));
+        var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.MAGIC_MISSILE_SPELL.get();
+        var profile = new SpellDispenserSpellProfile(
+                SpellDispenserCastAnchorMode.AUTO,
+                SpellDispenserCasterMode.NEUTRAL_LIVING,
+                0.3D,
+                0.5D,
+                0.25D,
+                90.0F,
+                0.0F,
+                false
+        );
+        var capturedFrame = new AtomicReference<SpellDispenserCastFrameBridge.CastFrame>();
+
+        try (var ignoredProfiles = SpellDispenserSpellProfileManager.useProfilesForGameTest(Map.of(spell.getSpellResource(), profile));
+             var ignoredProjector = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) -> {
+                 capturedFrame.set(frame);
+                 return frame;
+             })) {
+            var result = SpellDispenserCastHelper.tryCast(
+                    level,
+                    castBasePosition,
+                    new Vec3(0.0D, 0.0D, 1.0D),
+                    createSpellScroll(spell),
+                    null
+            );
+            helper.assertTrue(result.succeeded(), "Offset Spell Dispenser Magic Missile cast failed");
+        }
+
+        var frame = capturedFrame.get();
+        helper.assertTrue(frame != null, "Spell Dispenser cast frame projector was not invoked");
+        var expectedOrigin = castBasePosition.add(-0.25D, 0.5D, 1.0D);
+        assertVecClose(helper, expectedOrigin, frame.origin(), 1.0E-6D,
+                "Spell profile position offsets were not applied before projection");
+        var expectedForward = Vec3.directionFromRotation(0.0F, 90.0F).normalize();
+        helper.assertTrue(frame.forward().normalize().dot(expectedForward) > 0.999D,
+                "Spell profile angle offsets were not applied before projection: " + frame.forward());
         helper.succeed();
     }
     static void spellDispenserCastHelperCompletesLongCastImmediately(GameTestHelper helper) {
@@ -1773,6 +1901,17 @@ final class SpellDispenserGameTestScenarios {
 
         var remainingAnchors = helper.getLevel().getEntitiesOfClass(SpellDispenserAnchorEntity.class, proxyBox);
         helper.assertTrue(remainingAnchors.isEmpty(), message + " (tracked anchors): " + remainingAnchors.size());
+    }
+
+    private static void assertVecClose(
+            GameTestHelper helper,
+            Vec3 expected,
+            Vec3 actual,
+            double tolerance,
+            String message
+    ) {
+        helper.assertTrue(expected.distanceToSqr(actual) <= tolerance * tolerance,
+                message + ": expected=" + expected + ", actual=" + actual);
     }
 
     private static Object createSpellDispenserMovementHarness(

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellDispenserGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellDispenserGameTestScenarios.java
@@ -26,7 +26,10 @@ import jp.aquafactory.apprenticecodex.config.ApprenticeCodexServerConfig;
 import jp.aquafactory.apprenticecodex.entity.spelldispenser.SpellDispenserAnchorEntity;
 import jp.aquafactory.apprenticecodex.enchantment.Enchantments;
 import jp.aquafactory.apprenticecodex.item.flask.SpellcastersFlask;
+import jp.aquafactory.apprenticecodex.spell.arcanebeam.ArcaneBeamEntity;
 import jp.aquafactory.apprenticecodex.spell.compoundphial.CompoundPhialProjectileEntity;
+import jp.aquafactory.apprenticecodex.spell.fujin.FujinKatanaEntity;
+import jp.aquafactory.apprenticecodex.spell.fujin.FujinSlashProjectileEntity;
 import jp.aquafactory.apprenticecodex.spell.precisionjack.PrecisionJackKnifeEntity;
 import jp.aquafactory.apprenticecodex.spell.shock.ShockBoltEntity;
 import jp.aquafactory.apprenticecodex.registry.BlockRegistry;
@@ -578,6 +581,289 @@ final class SpellDispenserGameTestScenarios {
             SpellDispenserCastHelper.finishContinuousCast(level, session, true);
             assertNoSpellDispenserProxy(helper, castPos, scrollStack, "Spell Dispenser tracked anchor was left behind after Fire Breath cleanup");
         });
+    }
+    static void spellDispenserContinuousProjectionUpdatesFireBreathAnchor(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+            var castBasePosition = helper.absoluteVec(new Vec3(1.5D, 2.5D, 1.5D));
+            var projectedOrigin = helper.absoluteVec(new Vec3(4.5D, 3.0D, 4.5D));
+            var projectedForward = new Vec3(1.0D, 0.0D, 0.0D);
+            var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.FIRE_BREATH_SPELL.get();
+            var scrollStack = createSpellScroll(spell);
+
+            try (var ignored = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) ->
+                    new SpellDispenserCastFrameBridge.CastFrame(projectedOrigin, projectedForward))) {
+                var startResult = SpellDispenserCastHelper.tryStartContinuousCast(
+                        level,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D),
+                        SpellDispenserSpellValidator.validate(scrollStack),
+                        scrollStack,
+                        null
+                );
+                helper.assertTrue(startResult.result().succeeded() && startResult.session() != null,
+                        "Projected Spell Dispenser Fire Breath did not start");
+
+                var session = startResult.session();
+                SpellDispenserCastHelper.syncContinuousCastTransform(
+                        level,
+                        session,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D)
+                );
+                SpellDispenserCastHelper.tickContinuousCast(level, session);
+
+                var anchor = session.trackedAnchor();
+                helper.assertTrue(anchor != null, "Projected Fire Breath did not create its tracked anchor");
+                helper.assertTrue(anchor.getLookAngle().normalize().dot(projectedForward) > 0.999D,
+                        "Projected Fire Breath anchor did not use the projected direction: " + anchor.getLookAngle());
+                helper.assertTrue(anchor.getEyePosition().distanceToSqr(session.proxy().getEyePosition()) < 1.0E-6D,
+                        "Projected Fire Breath anchor did not follow the proxy caster");
+
+                var projectiles = level.getEntitiesOfClass(
+                        FireBreathProjectile.class,
+                        new AABB(projectedOrigin, projectedOrigin).inflate(4.0D)
+                );
+                helper.assertTrue(!projectiles.isEmpty(), "Projected Fire Breath did not spawn in the world frame");
+                helper.assertTrue(projectiles.get(0).getOwner() == anchor,
+                        "Projected Fire Breath did not retain its tracked anchor owner");
+
+                SpellDispenserCastHelper.finishContinuousCast(level, session, true);
+                helper.assertTrue(anchor.isRemoved(), "Projected Fire Breath anchor remained after cleanup");
+        }
+        helper.succeed();
+    }
+    static void spellDispenserContinuousProjectionUpdatesBlazeStormShots(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+            var castBasePosition = helper.absoluteVec(new Vec3(1.5D, 2.5D, 1.5D));
+            var projectedOrigin = helper.absoluteVec(new Vec3(4.5D, 3.0D, 4.5D));
+            var projectedForward = new Vec3(-1.0D, 0.0D, 0.0D);
+            var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.getSpell(
+                    ResourceLocation.fromNamespaceAndPath("irons_spellbooks", "blaze_storm")
+            );
+            var scrollStack = createSpellScroll(spell);
+
+            try (var ignored = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) ->
+                    new SpellDispenserCastFrameBridge.CastFrame(projectedOrigin, projectedForward))) {
+                var startResult = SpellDispenserCastHelper.tryStartContinuousCast(
+                        level,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D),
+                        createSpellDispenserValidation(scrollStack, spell),
+                        scrollStack,
+                        null
+                );
+                helper.assertTrue(startResult.result().succeeded() && startResult.session() != null,
+                        "Projected Spell Dispenser Blaze Storm did not start");
+
+                var session = startResult.session();
+                SpellDispenserCastHelper.syncContinuousCastTransform(
+                        level,
+                        session,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D)
+                );
+                SpellDispenserCastHelper.tickContinuousCast(level, session);
+
+                var fireballs = level.getEntitiesOfClass(
+                        SmallMagicFireball.class,
+                        new AABB(projectedOrigin, projectedOrigin).inflate(4.0D)
+                );
+                helper.assertTrue(!fireballs.isEmpty(), "Projected Blaze Storm did not spawn a fireball");
+                helper.assertTrue(fireballs.get(0).getDeltaMovement().normalize().dot(projectedForward) > 0.995D,
+                        "Projected Blaze Storm fireball used the wrong direction: " + fireballs.get(0).getDeltaMovement());
+
+                SpellDispenserCastHelper.finishContinuousCast(level, session, true);
+        }
+        helper.succeed();
+    }
+    static void spellDispenserContinuousProjectionUpdatesArcaneBeam(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+            var castBasePosition = helper.absoluteVec(new Vec3(1.5D, 2.5D, 1.5D));
+            var projectedFrame = new AtomicReference<>(new SpellDispenserCastFrameBridge.CastFrame(
+                    helper.absoluteVec(new Vec3(3.5D, 3.0D, 3.5D)),
+                    new Vec3(1.0D, 0.0D, 0.0D)
+            ));
+            var spell = SpellRegistry.ARCANE_BEAM.get();
+            var scrollStack = createSpellScroll(spell);
+
+            try (var ignored = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) ->
+                    projectedFrame.get())) {
+                var startResult = SpellDispenserCastHelper.tryStartContinuousCast(
+                        level,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D),
+                        SpellDispenserSpellValidator.validate(scrollStack),
+                        scrollStack,
+                        null
+                );
+                helper.assertTrue(startResult.result().succeeded() && startResult.session() != null,
+                        "Projected Spell Dispenser Arcane Beam did not start");
+
+                var session = startResult.session();
+                SpellDispenserCastHelper.tickContinuousCast(level, session);
+                var beams = level.getEntitiesOfClass(
+                        ArcaneBeamEntity.class,
+                        new AABB(projectedFrame.get().origin(), projectedFrame.get().origin()).inflate(8.0D)
+                );
+                helper.assertTrue(beams.size() == 1, "Projected Arcane Beam did not create exactly one beam");
+
+                projectedFrame.set(new SpellDispenserCastFrameBridge.CastFrame(
+                        helper.absoluteVec(new Vec3(5.5D, 3.5D, 5.5D)),
+                        new Vec3(0.0D, 0.0D, -1.0D)
+                ));
+                SpellDispenserCastHelper.syncContinuousCastTransform(
+                        level,
+                        session,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D)
+                );
+                SpellDispenserCastHelper.tickContinuousCast(level, session);
+
+                var beam = beams.get(0);
+                var expectedPosition = session.proxy().getEyePosition().add(0.0D, -0.7D, 0.0D)
+                        .add(projectedFrame.get().forward().scale(0.75D));
+                assertVecClose(helper, expectedPosition, beam.position(), 0.01D,
+                        "Arcane Beam did not follow the updated projected origin");
+                helper.assertTrue(beam.getLookAngle().normalize().dot(projectedFrame.get().forward()) > 0.999D,
+                        "Arcane Beam did not follow the updated projected direction: " + beam.getLookAngle());
+
+                SpellDispenserCastHelper.finishContinuousCast(level, session, true);
+                helper.assertTrue(beam.isRemoved(), "Projected Arcane Beam remained after cleanup");
+        }
+        helper.succeed();
+    }
+    static void spellDispenserContinuousProjectionUpdatesFujinWeapon(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+            var castBasePosition = helper.absoluteVec(new Vec3(1.5D, 2.5D, 1.5D));
+            var projectedFrame = new AtomicReference<>(new SpellDispenserCastFrameBridge.CastFrame(
+                    helper.absoluteVec(new Vec3(3.5D, 3.0D, 3.5D)),
+                    new Vec3(1.0D, 0.0D, 0.0D)
+            ));
+            var spell = SpellRegistry.FUJIN.get();
+            var scrollStack = createSpellScroll(spell);
+
+            try (var ignored = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) ->
+                    projectedFrame.get())) {
+                var startResult = SpellDispenserCastHelper.tryStartContinuousCast(
+                        level,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D),
+                        SpellDispenserSpellValidator.validate(scrollStack),
+                        scrollStack,
+                        null
+                );
+                helper.assertTrue(startResult.result().succeeded() && startResult.session() != null,
+                        "Projected Spell Dispenser Fujin did not start");
+
+                var session = startResult.session();
+                for (var tick = 0; tick < 10 && !session.hasReachedOnCast(); tick++) {
+                    SpellDispenserCastHelper.tickContinuousCast(level, session);
+                }
+                helper.assertTrue(session.hasReachedOnCast(),
+                        "Projected Fujin did not reach its first CONTINUOUS onCast interval");
+                var weapons = level.getEntitiesOfClass(
+                        FujinKatanaEntity.class,
+                        new AABB(projectedFrame.get().origin(), projectedFrame.get().origin()).inflate(4.0D)
+                );
+                helper.assertTrue(weapons.size() == 1,
+                        "Projected Fujin did not create exactly one katana: " + weapons.size());
+                var weapon = weapons.get(0);
+                helper.assertTrue(weapon.getOwner() == session.proxy(),
+                        "Projected Fujin katana did not retain the proxy caster as owner");
+
+                projectedFrame.set(new SpellDispenserCastFrameBridge.CastFrame(
+                        helper.absoluteVec(new Vec3(5.5D, 3.5D, 5.5D)),
+                        new Vec3(0.0D, 0.0D, -1.0D)
+                ));
+                SpellDispenserCastHelper.syncContinuousCastTransform(
+                        level,
+                        session,
+                        castBasePosition,
+                        new Vec3(0.0D, 0.0D, 1.0D)
+                );
+                var slashes = new ArrayList<FujinSlashProjectileEntity>();
+                java.util.function.Consumer<EntityJoinLevelEvent> slashListener = event -> {
+                    if (event.getLevel() == level && event.getEntity() instanceof FujinSlashProjectileEntity slash) {
+                        slashes.add(slash);
+                    }
+                };
+                NeoForge.EVENT_BUS.addListener(slashListener);
+                try {
+                    // 発射周期そのものはFujin固有テストに任せ、ここでは投影後の向きによる発射だけを固定tickで確認する。
+                    weapon.tickCount = 10;
+                    weapon.tickOnServer(level);
+                } finally {
+                    NeoForge.EVENT_BUS.unregister(slashListener);
+                }
+
+                helper.assertTrue(weapon.position().distanceToSqr(session.proxy().position()) < 4.0D,
+                        "Projected Fujin katana did not follow the updated proxy position: " + weapon.position());
+                helper.assertTrue(!slashes.isEmpty(), "Projected Fujin katana did not fire a slash");
+                helper.assertTrue(slashes.get(0).getDeltaMovement().normalize().dot(projectedFrame.get().forward()) > 0.999D,
+                        "Projected Fujin slash used the wrong direction: " + slashes.get(0).getDeltaMovement());
+
+                SpellDispenserCastHelper.finishContinuousCast(level, session, true);
+                helper.assertTrue(weapon.isRemoved(), "Projected Fujin katana remained after cleanup");
+        }
+        helper.succeed();
+    }
+    static void spellDispenserBlockEntityReprojectsContinuousCastEachTick(GameTestHelper helper) {
+        var level = (ServerLevel) helper.getLevel();
+        var pos = new BlockPos(0, 1, 0);
+        helper.setBlock(pos, BlockRegistry.SPELL_DISPENSER.get());
+        helper.setBlock(pos, helper.getBlockState(pos).setValue(SpellDispenser.TRIGGERED, true));
+
+        var blockEntity = helper.getBlockEntity(pos);
+        helper.assertTrue(blockEntity instanceof SpellDispenserBlockEntity,
+                "Spell Dispenser block entity was not created for projected CONTINUOUS tick test");
+        var spellDispenser = (SpellDispenserBlockEntity) blockEntity;
+        var spell = io.redspace.ironsspellbooks.api.registry.SpellRegistry.getSpell(
+                ResourceLocation.fromNamespaceAndPath("irons_spellbooks", "blaze_storm")
+        );
+        var scrollStack = createSpellScroll(spell);
+        spellDispenser.getInventory().setStackInSlot(0, scrollStack);
+
+        var projectedFrame = new AtomicReference<>(new SpellDispenserCastFrameBridge.CastFrame(
+                helper.absoluteVec(new Vec3(2.5D, 2.5D, 2.5D)),
+                new Vec3(1.0D, 0.0D, 0.0D)
+        ));
+        var projectionCount = new AtomicInteger();
+        try (var ignored = SpellDispenserCastFrameBridge.useProjectorForGameTest((serverLevel, sourcePosition, frame) -> {
+            projectionCount.incrementAndGet();
+            return projectedFrame.get();
+        })) {
+            var startResult = SpellDispenserCastHelper.tryStartContinuousCast(
+                    level,
+                    pos,
+                    Direction.NORTH,
+                    createSpellDispenserValidation(scrollStack, spell),
+                    scrollStack,
+                    null
+            );
+            helper.assertTrue(startResult.result().succeeded() && startResult.session() != null,
+                    "Spell Dispenser did not start projected BlockEntity CONTINUOUS test session");
+            var session = startResult.session();
+            spellDispenser.startContinuousCast(session);
+
+            projectedFrame.set(new SpellDispenserCastFrameBridge.CastFrame(
+                    helper.absoluteVec(new Vec3(5.5D, 3.5D, 5.5D)),
+                    new Vec3(0.0D, 0.0D, -1.0D)
+            ));
+            SpellDispenserBlockEntity.serverTick(level, pos, helper.getBlockState(pos), spellDispenser);
+
+            helper.assertTrue(projectionCount.get() >= 2,
+                    "Spell Dispenser BlockEntity tick did not re-run CONTINUOUS cast projection");
+            assertVecClose(helper, projectedFrame.get().origin(), session.proxy().getEyePosition(), 0.01D,
+                    "Spell Dispenser BlockEntity tick did not move the CONTINUOUS proxy to the projected origin");
+            helper.assertTrue(session.proxy().getLookAngle().normalize().dot(projectedFrame.get().forward()) > 0.999D,
+                    "Spell Dispenser BlockEntity tick did not rotate the CONTINUOUS proxy to the projected direction");
+
+            helper.setBlock(pos, helper.getBlockState(pos).setValue(SpellDispenser.TRIGGERED, false));
+            SpellDispenserBlockEntity.serverTick(level, pos, helper.getBlockState(pos), spellDispenser);
+            helper.assertFalse(spellDispenser.hasActiveContinuousCast(),
+                    "Projected BlockEntity CONTINUOUS test session remained after signal loss");
+        }
+        helper.succeed();
     }
     static void spellDispenserBlockEntityStopsContinuousCastWhenSignalTurnsOff(GameTestHelper helper) {
         var level = (ServerLevel) helper.getLevel();

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -66,6 +66,34 @@ config="mixins.apprenticecodex.json"
     side="BOTH"
 
 [[dependencies.${mod_id}]]
+    modId="sable"
+    type="optional"
+    versionRange="[${sable_version},)"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies.${mod_id}]]
+    modId="simulated"
+    type="optional"
+    versionRange="[${simulated_project_version},)"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies.${mod_id}]]
+    modId="aeronautics"
+    type="optional"
+    versionRange="[${simulated_project_version},)"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies.${mod_id}]]
+    modId="offroad"
+    type="optional"
+    versionRange="[${simulated_project_version},)"
+    ordering="NONE"
+    side="BOTH"
+
+[[dependencies.${mod_id}]]
     modId="jade"
     type="optional"
     versionRange="[${jade_version},)"


### PR DESCRIPTION
# 対応内容

- `SpellDispenser`がSableのサブレベルによる挙動に対応できていなかったのを対応
    - Create Aeronauticsなどで使われる機体移動速度の影響は**意図的に未対応**
    - これはそもそもIron's魔法はプレイヤーの移動速度に影響するシステムを持っておらず、要素として繋ぐと意図しないプレイ体験に変化するため
- Sable及びCreate Aeronauticsをoptional mod前提に追加、それに合わせそれぞれの前提バージョンの調整
- Sableが1.21.1限定のMODのため、この対応は**backport対象外**

# MOD要求バージョンについて

- MODの運用としてAll-in-Oneのjar一つの配布で行うため、今回のSable対応による要求バージョン更新が他構成を巻き込む破壊的変更となる
- All-in-Oneで対応する以上、構成別に対応バージョンを分けると開発上の管理運用コストが急上昇し、ユーザー側もどれを落とせばいいのかわからなくなって保守運用コストも急上昇する
- そのため、バージョン上昇に関してはユーザーへMOD配布ページの告知で基本は対応する
- バージョンポリシーとしては下記
    - 全般 : バージョン更新の必要がでる対応発生時に関係したものをその時点の最新に更新(今回はNeoforgeとCreateが該当)
    - Neoforge : 更新頻度が高いため、optional mod全て含めた要求バージョンが最も低いものを探して設定(今回は228)
    - 1.20.1におけるEpicFight : これのみ非常に特殊な例外となり、ユーザーが過去バージョンにとどまって遊ぶケースが多発し、最新版追従はデメリットの方が大きいため意図的に古いバージョンを採用する

# 検証

- `build` : `BUILD SUCCESSFUL in 15s`

## `runClient` 系

- `runClient` :  `SpellDispenser`のリグレッション無く動作確認
- `runClientCompat` : `SpellDispenser`のCreateからくりでリグレッション無く動作確認
- `runClientCreateSableAeronautics` : 今回対応の機能の動作確認済み

## `runGameTestServer` 系

- `runGameTestServer` : `All 961 required tests passed :)`
- `runGameTestServerCompat` : `All 961 required tests passed :)`
- `runGameTestServerCreateSableAeronautics` : `All 961 required tests passed :)`