### PR TITLE
1.21.1における魔法詠唱関連での切断不具合の対応

### DIFF
--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/CastDataNetworkSnapshotGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/CastDataNetworkSnapshotGameTests.java
@@ -1,0 +1,225 @@
+package jp.aquafactory.apprenticecodex.gametest;
+
+import io.netty.buffer.Unpooled;
+import io.redspace.ironsspellbooks.api.config.DefaultConfig;
+import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
+import io.redspace.ironsspellbooks.api.spells.CastType;
+import io.redspace.ironsspellbooks.api.spells.ICastDataSerializable;
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import jp.aquafactory.apprenticecodex.network.CastDataNetworkSnapshot;
+import jp.aquafactory.apprenticecodex.registry.SpellRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.gametest.framework.GameTest;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.gametest.GameTestHolder;
+import net.neoforged.neoforge.gametest.PrefixGameTestTemplate;
+
+import java.util.UUID;
+
+@GameTestHolder(ApprenticeCodex.MODID)
+@PrefixGameTestTemplate(false)
+public final class CastDataNetworkSnapshotGameTests {
+    private static final String TEMPLATE = "gametest/basic_floor";
+
+    private CastDataNetworkSnapshotGameTests() {
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void allOwnEmptyCastDataCanBeSnapshotted(GameTestHelper helper) {
+        var serializableCount = 0;
+        for (var spellEntry : SpellRegistry.SPELLS.getEntries()) {
+            var spell = spellEntry.get();
+            var source = spell.getEmptyCastData();
+            if (source == null) {
+                continue;
+            }
+
+            serializableCount++;
+            var snapshot = CastDataNetworkSnapshot.snapshotForAsyncPacketEncoding(spell, source);
+            helper.assertTrue(snapshot instanceof ICastDataSerializable,
+                    "Own serializable cast data should produce a serializable snapshot: " + spell.getSpellId());
+            helper.assertTrue(snapshot != source,
+                    "Own serializable cast data should be detached from its source: " + spell.getSpellId());
+            assertWireRoundTrip(helper, spell, (ICastDataSerializable) snapshot);
+        }
+
+        helper.assertTrue(serializableCount > 0, "Expected at least one own serializable cast data implementation");
+        helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void populatedCastDataSnapshotsSurviveSourceReset(GameTestHelper helper) {
+        var provider = helper.getLevel().registryAccess();
+
+        var weaponTag = new CompoundTag();
+        weaponTag.putUUID("Entity", UUID.fromString("5c7415e1-7f42-4c65-b10f-03ca2485f953"));
+        assertSnapshotSurvivesReset(helper, SpellRegistry.DUAL_ACROBAT.get(), weaponTag, provider);
+
+        var mageLightTag = new CompoundTag();
+        mageLightTag.putInt("PositionX", 12);
+        mageLightTag.putInt("PositionY", 34);
+        mageLightTag.putInt("PositionZ", -56);
+        assertSnapshotSurvivesReset(helper, SpellRegistry.MAGE_LIGHT.get(), mageLightTag, provider);
+
+        var tamersPocketTag = new CompoundTag();
+        tamersPocketTag.putString("Mode", "WITHDRAW_AREA");
+        var petList = new ListTag();
+        var petTag = new CompoundTag();
+        petTag.putUUID("Uuid", UUID.fromString("64f3eff3-127d-4f51-b4e3-6d14d9a7f33e"));
+        petList.add(petTag);
+        tamersPocketTag.put("LockedPetUuids", petList);
+        var positionList = new ListTag();
+        var positionTag = new CompoundTag();
+        var position = new BlockPos(7, 8, 9);
+        positionTag.putInt("X", position.getX());
+        positionTag.putInt("Y", position.getY());
+        positionTag.putInt("Z", position.getZ());
+        positionList.add(positionTag);
+        tamersPocketTag.put("LockedDeployPositions", positionList);
+        assertSnapshotSurvivesReset(helper, SpellRegistry.TAMERS_POCKET.get(), tamersPocketTag, provider);
+
+        helper.succeed();
+    }
+
+    @GameTest(template = TEMPLATE)
+    public static void snapshotFailureFallsBackAndExternalDataIsUntouched(GameTestHelper helper) {
+        var ownSpell = new SnapshotTestSpell(
+                ResourceLocation.fromNamespaceAndPath(ApprenticeCodex.MODID, "snapshot_failure_test")
+        );
+        var failingSource = new SnapshotTestCastData(true, 42);
+        var fallback = CastDataNetworkSnapshot.snapshotForAsyncPacketEncoding(ownSpell, failingSource);
+        helper.assertTrue(fallback instanceof SnapshotTestCastData,
+                "Snapshot failure should fall back to the same empty cast data type");
+        helper.assertTrue(fallback != failingSource,
+                "Snapshot failure should not return the mutable source cast data");
+        helper.assertTrue(((SnapshotTestCastData) fallback).value == 0,
+                "Snapshot failure should return an empty cast data instance");
+
+        var externalSpell = new SnapshotTestSpell(
+                ResourceLocation.fromNamespaceAndPath("external_test", "snapshot_skip_test")
+        );
+        var externalSource = new SnapshotTestCastData(false, 17);
+        var externalResult = CastDataNetworkSnapshot.snapshotForAsyncPacketEncoding(externalSpell, externalSource);
+        helper.assertTrue(externalResult == externalSource,
+                "External cast data should remain untouched by Apprentice's Codex protection");
+        helper.succeed();
+    }
+
+    private static void assertSnapshotSurvivesReset(
+            GameTestHelper helper,
+            AbstractSpell spell,
+            CompoundTag sourceTag,
+            HolderLookup.Provider provider
+    ) {
+        var source = spell.getEmptyCastData();
+        helper.assertTrue(source != null, "Expected serializable cast data for " + spell.getSpellId());
+        source.deserializeNBT(provider, sourceTag);
+        var expected = source.serializeNBT(provider).copy();
+
+        var snapshot = CastDataNetworkSnapshot.snapshotForAsyncPacketEncoding(spell, source);
+        helper.assertTrue(snapshot instanceof ICastDataSerializable,
+                "Expected serializable cast data snapshot for " + spell.getSpellId());
+        helper.assertTrue(snapshot != source, "Cast data snapshot should be detached for " + spell.getSpellId());
+
+        source.reset();
+        var actual = ((ICastDataSerializable) snapshot).serializeNBT(provider);
+        helper.assertTrue(expected.equals(actual),
+                "Cast data snapshot changed after source reset for " + spell.getSpellId()
+                        + ": expected=" + expected + ", actual=" + actual);
+    }
+
+    private static void assertWireRoundTrip(
+            GameTestHelper helper,
+            AbstractSpell spell,
+            ICastDataSerializable source
+    ) {
+        var buffer = new FriendlyByteBuf(Unpooled.buffer());
+        try {
+            source.writeToBuffer(buffer);
+            var decoded = spell.getEmptyCastData();
+            helper.assertTrue(decoded != null, "Expected empty cast data for " + spell.getSpellId());
+            decoded.readFromBuffer(buffer);
+            helper.assertTrue(!buffer.isReadable(),
+                    "Cast data decoder should consume the complete payload for " + spell.getSpellId());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static final class SnapshotTestSpell extends AbstractSpell {
+        private final ResourceLocation spellId;
+        private final DefaultConfig config = new DefaultConfig();
+
+        private SnapshotTestSpell(ResourceLocation spellId) {
+            this.spellId = spellId;
+        }
+
+        @Override
+        public ResourceLocation getSpellResource() {
+            return spellId;
+        }
+
+        @Override
+        public DefaultConfig getDefaultConfig() {
+            return config;
+        }
+
+        @Override
+        public CastType getCastType() {
+            return CastType.INSTANT;
+        }
+
+        @Override
+        public ICastDataSerializable getEmptyCastData() {
+            return new SnapshotTestCastData(false, 0);
+        }
+    }
+
+    private static final class SnapshotTestCastData implements ICastDataSerializable {
+        private boolean failOnWrite;
+        private int value;
+
+        private SnapshotTestCastData(boolean failOnWrite, int value) {
+            this.failOnWrite = failOnWrite;
+            this.value = value;
+        }
+
+        @Override
+        public void writeToBuffer(FriendlyByteBuf buffer) {
+            if (failOnWrite) {
+                throw new IllegalStateException("Intentional snapshot failure");
+            }
+            buffer.writeInt(value);
+        }
+
+        @Override
+        public void readFromBuffer(FriendlyByteBuf buffer) {
+            value = buffer.readInt();
+        }
+
+        @Override
+        public void reset() {
+            failOnWrite = false;
+            value = 0;
+        }
+
+        @Override
+        public CompoundTag serializeNBT(HolderLookup.Provider provider) {
+            var tag = new CompoundTag();
+            tag.putBoolean("FailOnWrite", failOnWrite);
+            tag.putInt("Value", value);
+            return tag;
+        }
+
+        @Override
+        public void deserializeNBT(HolderLookup.Provider provider, CompoundTag nbt) {
+            failOnWrite = nbt.getBoolean("FailOnWrite");
+            value = nbt.getInt("Value");
+        }
+    }
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/mixin/AbstractSpellMixin.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/mixin/AbstractSpellMixin.java
@@ -3,6 +3,7 @@ package jp.aquafactory.apprenticecodex.mixin;
 import io.redspace.ironsspellbooks.api.magic.MagicData;
 import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
 import io.redspace.ironsspellbooks.api.spells.CastSource;
+import io.redspace.ironsspellbooks.api.spells.ICastData;
 import io.redspace.ironsspellbooks.api.spells.SchoolType;
 import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbow;
 import jp.aquafactory.apprenticecodex.item.armor.MagiAgentSuitEffects;
@@ -12,6 +13,7 @@ import jp.aquafactory.apprenticecodex.item.mithrilfreecaststaff.MithrilFreecastS
 import jp.aquafactory.apprenticecodex.item.multicastechostaff.MulticastEchoStaffCastHelper;
 import jp.aquafactory.apprenticecodex.item.spellgun.SpellgunCastContext;
 import jp.aquafactory.apprenticecodex.item.revolvercaststaff.RevolvercastStaffPendingAdvance;
+import jp.aquafactory.apprenticecodex.network.CastDataNetworkSnapshot;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.core.Holder;
@@ -25,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -33,6 +36,21 @@ import java.util.Optional;
 
 @Mixin(value = AbstractSpell.class, remap = false)
 public abstract class AbstractSpellMixin {
+    @ModifyArg(
+            method = "castSpell",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lio/redspace/ironsspellbooks/network/casting/OnClientCastPacket;<init>(Ljava/lang/String;ILio/redspace/ironsspellbooks/api/spells/CastSource;Lio/redspace/ironsspellbooks/api/spells/ICastData;)V"
+            ),
+            index = 3
+    )
+    private ICastData apprentice_codex$snapshotCastDataBeforeAsyncEncoding(ICastData castData) {
+        return CastDataNetworkSnapshot.snapshotForAsyncPacketEncoding(
+                (AbstractSpell) (Object) this,
+                castData
+        );
+    }
+
     @Redirect(
             method = {"getSpellPower", "getEntityPowerMultiplier"},
             at = @At(

--- a/src/main/java/jp/aquafactory/apprenticecodex/network/CastDataNetworkSnapshot.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/network/CastDataNetworkSnapshot.java
@@ -1,0 +1,90 @@
+package jp.aquafactory.apprenticecodex.network;
+
+import io.netty.buffer.Unpooled;
+import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
+import io.redspace.ironsspellbooks.api.spells.ICastData;
+import io.redspace.ironsspellbooks.api.spells.ICastDataSerializable;
+import jp.aquafactory.apprenticecodex.ApprenticeCodex;
+import net.minecraft.network.FriendlyByteBuf;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class CastDataNetworkSnapshot {
+    private static final Set<ExternalCastDataKey> LOGGED_EXTERNAL_CAST_DATA = ConcurrentHashMap.newKeySet();
+
+    private CastDataNetworkSnapshot() {
+    }
+
+    public static @Nullable ICastData snapshotForAsyncPacketEncoding(
+            AbstractSpell spell,
+            @Nullable ICastData castData
+    ) {
+        if (!(castData instanceof ICastDataSerializable source)) {
+            return castData;
+        }
+
+        var spellId = spell.getSpellResource();
+        if (!ApprenticeCodex.MODID.equals(spellId.getNamespace())) {
+            var key = new ExternalCastDataKey(spellId.toString(), castData.getClass().getName());
+            if (LOGGED_EXTERNAL_CAST_DATA.add(key)) {
+                ApprenticeCodex.LOGGER.info(
+                        "Detected serializable cast data for external spell {} ({}); Apprentice's Codex async encoding protection was not applied.",
+                        spellId,
+                        castData.getClass().getName()
+                );
+            }
+            return castData;
+        }
+
+        // NeoForge 1.21.1 は custom payload を Netty thread で遅延 encode するため、
+        // Iron's Spells が詠唱完了直後に元データを reset しても影響しない独立コピーを先に作る。
+        var target = createEmptyCastData(spell, castData);
+        if (target == null) {
+            return null;
+        }
+
+        var buffer = new FriendlyByteBuf(Unpooled.buffer());
+        try {
+            source.writeToBuffer(buffer);
+            target.readFromBuffer(buffer);
+            return target;
+        } catch (RuntimeException exception) {
+            ApprenticeCodex.LOGGER.warn(
+                    "Failed to snapshot cast data for spell {} ({}); using empty cast data to avoid disconnecting the client.",
+                    spellId,
+                    castData.getClass().getName(),
+                    exception
+            );
+            return createEmptyCastData(spell, castData);
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static @Nullable ICastDataSerializable createEmptyCastData(AbstractSpell spell, ICastData source) {
+        try {
+            var emptyCastData = spell.getEmptyCastData();
+            if (emptyCastData == null) {
+                ApprenticeCodex.LOGGER.warn(
+                        "Spell {} returned no empty cast data for {}; omitting cast data to avoid disconnecting the client.",
+                        spell.getSpellResource(),
+                        source.getClass().getName()
+                );
+            }
+            return emptyCastData;
+        } catch (RuntimeException exception) {
+            ApprenticeCodex.LOGGER.warn(
+                    "Failed to create empty cast data for spell {} ({}); omitting cast data to avoid disconnecting the client.",
+                    spell.getSpellResource(),
+                    source.getClass().getName(),
+                    exception
+            );
+            return null;
+        }
+    }
+
+    private record ExternalCastDataKey(String spellId, String castDataClass) {
+    }
+}


### PR DESCRIPTION
- 通信時に`CastData`が処理順次第でパケットを壊されるのを検知して保護を実施する対応を追加
- 原因からApprentice's Codex以外の魔法でも潜在的に発生する可能性があるが、Iron's本体含め他MODの魔法はログ報告のみ行って保護を実施しない方向で対応
    - Iron's本体は不具合が発生する実装を持つ魔法が存在せず、パッチとして対応するにはユーザー側メリットが少ない割に影響範囲が大きすぎるため
    - ただし、検知は出来ている以上参考としてログ出力対応は入れた
- 1.21.1限定の通信処理によるもののため、backport対象外
- `build` : 成功
- `runClient` : 今回事象を確認した`DualAcrobat`を3連続で実行して再現しないことを確認(元々発生率が低いため再現しない可能性はある)
- `runGameTestServer` : 全964件成功