### PR TITLE
Malum連携アイテムの調整

### DIFF
--- a/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_boots.json
+++ b/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_boots.json
@@ -8,7 +8,8 @@
   "type": "malum:spirit_infusion",
   "extraInputs": [
     {
-      "item": "apprenticecodex:apprentice_mage_boots"
+      "count": 8,
+      "item": "apprenticecodex:crystalline_arcane_shard"
     },
     {
       "count": 2,

--- a/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_hat.json
+++ b/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_hat.json
@@ -8,7 +8,8 @@
   "type": "malum:spirit_infusion",
   "extraInputs": [
     {
-      "item": "apprenticecodex:apprentice_mage_scarf"
+      "count": 8,
+      "item": "apprenticecodex:crystalline_arcane_shard"
     },
     {
       "count": 2,

--- a/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_leggings.json
+++ b/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_leggings.json
@@ -8,7 +8,8 @@
   "type": "malum:spirit_infusion",
   "extraInputs": [
     {
-      "item": "apprenticecodex:apprentice_mage_leggings"
+      "count": 8,
+      "item": "apprenticecodex:crystalline_arcane_shard"
     },
     {
       "count": 2,

--- a/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_robe.json
+++ b/src/generated/resources/data/apprenticecodex/recipe/malum/spirit_infusion/soulcollector_robe.json
@@ -8,7 +8,8 @@
   "type": "malum:spirit_infusion",
   "extraInputs": [
     {
-      "item": "apprenticecodex:apprentice_mage_torso"
+      "count": 8,
+      "item": "apprenticecodex:crystalline_arcane_shard"
     },
     {
       "count": 2,

--- a/src/main/java/jp/aquafactory/apprenticecodex/config/item/SoulstainedSteelSwingcastStaffServerConfig.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/config/item/SoulstainedSteelSwingcastStaffServerConfig.java
@@ -3,7 +3,7 @@ package jp.aquafactory.apprenticecodex.config.item;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 public final class SoulstainedSteelSwingcastStaffServerConfig {
-    public static final double DEFAULT_MANA_COST_PER_BLADE = 20.0D;
+    public static final double DEFAULT_MANA_COST_PER_BLADE = 15.0D;
     private static final double MAX_MANA_COST_PER_BLADE = 10000.0D;
 
     private final ModConfigSpec.DoubleValue manaCostPerBlade;

--- a/src/main/java/jp/aquafactory/apprenticecodex/datagen/recipe/MalumSpiritInfusionRecipeDataGenerator.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/datagen/recipe/MalumSpiritInfusionRecipeDataGenerator.java
@@ -34,14 +34,10 @@ public final class MalumSpiritInfusionRecipeDataGenerator implements DataProvide
     public @NotNull CompletableFuture<?> run(@NotNull CachedOutput cachedOutput) {
         var spirits = List.of(malumSpirit("arcane", 16), malumSpirit("wicked", 16));
         var recipes = List.of(
-                soulcollectorRecipe("soulcollector_hat", "soul_hunter_cloak", ItemRegistry.SOULCOLLECTOR_HAT.get(),
-                        ItemRegistry.APPRENTICE_MAGE_SCARF.get(), spirits),
-                soulcollectorRecipe("soulcollector_robe", "soul_hunter_robe", ItemRegistry.SOULCOLLECTOR_ROBE.get(),
-                        ItemRegistry.APPRENTICE_MAGE_TORSO.get(), spirits),
-                soulcollectorRecipe("soulcollector_leggings", "soul_hunter_leggings", ItemRegistry.SOULCOLLECTOR_LEGGINGS.get(),
-                        ItemRegistry.APPRENTICE_MAGE_LEGGINGS.get(), spirits),
-                soulcollectorRecipe("soulcollector_boots", "soul_hunter_boots", ItemRegistry.SOULCOLLECTOR_BOOTS.get(),
-                        ItemRegistry.APPRENTICE_MAGE_BOOTS.get(), spirits),
+                soulcollectorRecipe("soulcollector_hat", "soul_hunter_cloak", ItemRegistry.SOULCOLLECTOR_HAT.get(), spirits),
+                soulcollectorRecipe("soulcollector_robe", "soul_hunter_robe", ItemRegistry.SOULCOLLECTOR_ROBE.get(), spirits),
+                soulcollectorRecipe("soulcollector_leggings", "soul_hunter_leggings", ItemRegistry.SOULCOLLECTOR_LEGGINGS.get(), spirits),
+                soulcollectorRecipe("soulcollector_boots", "soul_hunter_boots", ItemRegistry.SOULCOLLECTOR_BOOTS.get(), spirits),
                 spiritInfusionRecipe("soulstained_steel_swingcast_staff",
                         ItemRegistry.IRON_SWINGCAST_STAFF.getId(),
                         ItemRegistry.SOULSTAINED_STEEL_SWINGCAST_STAFF.getId(),
@@ -96,7 +92,6 @@ public final class MalumSpiritInfusionRecipeDataGenerator implements DataProvide
             String path,
             String malumInput,
             Item output,
-            Item baseArmor,
             List<SpiritCost> spirits
     ) {
         return spiritInfusionRecipe(
@@ -104,7 +99,7 @@ public final class MalumSpiritInfusionRecipeDataGenerator implements DataProvide
                 ResourceLocation.fromNamespaceAndPath(MALUM_MOD_ID, malumInput),
                 itemId(output),
                 List.of(
-                        recipeItem(baseArmor, 1),
+                        new RecipeItem(ItemRegistry.CRYSTALLINE_ARCANE_SHARD.getId(), 8),
                         new RecipeItem(MAGIC_CLOTH, 2),
                         new RecipeItem(REFINED_SOULSTONE, 4)
                 ),

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests.java
@@ -101,23 +101,23 @@ public final class ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests {
     @GameTest(template = TEMPLATE)
     public static void soulstainedSteelSwingcastStaffResolvesBladeCountFromMana(GameTestHelper helper) {
         helper.succeedIf(() -> {
-            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(19.99F) == 0,
-                    "Less than 20 mana should not fire a Mnemonic Blade");
-            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(20.0F) == 1,
-                    "20 mana should fire one Mnemonic Blade");
-            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(59.99F) == 2,
-                    "Less than 60 mana should fire two Mnemonic Blades");
-            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(60.0F) == 3,
-                    "60 mana should fire three Mnemonic Blades");
+            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(14.99F) == 0,
+                    "Less than 15 mana should not fire a Mnemonic Blade");
+            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(15.0F) == 1,
+                    "15 mana should fire one Mnemonic Blade");
+            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(44.99F) == 2,
+                    "Less than 45 mana should fire two Mnemonic Blades");
+            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(45.0F) == 3,
+                    "45 mana should fire three Mnemonic Blades");
             helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(100.0F) == 3,
                     "Mnemonic Blade burst size should be capped at three");
-            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(1.0D) - 20.0D) < 1.0e-6D,
-                    "Charge Recovery Rate 1.0 should cost 20 mana per blade");
-            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(0.5D) - 40.0D) < 1.0e-6D,
-                    "Charge Recovery Rate 0.5 should cost 40 mana per blade");
-            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(0.01D) - 2000.0D) < 1.0e-6D,
-                    "Charge Recovery Rate 0.01 should cost 2000 mana per blade");
-            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(0.0D) - 2000.0D) < 1.0e-6D,
+            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(1.0D) - 15.0D) < 1.0e-6D,
+                    "Charge Recovery Rate 1.0 should cost 15 mana per blade");
+            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(0.5D) - 30.0D) < 1.0e-6D,
+                    "Charge Recovery Rate 0.5 should cost 30 mana per blade");
+            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(0.01D) - 1500.0D) < 1.0e-6D,
+                    "Charge Recovery Rate 0.01 should cost 1500 mana per blade");
+            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(0.0D) - 1500.0D) < 1.0e-6D,
                     "Charge Recovery Rate 0 should clamp to 0.01");
             helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(19.99F, 20.0D) == 0,
                     "Mana below the dynamic cost should not fire a blade");
