### PR TITLE
結晶化秘術の強化(1.21.1のみ)

### DIFF
--- a/src/main/resources/data/apprenticecodex/irons_jewelry/material/crystalline_arcane.json
+++ b/src/main/resources/data/apprenticecodex/irons_jewelry/material/crystalline_arcane.json
@@ -8,7 +8,7 @@
   "bonusParameters": {
     "irons_jewelry:attribute": {
       "attribute": "irons_spellbooks:spell_power",
-      "amount": 0.01,
+      "amount": 0.03,
       "operation": "add_multiplied_total"
     }
   }


### PR DESCRIPTION
- 1%だと低すぎたため。
- 5%は上位のパターン且つパイリウム類と組み合わせると容易に壊れるため、ミスリル棘の指輪を越さない程度の3%で一旦様子見
- Iron's Gemsは1.21.1にしかないためbackport非対象
- `build` : `BUILD SUCCESSFUL in 26s`
- `runClientCompat` : 数値バランス確認済み
- `runGameTestServer` : `All 967 required tests passed :)`
- `runGameTestServerCompat` : `All 967 required tests passed :)`