### PR TITLE
参加しておくとよい1.21.1 Neoforgeの汎用アイテムタグに参加

### DIFF
--- a/src/generated/resources/data/c/tags/item/foods.json
+++ b/src/generated/resources/data/c/tags/item/foods.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "apprenticecodex:comfort_sandwich"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/foods/berry.json
+++ b/src/generated/resources/data/c/tags/item/foods/berry.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "apprenticecodex:comfort_berries"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/gems.json
+++ b/src/generated/resources/data/c/tags/item/gems.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "apprenticecodex:spellstained_diamond"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/ingots.json
+++ b/src/generated/resources/data/c/tags/item/ingots.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "apprenticecodex:spellstained_arcane_ingot",
+    "apprenticecodex:emberstained_netherite_ingot"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/tools/bow.json
+++ b/src/generated/resources/data/c/tags/item/tools/bow.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "apprenticecodex:elemental_bow"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/tools/ranged_weapon.json
+++ b/src/generated/resources/data/c/tags/item/tools/ranged_weapon.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "apprenticecodex:elemental_bow"
+  ]
+}

--- a/src/generated/resources/data/c/tags/item/tools/shield.json
+++ b/src/generated/resources/data/c/tags/item/tools/shield.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "apprenticecodex:reflectcast_shield",
+    "apprenticecodex:parrycast_buckler",
+    "apprenticecodex:bulwark_greatshield"
+  ]
+}

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/ItemTagGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/ItemTagGenerator.java
@@ -25,6 +25,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import io.redspace.ironsspellbooks.item.weapons.StaffItem;
 import net.minecraft.world.level.block.Block;
+import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import org.jetbrains.annotations.NotNull;
 