@@ -128,8 +128,8 @@ public final class ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests {
                     "Configured base mana cost should be scaled by Charge Recovery Rate");
             helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveBladeCount(0.0F, 0.0D) == 3,
                     "Zero configured mana cost should fire the full burst without mana");
-            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveDisplayedTotalManaCost(20.0D, 1.0D) == 60L,
-                    "Default tooltip cost should show 60 mana for the full burst");
+            helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveDisplayedTotalManaCost(15.0D, 1.0D) == 45L,
+                    "Default tooltip cost should show 45 mana for the full burst");
             helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveDisplayedTotalManaCost(20.0D, 0.5D) == 120L,
                     "Tooltip cost should reflect Charge Recovery Rate scaling");
             helper.assertTrue(SoulstainedSteelSwingcastStaff.resolveDisplayedTotalManaCost(20.0D, 0.7D) == 86L,
@@ -156,7 +156,7 @@ public final class ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests {
                             < 1.0e-9D,
                     "Client config state should retain the synchronized mana cost");
             SoulstainedSteelSwingcastStaffConfigState.reset();
-            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaffConfigState.manaCostPerBlade() - 20.0D)
+            helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaffConfigState.manaCostPerBlade() - 15.0D)
                             < 1.0e-9D,
                     "Client config state reset should restore the default mana cost");
 
