### PR TITLE
PR #785 詠唱者の矢筒の装備箇所追加 1.20.1backport対応

### DIFF
--- a/src/generated/resources/data/curios/tags/items/belt.json
+++ b/src/generated/resources/data/curios/tags/items/belt.json
@@ -2,6 +2,7 @@
   "values": [
     "apprenticecodex:protection_spell_supporter",
     "apprenticecodex:spellcaster_ammo_pouch",
-    "apprenticecodex:magi_compressor_gadget"
+    "apprenticecodex:magi_compressor_gadget",
+    "apprenticecodex:spellcaster_quiver"
   ]
 }

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/ItemTagGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/ItemTagGenerator.java
@@ -207,7 +207,8 @@ public final class ItemTagGenerator extends ItemTagsProvider {
         tag(CURIOS_BELT).add(
                 ItemRegistry.PROTECTION_SPELL_SUPPORTER.get(),
                 ItemRegistry.SPELLCASTER_AMMO_POUCH.get(),
-                ItemRegistry.MAGI_COMPRESSOR_GADGET.get()
+                ItemRegistry.MAGI_COMPRESSOR_GADGET.get(),
+                ItemRegistry.SPELLCASTER_QUIVER.get()
         );
         tag(CURIOS_BACK).add(ItemRegistry.SPELLCASTER_QUIVER.get());
         tag(CURIOS_NECKLACE).add(

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -1909,8 +1909,13 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)
-    public static void spellcasterQuiverUsesBackSlotAndCapsStoredArrows(GameTestHelper helper) {
-        SpellcasterQuiverGameTestScenarios.spellcasterQuiverUsesBackSlotAndCapsStoredArrows(helper);
+    public static void spellcasterQuiverUsesBackAndBeltSlotsAndCapsStoredArrows(GameTestHelper helper) {
+        SpellcasterQuiverGameTestScenarios.spellcasterQuiverUsesBackAndBeltSlotsAndCapsStoredArrows(helper);
+    }
+
+    @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)
+    public static void spellcasterQuiverAllowsOnlyOneEquippedAcrossSlots(GameTestHelper helper) {
+        SpellcasterQuiverGameTestScenarios.spellcasterQuiverAllowsOnlyOneEquippedAcrossSlots(helper);
     }
 
     @GameTest(template = TEMPLATE, batch = SPELLCASTER_QUIVER_ISOLATED_BATCH)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/BowGameTestSupport.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/BowGameTestSupport.java
@@ -62,6 +62,10 @@ final class BowGameTestSupport {
             Registries.ITEM,
             ResourceLocation.fromNamespaceAndPath("curios", CuriosSlotConstants.BACK)
     );
+    static final TagKey<Item> CURIOS_BELT = TagKey.create(
+            Registries.ITEM,
+            ResourceLocation.fromNamespaceAndPath("curios", CuriosSlotConstants.BELT)
+    );
     static final TagKey<Item> CURIOS_CHARM = TagKey.create(
             Registries.ITEM,
             ResourceLocation.fromNamespaceAndPath("curios", CuriosSlotConstants.CHARM)

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellcasterQuiverGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/SpellcasterQuiverGameTestScenarios.java
@@ -15,6 +15,7 @@ import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import net.minecraft.core.BlockPos;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.enchantment.Enchantments;
@@ -23,17 +24,26 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.alchemy.PotionUtils;
 import net.minecraft.world.item.alchemy.Potions;
 import net.minecraftforge.event.entity.player.EntityItemPickupEvent;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotContext;
+
+import java.util.UUID;
 import static jp.aquafactory.apprenticecodex.gametest.BowGameTestSupport.*;
 
 final class SpellcasterQuiverGameTestScenarios {
+    private static final UUID EXPANDED_BELT_MODIFIER_ID =
+            UUID.fromString("6d7cb2e5-4c51-4d42-9a33-2bccd4402427");
+
     private SpellcasterQuiverGameTestScenarios() {
     }
 
-    static void spellcasterQuiverUsesBackSlotAndCapsStoredArrows(GameTestHelper helper) {
+    static void spellcasterQuiverUsesBackAndBeltSlotsAndCapsStoredArrows(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var quiverStack = new ItemStack(ItemRegistry.SPELLCASTER_QUIVER.get());
             helper.assertTrue(quiverStack.is(CURIOS_BACK),
                     "Spellcaster Quiver should be tagged for the Curios back slot");
+            helper.assertTrue(quiverStack.is(CURIOS_BELT),
+                    "Spellcaster Quiver should be tagged for the Curios belt slot");
 
             var firstInsert = SpellcasterQuiver.store(quiverStack, new ItemStack(Items.ARROW, 300));
             var secondInsert = SpellcasterQuiver.store(quiverStack, new ItemStack(Items.SPECTRAL_ARROW, 300));
@@ -52,11 +62,62 @@ final class SpellcasterQuiverGameTestScenarios {
         });
     }
 
+    static void spellcasterQuiverAllowsOnlyOneEquippedAcrossSlots(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            var quiverItem = (SpellcasterQuiver) ItemRegistry.SPELLCASTER_QUIVER.get();
+
+            var crossSlotPlayer = createEquipmentTestPlayer(
+                    helper,
+                    new BlockPos(0, 2, 0),
+                    "spellcaster_quiver_cross_slot_limit_test"
+            );
+            var backStack = new ItemStack(quiverItem);
+            equipCurio(crossSlotPlayer, CuriosSlotConstants.BACK, backStack);
+
+            var backContext = new SlotContext(CuriosSlotConstants.BACK, crossSlotPlayer, 0, false, true);
+            var beltContext = new SlotContext(CuriosSlotConstants.BELT, crossSlotPlayer, 0, false, true);
+            helper.assertTrue(quiverItem.canEquip(backContext, backStack),
+                    "Spellcaster Quiver should remain valid in its current slot");
+            helper.assertFalse(quiverItem.canEquip(beltContext, new ItemStack(quiverItem)),
+                    "Spellcaster Quiver should reject a second copy in a different slot type");
+
+            var expandedBeltPlayer = createEquipmentTestPlayer(
+                    helper,
+                    new BlockPos(1, 2, 0),
+                    "spellcaster_quiver_expanded_belt_limit_test"
+            );
+            var curiosInventory = CuriosApi.getCuriosInventory(expandedBeltPlayer)
+                    .orElseThrow(() -> new IllegalStateException("Missing curios inventory for expanded belt test"));
+            curiosInventory.addTransientSlotModifier(
+                    CuriosSlotConstants.BELT,
+                    EXPANDED_BELT_MODIFIER_ID,
+                    "apprenticecodex:gametest/spellcaster_quiver_expanded_belt",
+                    1.0D,
+                    AttributeModifier.Operation.ADDITION
+            );
+            var beltStack = new ItemStack(quiverItem);
+            curiosInventory.setEquippedCurio(CuriosSlotConstants.BELT, 0, beltStack);
+
+            var secondBeltContext = new SlotContext(CuriosSlotConstants.BELT, expandedBeltPlayer, 1, false, true);
+            helper.assertFalse(quiverItem.canEquip(secondBeltContext, new ItemStack(quiverItem)),
+                    "Spellcaster Quiver should reject a second copy when the belt slot is expanded");
+            var expandedPlayerBackContext =
+                    new SlotContext(CuriosSlotConstants.BACK, expandedBeltPlayer, 0, false, true);
+            helper.assertFalse(quiverItem.canEquip(expandedPlayerBackContext, new ItemStack(quiverItem)),
+                    "Spellcaster Quiver should reject a second copy on the back while equipped on the belt");
+            var expandedBeltHandler = curiosInventory.getCurios().get(CuriosSlotConstants.BELT);
+            helper.assertTrue(expandedBeltHandler != null && expandedBeltHandler.getStacks().getSlots() >= 2,
+                    "Expanded belt test should provide at least two functional belt slots");
+            helper.assertFalse(expandedBeltHandler.getStacks().isItemValid(1, new ItemStack(quiverItem)),
+                    "Curios slot validation should reject a second Spellcaster Quiver in the expanded belt");
+        });
+    }
+
     static void equippedSpellcasterQuiverAutoStoresPickedUpArrows(GameTestHelper helper) {
         helper.succeedIf(() -> {
             var player = createEquipmentTestPlayer(helper, new BlockPos(0, 2, 0), "spellcaster_quiver_pickup_test");
             var quiverStack = new ItemStack(ItemRegistry.SPELLCASTER_QUIVER.get());
-            equipCurio(player, CuriosSlotConstants.BACK, quiverStack);
+            equipCurio(player, CuriosSlotConstants.BELT, quiverStack);
 
             var itemEntity = new ItemEntity(helper.getLevel(), player.getX(), player.getY(), player.getZ(), new ItemStack(Items.ARROW, 12));
             SpellcasterQuiverPickupEvent.onEntityItemPickup(new EntityItemPickupEvent(player, itemEntity));

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellcasterquiver/SpellcasterQuiver.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellcasterquiver/SpellcasterQuiver.java
@@ -31,6 +31,7 @@ import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.SlotResult;
 import top.theillusivec4.curios.api.type.capability.ICurioItem;
+import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,13 +75,8 @@ public class SpellcasterQuiver extends Item implements ICurioItem, InventoryInse
             return true;
         }
 
-        // Item指定の検索は同一tick内で結果がcacheされるため、連続した装備操作でも現在値を見るpredicate検索を使う.
         return CuriosApi.getCuriosInventory(slotContext.entity())
-                .map(inventory -> inventory.findCurios(
-                                equippedStack -> equippedStack.is(ItemRegistry.SPELLCASTER_QUIVER.get())
-                        ).stream()
-                        .map(SlotResult::slotContext)
-                        .allMatch(equippedSlot -> isSameSlot(equippedSlot, slotContext)))
+                .map(inventory -> hasNoOtherEquippedQuiver(inventory, slotContext))
                 .orElse(true);
     }
 
@@ -89,8 +85,20 @@ public class SpellcasterQuiver extends Item implements ICurioItem, InventoryInse
         return true;
     }
 
-    private static boolean isSameSlot(SlotContext first, SlotContext second) {
-        return first.index() == second.index() && first.identifier().equals(second.identifier());
+    private static boolean hasNoOtherEquippedQuiver(ICuriosItemHandler inventory, SlotContext targetSlot) {
+        // 枠の種類・数・有効状態に依存せず、Curiosが保持する実装備領域全体で一つだけに制限する.
+        for (var entry : inventory.getCurios().entrySet()) {
+            var stacks = entry.getValue().getStacks();
+            for (var index = 0; index < stacks.getSlots(); index++) {
+                if (entry.getKey().equals(targetSlot.identifier()) && index == targetSlot.index()) {
+                    continue;
+                }
+                if (stacks.getStackInSlot(index).is(ItemRegistry.SPELLCASTER_QUIVER.get())) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellcasterquiver/SpellcasterQuiver.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/curios/spellcasterquiver/SpellcasterQuiver.java
@@ -2,7 +2,6 @@ package jp.aquafactory.apprenticecodex.item.curios.spellcasterquiver;
 
 import jp.aquafactory.apprenticecodex.item.InventoryInsertTarget;
 import jp.aquafactory.apprenticecodex.item.focusstaffbow.FocusStaffbow;
-import jp.aquafactory.apprenticecodex.item.curios.CuriosSlotConstants;
 import jp.aquafactory.apprenticecodex.item.curios.spellcasterammopouch.SpellcasterAmmoPouchTooltip;
 import jp.aquafactory.apprenticecodex.registry.ItemRegistry;
 import jp.aquafactory.apprenticecodex.registry.TagRegistry;
@@ -47,35 +46,51 @@ public class SpellcasterQuiver extends Item implements ICurioItem, InventoryInse
     private static final String STACK_TAG = "Stack";
     private static final String COUNT_TAG = "Count";
 
-    private final String slotIdentifier;
-
     public SpellcasterQuiver() {
         super(new Item.Properties().stacksTo(1).rarity(Rarity.UNCOMMON));
-        slotIdentifier = CuriosSlotConstants.BACK;
     }
 
     @Override
     public List<Component> getSlotsTooltip(List<Component> tooltips, ItemStack stack) {
-        if (slotIdentifier != null) {
-            tooltips.add(Component.empty());
-            tooltips.add(Component.translatable("curios.modifiers." + slotIdentifier).withStyle(ChatFormatting.GOLD));
-            tooltips.add(Component.literal(" ")
-                    .append(Component.translatable(getDescriptionId() + ".desc_1"))
-                    .withStyle(Style.EMPTY.withColor(ChatFormatting.YELLOW)));
-            tooltips.add(Component.literal(" ")
-                    .append(Component.translatable(getDescriptionId() + ".desc_2"))
-                    .withStyle(Style.EMPTY.withColor(ChatFormatting.YELLOW)));
-            tooltips.add(Component.literal(" ")
-                    .append(Component.translatable(getDescriptionId() + ".desc_3"))
-                    .withStyle(Style.EMPTY.withColor(ChatFormatting.YELLOW)));
-        }
+        tooltips.add(Component.empty());
+        // item.modifiers.anyは1.20.1にはないため、オリジナルのキーを定義して使う.
+        tooltips.add(Component.translatable("curios.apprenticecodex.modifier.for_quiver").withStyle(ChatFormatting.GOLD));
+        tooltips.add(Component.literal(" ")
+                .append(Component.translatable(getDescriptionId() + ".desc_1"))
+                .withStyle(Style.EMPTY.withColor(ChatFormatting.YELLOW)));
+        tooltips.add(Component.literal(" ")
+                .append(Component.translatable(getDescriptionId() + ".desc_2"))
+                .withStyle(Style.EMPTY.withColor(ChatFormatting.YELLOW)));
+        tooltips.add(Component.literal(" ")
+                .append(Component.translatable(getDescriptionId() + ".desc_3"))
+                .withStyle(Style.EMPTY.withColor(ChatFormatting.YELLOW)));
 
         return tooltips;
     }
 
     @Override
+    public boolean canEquip(SlotContext slotContext, ItemStack stack) {
+        if (slotContext.entity() == null) {
+            return true;
+        }
+
+        // Item指定の検索は同一tick内で結果がcacheされるため、連続した装備操作でも現在値を見るpredicate検索を使う.
+        return CuriosApi.getCuriosInventory(slotContext.entity())
+                .map(inventory -> inventory.findCurios(
+                                equippedStack -> equippedStack.is(ItemRegistry.SPELLCASTER_QUIVER.get())
+                        ).stream()
+                        .map(SlotResult::slotContext)
+                        .allMatch(equippedSlot -> isSameSlot(equippedSlot, slotContext)))
+                .orElse(true);
+    }
+
+    @Override
     public boolean canEquipFromUse(SlotContext slotContext, ItemStack stack) {
         return true;
+    }
+
+    private static boolean isSameSlot(SlotContext first, SlotContext second) {
+        return first.index() == second.index() && first.identifier().equals(second.identifier());
     }
 
     @Override

--- a/src/main/java/jp/aquafactory/apprenticecodex/renderer/curio/SpellcasterQuiverCurioRenderer.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/renderer/curio/SpellcasterQuiverCurioRenderer.java
@@ -26,10 +26,10 @@ public class SpellcasterQuiverCurioRenderer implements ICurioRenderer {
     private static final float BACK_OFFSET_Y = 2.85F * PIXEL;
     private static final float BACK_OFFSET_Z = -2.9F * PIXEL;
     private static final float BACK_ROTATE_DEG_Z = 214F;
-    private static final float BELT_OFFSET_X = 9.5F * PIXEL;
-    private static final float BELT_OFFSET_Y = 3F * PIXEL;
-    private static final float BELT_OFFSET_Z = -2F * PIXEL;
-    private static final float BELT_ROTATE_DEG_Z = 114F;
+    private static final float BELT_OFFSET_X = -10F * PIXEL;
+    private static final float BELT_OFFSET_Y = 5F * PIXEL;
+    private static final float BELT_OFFSET_Z = -2.7F * PIXEL;
+    private static final float BELT_ROTATE_DEG_Z = 260F;
     private static final float ARMORED_OFFSET_Z = -0.45F * PIXEL;
     private static final float QUIVER_SCALE = 1.45F;
 

--- a/src/main/java/jp/aquafactory/apprenticecodex/renderer/curio/SpellcasterQuiverCurioRenderer.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/renderer/curio/SpellcasterQuiverCurioRenderer.java
@@ -2,6 +2,7 @@ package jp.aquafactory.apprenticecodex.renderer.curio;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
+import jp.aquafactory.apprenticecodex.item.curios.CuriosSlotConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.EntityModel;
 import net.minecraft.client.model.HumanoidModel;
@@ -24,6 +25,11 @@ public class SpellcasterQuiverCurioRenderer implements ICurioRenderer {
     private static final float BACK_OFFSET_X = -2.8F * PIXEL;
     private static final float BACK_OFFSET_Y = 2.85F * PIXEL;
     private static final float BACK_OFFSET_Z = -2.9F * PIXEL;
+    private static final float BACK_ROTATE_DEG_Z = 214F;
+    private static final float BELT_OFFSET_X = 9.5F * PIXEL;
+    private static final float BELT_OFFSET_Y = 3F * PIXEL;
+    private static final float BELT_OFFSET_Z = -2F * PIXEL;
+    private static final float BELT_ROTATE_DEG_Z = 114F;
     private static final float ARMORED_OFFSET_Z = -0.45F * PIXEL;
     private static final float QUIVER_SCALE = 1.45F;
 
@@ -47,13 +53,34 @@ public class SpellcasterQuiverCurioRenderer implements ICurioRenderer {
 
         var humanoidModel = (HumanoidModel<LivingEntity>) rawHumanoidModel;
         var armorOffset = entity.getItemBySlot(EquipmentSlot.CHEST).isEmpty() ? 0.0F : ARMORED_OFFSET_Z;
+        float offsetX;
+        float offsetY;
+        float offsetZ;
+        float rotateDegZ;
+        switch (slotContext.identifier()) {
+            case CuriosSlotConstants.BACK -> {
+                offsetX = BACK_OFFSET_X;
+                offsetY = BACK_OFFSET_Y;
+                offsetZ = BACK_OFFSET_Z;
+                rotateDegZ = BACK_ROTATE_DEG_Z;
+            }
+            case CuriosSlotConstants.BELT -> {
+                offsetX = BELT_OFFSET_X;
+                offsetY = BELT_OFFSET_Y;
+                offsetZ = BELT_OFFSET_Z;
+                rotateDegZ = BELT_ROTATE_DEG_Z;
+            }
+            default -> {
+                return;
+            }
+        }
 
         poseStack.pushPose();
         humanoidModel.body.translateAndRotate(poseStack);
         poseStack.mulPose(Axis.YP.rotationDegrees(180.0F));
-        poseStack.mulPose(Axis.ZP.rotationDegrees(214.0F));
+        poseStack.mulPose(Axis.ZP.rotationDegrees(rotateDegZ));
         poseStack.mulPose(Axis.XP.rotationDegrees(18.0F));
-        poseStack.translate(BACK_OFFSET_X, BACK_OFFSET_Y, BACK_OFFSET_Z + armorOffset);
+        poseStack.translate(offsetX, offsetY, offsetZ + armorOffset);
         poseStack.scale(QUIVER_SCALE, QUIVER_SCALE, QUIVER_SCALE);
         itemRenderer.renderStatic(itemStack, ItemDisplayContext.NONE, light, OverlayTexture.NO_OVERLAY,
                 poseStack, renderTypeBuffer, entity.level(), entity.getId());

--- a/src/main/resources/assets/apprenticecodex/lang/en_us.json
+++ b/src/main/resources/assets/apprenticecodex/lang/en_us.json
@@ -3,6 +3,7 @@
 
   "curios.identifier.feet": "Feet",
   "curios.modifiers.feet": "When on feet:",
+  "curios.apprenticecodex.modifier.for_quiver": "When worn on the back or waist:",
 
   "attribute.name.apprenticecodex.max_enchantment_table_level": "Max Enchantment Table Level",
 

--- a/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
+++ b/src/main/resources/assets/apprenticecodex/lang/ja_jp.json
@@ -3,6 +3,7 @@
 
   "curios.identifier.feet": "足",
   "curios.modifiers.feet": "足に装備した時:",
+  "curios.apprenticecodex.modifier.for_quiver": "背中か腰に装備したとき：",
 
   "attribute.name.apprenticecodex.max_enchantment_table_level": "最大エンチャントテーブルレベル",
 

--- a/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
+++ b/src/main/resources/assets/apprenticecodex/lang/zh_cn.json
@@ -3,6 +3,7 @@
 
   "curios.identifier.feet": "脚饰",
   "curios.modifiers.feet": "佩戴脚饰时：",
+  "curios.apprenticecodex.modifier.for_quiver": "装备在背部或腰部时：",
 
   "attribute.name.apprenticecodex.max_enchantment_table_level": "附魔台最高等级",
 


### PR DESCRIPTION
- PR #785 のbackport対応
    - backport対応のため、機能そのものの不備よりはbackport時の1.21.1からのリグレッションを重点的にレビューすること
- 主に詠唱者の矢筒の装備箇所に腰を追加する対応
- PR #785 で指摘されているコスメスロット対応は1.21.1でも対応を見送っているため、backport側も未対応
- `build` : 成功
- `runClient` : 機能の1.21.1からのリグレッション無しを確認
- `runGameTestServer` : 全919件成功