@@ -97,6 +98,21 @@ public final class ItemTagGenerator extends ItemTagsProvider {
 
     @Override
     protected void addTags(@NotNull HolderLookup.Provider provider) {
+        tag(Tags.Items.INGOTS).add(
+                ItemRegistry.SPELLSTAINED_ARCANE_INGOT.get(),
+                ItemRegistry.EMBERSTAINED_NETHERITE_INGOT.get()
+        );
+        tag(Tags.Items.GEMS).add(ItemRegistry.SPELLSTAINED_DIAMOND.get());
+        tag(Tags.Items.FOODS).add(ItemRegistry.COMFORT_SANDWICH.get());
+        tag(Tags.Items.FOODS_BERRY).add(ItemRegistry.COMFORT_BERRIES.get());
+        tag(Tags.Items.TOOLS_SHIELD).add(
+                ItemRegistry.REFLECTCAST_SHIELD.get(),
+                ItemRegistry.PARRYCAST_BUCKLER.get(),
+                ItemRegistry.BULWARK_GREATSHIELD.get()
+        );
+        tag(Tags.Items.TOOLS_BOW).add(ItemRegistry.ELEMENTAL_BOW.get());
+        tag(Tags.Items.RANGED_WEAPON_TOOLS).add(ItemRegistry.ELEMENTAL_BOW.get());
+
         tag(TagRegistry.Items.ALCHEMY_BREWER_HIGH_EFFICIENCY_BASES).add(Items.NETHER_WART);
         tag(TagRegistry.Items.ALCHEMY_BREWER_FAST_BASES).add(Items.GLOW_LICHEN);
         tag(IRONS_STAFF).add(

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexEquipmentAndEnchantGameTests.java
@@ -2049,6 +2049,11 @@ public final class ApprenticeCodexEquipmentAndEnchantGameTests {
     }
 
     @GameTest(template = TEMPLATE)
+    public static void commonItemTagsExposeIntendedCompatibilitySurface(GameTestHelper helper) {
+        EquipmentEnchantmentSurfaceGameTestScenarios.commonItemTagsExposeIntendedCompatibilitySurface(helper);
+    }
+
+    @GameTest(template = TEMPLATE)
     public static void spellchargedGreatswordKeepsExpectedStatsAndTags(GameTestHelper helper) {
         EquipmentEnchantmentSurfaceGameTestScenarios.spellchargedGreatswordKeepsExpectedStatsTagsAndEnchantments(helper);
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/EquipmentEnchantmentSurfaceGameTestScenarios.java
@@ -71,6 +71,7 @@ import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.common.Tags;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -81,6 +82,58 @@ import java.util.function.Predicate;
 
 final class EquipmentEnchantmentSurfaceGameTestScenarios extends ApprenticeCodexGameTestScenarios {
     private EquipmentEnchantmentSurfaceGameTestScenarios() {
+    }
+
+    static void commonItemTagsExposeIntendedCompatibilitySurface(GameTestHelper helper) {
+        helper.succeedIf(() -> {
+            helper.assertTrue(new ItemStack(ItemRegistry.SPELLSTAINED_ARCANE_INGOT.get()).is(Tags.Items.INGOTS),
+                    "Spell-stained Arcane Ingot should be classified as a common ingot");
+            var emberstainedNetherite = new ItemStack(ItemRegistry.EMBERSTAINED_NETHERITE_INGOT.get());
+            helper.assertTrue(emberstainedNetherite.is(Tags.Items.INGOTS),
+                    "Ember-stained Netherite Ingot should be classified as a common ingot");
+            helper.assertFalse(emberstainedNetherite.is(Tags.Items.INGOTS_NETHERITE),
+                    "Ember-stained Netherite Ingot should not substitute for ordinary netherite");
+
+            var spellstainedDiamond = new ItemStack(ItemRegistry.SPELLSTAINED_DIAMOND.get());
+            helper.assertTrue(spellstainedDiamond.is(Tags.Items.GEMS),
+                    "Spell-stained Diamond should be classified as a common gem");
+            helper.assertFalse(spellstainedDiamond.is(Tags.Items.GEMS_DIAMOND),
+                    "Spell-stained Diamond should not substitute for ordinary diamonds");
+
+            var comfortBerries = new ItemStack(ItemRegistry.COMFORT_BERRIES.get());
+            helper.assertTrue(comfortBerries.is(Tags.Items.FOODS_BERRY),
+                    "Comfort Berries should be classified as common berries");
+            helper.assertTrue(comfortBerries.is(Tags.Items.FOODS),
+                    "Common berry classification should expose Comfort Berries as food");
+            var comfortSandwich = new ItemStack(ItemRegistry.COMFORT_SANDWICH.get());
+            helper.assertTrue(comfortSandwich.is(Tags.Items.FOODS),
+                    "Comfort Sandwich should be classified as common food");
+            helper.assertFalse(comfortSandwich.is(Tags.Items.FOODS_BERRY),
+                    "Comfort Sandwich should not be classified as a berry");
+
+            for (var shield : List.of(
+                    ItemRegistry.REFLECTCAST_SHIELD.get(),
+                    ItemRegistry.PARRYCAST_BUCKLER.get(),
+                    ItemRegistry.BULWARK_GREATSHIELD.get()
+            )) {
+                helper.assertTrue(new ItemStack(shield).is(Tags.Items.TOOLS_SHIELD),
+                        "Apprentice shield should be classified as a common shield: " + shield);
+            }
+
+            var elementalBow = new ItemStack(ItemRegistry.ELEMENTAL_BOW.get());
+            helper.assertTrue(elementalBow.is(Tags.Items.TOOLS_BOW),
+                    "Elemental Bow should be classified as a common bow");
+            helper.assertTrue(elementalBow.is(Tags.Items.RANGED_WEAPON_TOOLS),
+                    "Elemental Bow should be classified as a common ranged weapon");
+
+            helper.assertFalse(new ItemStack(ItemRegistry.FOCUS_STAFFBOW.get()).is(Tags.Items.TOOLS_BOW),
+                    "Focus Staffbow should remain outside the common bow tag");
+            helper.assertFalse(new ItemStack(ItemRegistry.MULTIPURPOSE_STAFFRIFLE.get())
+                            .is(Tags.Items.RANGED_WEAPON_TOOLS),
+                    "Multipurpose Staffrifle should remain outside the common ranged weapon tag");
+            helper.assertFalse(new ItemStack(ItemRegistry.PASTEL_STAFF.get()).is(Tags.Items.MELEE_WEAPON_TOOLS),
+                    "Staff items should remain outside the common melee weapon tag");
+        });
     }
 
     static void reflectcastShieldKeepsExpectedItemContract(GameTestHelper helper) {


### PR DESCRIPTION
- 1.21.1 Neoforgeのアイテムタグ追加で影響範囲が少ない、もしくは対応してしかるべきもののみを対応
- 1.20.1 Forgeにおける慣習は未調査且つそもそもcタグは使ってない認識のため、backport対象にはしない
- `build`: `BUILD SUCCESSFUL in 8s`
- `runClient`: Farmer's Delightのベリーを素材に使える料理のレシピに安楽ベリーが使えることを確認(対応してしかるべきものに該当)、その他致命的なプログレッション破壊が無いことを確認
- `runGameTestServer`: `All 1038 required tests passed :)`