@@ -243,7 +243,7 @@ public final class ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests {
             helper.assertTrue(Math.abs(MalumMnemonicBladeBridge.getChargeRecoveryRate(player) - 0.5D) < 1.0e-6D,
                     "Malum Charge Recovery Rate should resolve the -50% modifier as 0.5");
             helper.assertTrue(Math.abs(SoulstainedSteelSwingcastStaff.resolveManaCost(
-                    MalumMnemonicBladeBridge.getChargeRecoveryRate(player)) - 40.0D) < 1.0e-6D,
+                    MalumMnemonicBladeBridge.getChargeRecoveryRate(player)) - 30.0D) < 1.0e-6D,
                     "Soulstained Steel Swingcast Staff should use the resolved Charge Recovery Rate");
         });
     }
@@ -263,7 +263,13 @@ public final class ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests {
         magicData.setMana(45.0F);
         var before = countHexBolts(helper);
 
-        var triggered = item.tryTriggerSpellOnSwing(player, InteractionHand.MAIN_HAND, true);
+        boolean triggered;
+        try (var ignored = ApprenticeCodexServerConfig
+                .useSoulstainedSteelSwingcastStaffConfigOverrideForGameTest(
+                        SoulstainedSteelSwingcastStaff.DEFAULT_MANA_COST_PER_BLADE
+                )) {
+            triggered = item.tryTriggerSpellOnSwing(player, InteractionHand.MAIN_HAND, true);
+        }
         if (!MalumMnemonicBladeBridge.isAvailable()) {
             helper.assertFalse(triggered, "Soulstained Steel Swingcast Staff should stay inert without Malum");
             helper.assertTrue(Math.abs(magicData.getMana() - 45.0F) < 1.0e-6F,
@@ -273,11 +279,11 @@ public final class ApprenticeCodexSoulstainedSteelSwingcastStaffGameTests {
         }
 
         helper.assertTrue(triggered, "Soulstained Steel Swingcast Staff should fire when Malum is loaded");
-        helper.assertTrue(Math.abs(magicData.getMana() - 5.0F) < 1.0e-6F,
-                "Two Mnemonic Blades should consume 40 mana");
+        helper.assertTrue(Math.abs(magicData.getMana()) < 1.0e-6F,
+                "Three Mnemonic Blades should consume 45 mana");
         helper.runAfterDelay(1, () -> {
-            helper.assertTrue(countHexBolts(helper) - before == 2,
-                    "45 mana should spawn exactly two Malum Mnemonic Blades");
+            helper.assertTrue(countHexBolts(helper) - before == 3,
+                    "45 mana should spawn exactly three Malum Mnemonic Blades");
             helper.succeed();
         });
     }

--- a/src/main/java/jp/aquafactory/apprenticecodex/gametest/OffhandAndBetterCombatGameTestScenarios.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/gametest/OffhandAndBetterCombatGameTestScenarios.java
@@ -199,6 +199,19 @@ final class OffhandAndBetterCombatGameTestScenarios extends ApprenticeCodexGameT
                 );
             }
 
+            var soulWardCapacityId = ResourceLocation.fromNamespaceAndPath("malum", "soul_ward_capacity");
+            var soulWardCapacity = BuiltInRegistries.ATTRIBUTE.getOptional(soulWardCapacityId).orElse(null);
+            if (soulWardCapacity != null) {
+                assertModifierAmount(
+                        helper,
+                        item.getDefaultAttributeModifiers(stack),
+                        soulWardCapacity,
+                        SoulstainedSteelSpellAmplifier.SOUL_WARD_CAPACITY_BONUS,
+                        AttributeModifier.Operation.ADD_VALUE,
+                        "Soulstained Steel Spell Amplifier soul ward capacity bonus regression"
+                );
+            }
+
             var recipeId = ResourceLocation.fromNamespaceAndPath(
                     "apprenticecodex", "soulstained_steel_spell_amplifier");
             var recipeHolder = helper.getLevel().getRecipeManager().byKey(recipeId).orElse(null);

--- a/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/SoulstainedSteelSpellAmplifier.java
+++ b/src/main/java/jp/aquafactory/apprenticecodex/item/offhand/SoulstainedSteelSpellAmplifier.java
@@ -8,10 +8,13 @@ import net.minecraft.world.item.Rarity;
 import net.minecraft.world.item.component.ItemAttributeModifiers;
 
 public final class SoulstainedSteelSpellAmplifier extends AbstractSpellAmplifierItem {
-    public static final double MAGIC_PROFICIENCY_BONUS = 0.10D;
+    public static final double MAGIC_PROFICIENCY_BONUS = 0.15D;
+    public static final double SOUL_WARD_CAPACITY_BONUS = 3.0D;
     private static final int ENCHANTMENT_VALUE = 16;
     private static final ResourceLocation MAGIC_PROFICIENCY =
             ResourceLocation.fromNamespaceAndPath("lodestone", "magic_proficiency");
+    private static final ResourceLocation SOUL_WARD_CAPACITY =
+            ResourceLocation.fromNamespaceAndPath("malum", "soul_ward_capacity");
 
     public SoulstainedSteelSpellAmplifier() {
         super(Rarity.COMMON, "soulstained_steel_spell_amplifier");
@@ -23,12 +26,8 @@ public final class SoulstainedSteelSpellAmplifier extends AbstractSpellAmplifier
             ItemStack stack,
             String modifierKeyPrefix
     ) {
-        // Malum を必須依存にせず、前提 MOD の Lodestone が登録した属性だけを実行時に接続する。
+        // Malum を必須依存にせず、Lodestone / Malum が登録した属性だけを実行時に接続する。
         var magicProficiency = BuiltInRegistries.ATTRIBUTE.getOptional(MAGIC_PROFICIENCY).orElse(null);
-        if (magicProficiency == null) {
-            return false;
-        }
-
         addStackDependentModifier(
                 builder,
                 magicProficiency,
@@ -36,7 +35,16 @@ public final class SoulstainedSteelSpellAmplifier extends AbstractSpellAmplifier
                 AttributeModifier.Operation.ADD_MULTIPLIED_BASE,
                 modifierKeyPrefix + "_magic_proficiency"
         );
-        return true;
+
+        var soulWardCapacity = BuiltInRegistries.ATTRIBUTE.getOptional(SOUL_WARD_CAPACITY).orElse(null);
+        addStackDependentModifier(
+                builder,
+                soulWardCapacity,
+                SOUL_WARD_CAPACITY_BONUS,
+                AttributeModifier.Operation.ADD_VALUE,
+                modifierKeyPrefix + "_soul_ward_capacity"
+        );
+        return magicProficiency != null || soulWardCapacity != null;
     }
 
     @Override


### PR DESCRIPTION
- レシピ変更は現在のMalum1.8.2においてエンチャントされているアイテムを台座側素材にすると切断される不具合があるため、レシピ難易度をあまり変えずに対応
- 他のアイテムは多少弱く感じたためバフ
- 未リリースの機能のためユーザーへの案内は不要の認識
- **backport対象**
- `build`: 成功、実プレイ確認済み
- `runClient`: 影響無しを確認済み
- `runClientCompat`: 変更を確認済み
- `runGameTestServer`: `All 1044 required tests passed :)`
- `runGameTestServerCompat`: `All 1044 required tests passed :)`